### PR TITLE
fix: JSON schema/swagger codegen workaround for VerifiableCredential

### DIFF
--- a/packages/daf-cli/src/schema.ts
+++ b/packages/daf-cli/src/schema.ts
@@ -35,10 +35,20 @@ function createSchema(generator: TJS.SchemaGenerator, symbol: string) {
   let fixedSymbol = symbol.replace('Array<', '').replace('>', '')
 
   const schema = generator.createSchema(fixedSymbol)
-  
-  if (fixedSymbol === 'ICreateVerifiableCredentialArgs') {
+
+  if (schema.definitions?.['VerifiableCredential']) {
+    //@ts-ignore
+    schema.definitions['VerifiableCredential']['properties']['credentialSubject'][
+      'additionalProperties'
+    ] = true
+    //@ts-ignore
+    delete schema.definitions['VerifiableCredential']['properties']['credentialSubject']['properties']
+  }
+  if (schema.definitions?.['W3CCredential']) {
     //@ts-ignore
     schema.definitions['W3CCredential']['properties']['credentialSubject']['additionalProperties'] = true
+    //@ts-ignore
+    delete schema.definitions['W3CCredential']['properties']['credentialSubject']['properties']
   }
   // console.dir({ fixedSymbol, schema }, {depth: 10})
 

--- a/packages/daf-core/plugin.schema.json
+++ b/packages/daf-core/plugin.schema.json
@@ -1153,11 +1153,7 @@
             },
             "credentialSubject": {
               "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                }
-              }
+              "additionalProperties": true
             },
             "credentialStatus": {
               "type": "object",
@@ -1548,11 +1544,7 @@
             },
             "credentialSubject": {
               "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                }
-              }
+              "additionalProperties": true
             },
             "credentialStatus": {
               "type": "object",

--- a/packages/daf-did-comm/plugin.schema.json
+++ b/packages/daf-did-comm/plugin.schema.json
@@ -196,11 +196,7 @@
             },
             "credentialSubject": {
               "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                }
-              }
+              "additionalProperties": true
             },
             "credentialStatus": {
               "type": "object",

--- a/packages/daf-selective-disclosure/plugin.schema.json
+++ b/packages/daf-selective-disclosure/plugin.schema.json
@@ -136,11 +136,7 @@
             },
             "credentialSubject": {
               "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                }
-              }
+              "additionalProperties": true
             },
             "credentialStatus": {
               "type": "object",

--- a/packages/daf-typeorm/plugin.schema.json
+++ b/packages/daf-typeorm/plugin.schema.json
@@ -444,11 +444,7 @@
             },
             "credentialSubject": {
               "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                }
-              }
+              "additionalProperties": true
             },
             "credentialStatus": {
               "type": "object",

--- a/packages/daf-w3c/plugin.schema.json
+++ b/packages/daf-w3c/plugin.schema.json
@@ -61,11 +61,6 @@
             },
             "credentialSubject": {
               "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                }
-              },
               "additionalProperties": true
             },
             "credentialStatus": {
@@ -135,11 +130,7 @@
             },
             "credentialSubject": {
               "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                }
-              }
+              "additionalProperties": true
             },
             "credentialStatus": {
               "type": "object",


### PR DESCRIPTION
Not sure if we want to do this, just putting it up for discussion, see https://consensysmesh.slack.com/archives/C01AJDJDRJ7/p1607627004057100?thread_ts=1607397897.054800&cid=C01AJDJDRJ7.

We would have to do the same thing for `VerifiableCredential.proof` property - it only specifies `type` and so codegen library ignores e.g. the `jwt` property unless we a) explicitly include it in schema or b) make `proof` a generic object like this PR does with `credentialSubject`.