### PR TITLE
chore: fix build error caused by generated file

### DIFF
--- a/packages/data-store/api/data-store.api.md
+++ b/packages/data-store/api/data-store.api.md
@@ -157,7 +157,7 @@ export class DIDStore extends AbstractDIDStore {
 }
 
 // @public (undocumented)
-export const Entities: (typeof Identifier | typeof Message | typeof Claim | typeof Credential_2 | typeof Presentation | typeof Key | typeof Service)[];
+export const Entities: (typeof Key | typeof Identifier | typeof Service | typeof Claim | typeof Credential_2 | typeof Presentation | typeof Message)[];
 
 // @public (undocumented)
 export interface FindArgs<TColumns> {


### PR DESCRIPTION
The API description generated markdown is non-deterministic, causing build failures.

I regenerated the problematic file here to [hopefully] patch the issue that's blocking the `next` branch release.