### PR TITLE
refactor(cli): use routers defined in config

### DIFF
--- a/__tests__/restAgent.test.ts
+++ b/__tests__/restAgent.test.ts
@@ -37,7 +37,7 @@ import {
 import { AgentRestClient } from '../packages/remote-client/src'
 import express from 'express'
 import { Server } from 'http'
-import { AgentRouter } from '../packages/remote-server/src'
+import { AgentRouter, RequestWithAgentRouter } from '../packages/remote-server/src'
 import { Resolver } from 'did-resolver'
 import { getResolver as ethrDidResolver } from 'ethr-did-resolver'
 import { getResolver as webDidResolver } from 'web-did-resolver'
@@ -159,13 +159,16 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
   })
 
   const agentRouter = AgentRouter({
-    getAgentForRequest: async (req) => serverAgent,
     exposedMethods: serverAgent.availableMethods(),
+  })
+
+  const requestWithAgent = RequestWithAgentRouter({
+    agent: serverAgent,
   })
 
   return new Promise((resolve) => {
     const app = express()
-    app.use(basePath, agentRouter)
+    app.use(basePath, requestWithAgent, agentRouter)
     restServer = app.listen(port, () => {
       resolve(true)
     })

--- a/packages/cli/default/client.yml
+++ b/packages/cli/default/client.yml
@@ -1,21 +1,5 @@
-version: 1.0
-server:
-  hostname: localhost
-  port: 3335
-  schemaPath: /open-api.json
-  apiBasePath: /agent
-  apiDocsPath: /api-docs
-  defaultDID:
-    create: true
-    messagingServiceEndpoint: /messaging
-  ngrok:
-    connect: true
-    # authtoken: XZY
-    # subdomain: alice-did
-    # region: eu
-  # exposedMethods:
-  #   - resolveDid
-  #   - dataStoreORMGetIdentifiers
+version: 2.0
+
 agent:
   $require: '@veramo/core#Agent'
   $args:
@@ -48,8 +32,11 @@ agent:
                 - didManagerAddService
                 - didManagerRemoveService
                 - resolveDid
+                - dataStoreGetMessage
                 - dataStoreSaveMessage
+                - dataStoreGetVerifiableCredential
                 - dataStoreSaveVerifiableCredential
+                - dataStoreGetVerifiablePresentation
                 - dataStoreSaveVerifiablePresentation
                 - dataStoreORMGetIdentifiers
                 - dataStoreORMGetIdentifiersCount

--- a/packages/cli/default/default.yml
+++ b/packages/cli/default/default.yml
@@ -1,34 +1,57 @@
-version: 1.0
-server:
+version: 2.0
+
+constants:
   baseUrl: http://localhost:3332
   port: 3332
-  # baseUrl:
-  #   $env: BASE_URL
-  # port:
-  #   $env: PORT
-  # apiKey:
-  #   $env: API_KEY
-  schemaPath: /open-api.json
-  # homePageTemplate: ./homepage.html
-  apiName: Agent
-  apiVersion: 1.0.0
-  apiBasePath: /agent
-  apiDocsPath: /api-docs
-  defaultDID:
-    create: true
-    messagingServiceEndpoint: /messaging
-  ngrok:
-    connect: true
-    # authtoken: XZY
-    # subdomain: alice-did
-    # region: eu
-  # exposedMethods:
-  #   - resolveDid
-  #   - dataStoreORMGetIdentities
-constants:
   secretKey: 29739248cad1bd1a0fc4d9b75cd4d2990de535baf5caadfdf8d8f86664aa830c
   databaseFile: ./database.sqlite
+  methods:
+    - keyManagerGetKeyManagementSystems
+    - keyManagerCreate
+    - keyManagerGet
+    - keyManagerDelete
+    - keyManagerImport
+    - keyManagerEncryptJWE
+    - keyManagerDecryptJWE
+    - keyManagerSignJWT
+    - keyManagerSignEthTX
+    - didManagerGetProviders
+    - didManagerFind
+    - didManagerGet
+    - didManagerCreate
+    - didManagerGetOrCreate
+    - didManagerImport
+    - didManagerDelete
+    - didManagerAddKey
+    - didManagerRemoveKey
+    - didManagerAddService
+    - didManagerRemoveService
+    - resolveDid
+    - dataStoreGetMessage
+    - dataStoreSaveMessage
+    - dataStoreGetVerifiableCredential
+    - dataStoreSaveVerifiableCredential
+    - dataStoreGetVerifiablePresentation
+    - dataStoreSaveVerifiablePresentation
+    - dataStoreORMGetIdentifiers
+    - dataStoreORMGetIdentifiersCount
+    - dataStoreORMGetMessages
+    - dataStoreORMGetMessagesCount
+    - dataStoreORMGetVerifiableCredentialsByClaims
+    - dataStoreORMGetVerifiableCredentialsByClaimsCount
+    - dataStoreORMGetVerifiableCredentials
+    - dataStoreORMGetVerifiableCredentialsCount
+    - dataStoreORMGetVerifiablePresentations
+    - dataStoreORMGetVerifiablePresentationsCount
+    - handleMessage
+    - sendMessageDIDCommAlpha1
+    - createVerifiablePresentation
+    - createVerifiableCredential
+    - createSelectiveDisclosureRequest
+    - getVerifiableCredentialsForSdr
+    - validatePresentationAgainstSdr
 
+# Data base
 dbConnection:
   $require: typeorm?t=function#createConnection
   $args:
@@ -40,6 +63,74 @@ dbConnection:
       entities:
         $require: '@veramo/data-store?t=object#Entities'
 
+# Server configuration
+server:
+  baseUrl:
+    $ref: /constants/baseUrl
+  port:
+    $ref: /constants/port
+  use:
+    # CORS
+    - - $require: 'cors'
+
+    # Add agent to the request object
+    - - $require: '@veramo/remote-server?t=function#RequestWithAgentRouter'
+        $args:
+          - agent:
+              $ref: /agent
+
+    # DID Documents
+    - - $require: '@veramo/remote-server?t=function#WebDidDocRouter'
+
+    # API base path
+    - - /messaging
+      - $require: '@veramo/remote-server?t=function#MessagingRouter'
+        $args:
+          - metaData:
+              type: DIDComm
+              value: https
+
+    # API base path
+    - - /agent
+      - $require: '@veramo/remote-server?t=function#apiKeyAuth'
+        $args:
+          - apiKey: test123
+      - $require: '@veramo/remote-server?t=function#AgentRouter'
+        $args:
+          - exposedMethods:
+              $ref: /constants/methods
+
+    # Open API schema
+    - - /open-api.json
+      - $require: '@veramo/remote-server?t=function#ApiSchemaRouter'
+        $args:
+          - basePath: /agent
+            securityScheme: bearer
+            apiName: Agent
+            apiVersion: '1.0.0'
+            exposedMethods:
+              $ref: /constants/methods
+
+    # Swagger docs
+    - - /api-docs
+      - $require: swagger-ui-express?t=object#serve
+      - $require: swagger-ui-express?t=function#setup
+        $args:
+          - null
+          - swaggerOptions:
+              url: '/open-api.json'
+
+  # Execute during server initialization
+  init:
+    - $require: '@veramo/remote-server?t=function#createDefaultDid'
+      $args:
+        - agent:
+            $ref: /agent
+          baseUrl:
+            $ref: /constants/baseUrl
+          messagingServiceEndpoint: /messaging
+
+# Message handler plugin
 messageHandler:
   $require: '@veramo/message-handler#MessageHandler'
   $args:
@@ -48,6 +139,28 @@ messageHandler:
         - $require: '@veramo/did-jwt#JwtMessageHandler'
         - $require: '@veramo/credential-w3c#W3cMessageHandler'
         - $require: '@veramo/selective-disclosure#SdrMessageHandler'
+
+# DID resolvers
+didResolver:
+  $require: '@veramo/did-resolver#DIDResolverPlugin'
+  $args:
+    - resolver:
+        $require: did-resolver#Resolver
+        $args:
+          - ethr:
+              $ref: /ethr-did-resolver
+            web:
+              $ref: /web-did-resolver
+            io:
+              $ref: /universal-resolver
+            elem:
+              $ref: /universal-resolver
+            key:
+              $ref: /universal-resolver
+            ion:
+              $ref: /universal-resolver
+            sov:
+              $ref: /universal-resolver
 
 ethr-did-resolver:
   $require: ethr-did-resolver?t=function&p=/ethr#getResolver
@@ -75,104 +188,92 @@ universal-resolver:
   $args:
     - url: https://dev.uniresolver.io/1.0/identifiers/
 
-resolver:
-  $require: did-resolver#Resolver
+# Key Manager
+keyManager:
+  $require: '@veramo/key-manager#KeyManager'
   $args:
-    - ethr:
-        $ref: /ethr-did-resolver
-      web:
-        $ref: /web-did-resolver
-      io:
-        $ref: /universal-resolver
-      elem:
-        $ref: /universal-resolver
-      key:
-        $ref: /universal-resolver
-      ion:
-        $ref: /universal-resolver
-      sov:
-        $ref: /universal-resolver
+    - store:
+        $require: '@veramo/data-store#KeyStore'
+        $args:
+          - $ref: /dbConnection
+          - $require: '@veramo/kms-local#SecretBox'
+            $args:
+              - $ref: /constants/secretKey
+      kms:
+        local:
+          $require: '@veramo/kms-local#KeyManagementSystem'
 
+# DID Manager
+didManager:
+  $require: '@veramo/did-manager#DIDManager'
+  $args:
+    - store:
+        $require: '@veramo/data-store#DIDStore'
+        $args:
+          - $ref: /dbConnection
+      defaultProvider: did:ethr:rinkeby
+      providers:
+        did:ethr:
+          $require: '@veramo/did-provider-ethr#EthrDIDProvider'
+          $args:
+            - defaultKms: local
+              network: mainnet
+              rpcUrl: https://mainnet.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+              gas: 1000001
+              ttl: 31104001
+        did:ethr:rinkeby:
+          $require: '@veramo/did-provider-ethr#EthrDIDProvider'
+          $args:
+            - defaultKms: local
+              network: rinkeby
+              rpcUrl: https://rinkeby.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+              gas: 1000001
+              ttl: 31104001
+        did:ethr:ropsten:
+          $require: '@veramo/did-provider-ethr#EthrDIDProvider'
+          $args:
+            - defaultKms: local
+              network: ropsten
+              rpcUrl: https://ropsten.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+              gas: 1000001
+              ttl: 31104001
+        did:ethr:kovan:
+          $require: '@veramo/did-provider-ethr#EthrDIDProvider'
+          $args:
+            - defaultKms: local
+              network: kovan
+              rpcUrl: https://kovan.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+              gas: 1000001
+              ttl: 31104001
+        did:ethr:goerli:
+          $require: '@veramo/did-provider-ethr#EthrDIDProvider'
+          $args:
+            - defaultKms: local
+              network: goerli
+              rpcUrl: https://goerli.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
+              gas: 1000001
+              ttl: 31104001
+        did:web:
+          $require: '@veramo/did-provider-web#WebDIDProvider'
+          $args:
+            - defaultKms: local
+
+# Agent
 agent:
   $require: '@veramo/core#Agent'
   $args:
     - schemaValidation: false
       plugins:
-        - $require: '@veramo/key-manager#KeyManager'
-          $args:
-            - store:
-                $require: '@veramo/data-store#KeyStore'
-                $args:
-                  - $ref: /dbConnection
-                  - $require: '@veramo/kms-local#SecretBox'
-                    $args:
-                      - $ref: /constants/secretKey
-              kms:
-                local:
-                  $require: '@veramo/kms-local#KeyManagementSystem'
-        - $require: '@veramo/did-manager#DIDManager'
-          $args:
-            - store:
-                $require: '@veramo/data-store#DIDStore'
-                $args:
-                  - $ref: /dbConnection
-              defaultProvider: did:ethr:rinkeby
-              providers:
-                did:ethr:
-                  $require: '@veramo/did-provider-ethr#EthrDIDProvider'
-                  $args:
-                    - defaultKms: local
-                      network: mainnet
-                      rpcUrl: https://mainnet.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
-                      gas: 1000001
-                      ttl: 31104001
-                did:ethr:rinkeby:
-                  $require: '@veramo/did-provider-ethr#EthrDIDProvider'
-                  $args:
-                    - defaultKms: local
-                      network: rinkeby
-                      rpcUrl: https://rinkeby.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
-                      gas: 1000001
-                      ttl: 31104001
-                did:ethr:ropsten:
-                  $require: '@veramo/did-provider-ethr#EthrDIDProvider'
-                  $args:
-                    - defaultKms: local
-                      network: ropsten
-                      rpcUrl: https://ropsten.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
-                      gas: 1000001
-                      ttl: 31104001
-                did:ethr:kovan:
-                  $require: '@veramo/did-provider-ethr#EthrDIDProvider'
-                  $args:
-                    - defaultKms: local
-                      network: kovan
-                      rpcUrl: https://kovan.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
-                      gas: 1000001
-                      ttl: 31104001
-                did:ethr:goerli:
-                  $require: '@veramo/did-provider-ethr#EthrDIDProvider'
-                  $args:
-                    - defaultKms: local
-                      network: goerli
-                      rpcUrl: https://goerli.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
-                      gas: 1000001
-                      ttl: 31104001
-                did:web:
-                  $require: '@veramo/did-provider-web#WebDIDProvider'
-                  $args:
-                    - defaultKms: local
-        - $require: '@veramo/did-resolver#DIDResolverPlugin'
-          $args:
-            - resolver:
-                $ref: /resolver
+        - $ref: /keyManager
+        - $ref: /didManager
+        - $ref: /didResolver
+        - $ref: /messageHandler
+        - $require: '@veramo/did-comm#DIDComm'
+        - $require: '@veramo/credential-w3c#CredentialIssuer'
+        - $require: '@veramo/selective-disclosure#SelectiveDisclosure'
         - $require: '@veramo/data-store#DataStore'
           $args:
             - $ref: /dbConnection
         - $require: '@veramo/data-store#DataStoreORM'
           $args:
             - $ref: /dbConnection
-        - $ref: /messageHandler
-        - $require: '@veramo/did-comm#DIDComm'
-        - $require: '@veramo/credential-w3c#CredentialIssuer'
-        - $require: '@veramo/selective-disclosure#SelectiveDisclosure'

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,6 +1,6 @@
 import express from 'express'
-import cors from 'cors'
-import program from 'commander'
+var cors = require('cors')
+import program, { addOption } from 'commander'
 import ngrok from 'ngrok'
 import parse from 'url-parse'
 import { AgentRouter, ApiSchemaRouter, WebDidDocRouter, didDocEndpoint } from '@veramo/remote-server'
@@ -25,163 +25,23 @@ program
   .option('-p, --port <number>', 'Optionally set port to override config')
   .action(async (cmd) => {
     const app = express()
-    app.use(cors())
-    const agent = getAgent(program.opts().config)
-    const { server: options } = createObjects(getConfig(program.opts().config), { server: '/server' })
 
-    /**
-     * Ngrok configuration
-     */
-    let baseUrl = options.baseUrl
-    if (options.ngrok?.connect) {
-      try {
-        baseUrl = await ngrok.connect({
-          addr: cmd.port || options.port,
-          subdomain: options.ngrok.subdomain,
-          region: options.ngrok.region,
-          authtoken: options.ngrok.authtoken,
-        })
-      } catch (e) {
-        console.error(e)
-        process.exit()
-      }
-      app.set('trust proxy', 'loopback')
-    }
-    const hostname = parse(baseUrl).hostname
+    let server: any
 
-    /**
-     *  Authentication setup
-     */
-    let authMiddleware = (req: any, res: any, next: any) => {
-      next()
-    }
-    let securityScheme
-    if (options.apiKey) {
-      console.log('🔐 Secured by API Key')
-      passport.use(
-        new Bearer.Strategy((token, done) => {
-          if (!options.apiKey || options.apiKey === token) {
-            done(null, {}, { scope: 'all' })
-          } else {
-            done(null, false)
-          }
-        }),
-      )
+    try {
+      const config = createObjects(getConfig(program.opts().config), { server: '/server' })
 
-      authMiddleware = passport.authenticate('bearer', { session: false })
-      securityScheme = 'bearer'
+      server = config.server
+    } catch (e) {
+      console.log(e.message)
+      process.exit(1)
     }
 
-    /**
-     * Exposing agent methods
-     */
-    const exposedMethods = options.exposedMethods ? options.exposedMethods : agent.availableMethods()
-    const getAgentForRequest = async (req: express.Request) => agent
-
-    console.log('🗺  API base path', baseUrl + options.apiBasePath)
-    app.use(
-      options.apiBasePath,
-      authMiddleware,
-      AgentRouter({
-        getAgentForRequest,
-        exposedMethods,
-      }),
-    )
-
-    /**
-     * Exposing OpenAPI schema
-     */
-    console.log('🗺  OpenAPI schema', baseUrl + options.schemaPath)
-    app.use(
-      options.schemaPath,
-      ApiSchemaRouter({
-        basePath: options.apiBasePath,
-        getAgentForRequest,
-        exposedMethods,
-        securityScheme,
-        apiName: options.apiName,
-        apiVersion: options.apiVersion,
-      }),
-    )
-
-    console.log('📖 API Documentation', baseUrl + options.apiDocsPath)
-    app.use(
-      options.apiDocsPath,
-      swaggerUi.serve,
-      swaggerUi.setup(undefined, {
-        swaggerOptions: {
-          url: baseUrl + options.schemaPath,
-        },
-      }),
-    )
-
-    console.log('🧩 Available methods', agent.availableMethods().length)
-    console.log('🛠  Exposed methods', exposedMethods.length)
-
-    /**
-     * Creating server identifier and configuring messaging service endpoint
-     */
-    let serverIdentifier: IIdentifier
-    if (options.defaultDID.create) {
-      serverIdentifier = await agent.didManagerGetOrCreate({
-        provider: 'did:web',
-        alias: hostname,
-      })
-      console.log('🆔', serverIdentifier.did)
-
-      const messagingServiceEndpoint = baseUrl + options.defaultDID.messagingServiceEndpoint
-
-      console.log('📨 Messaging endpoint', messagingServiceEndpoint)
-      await agent.didManagerAddService({
-        did: serverIdentifier.did,
-        service: {
-          id: serverIdentifier.did + '#msg',
-          type: 'Messaging',
-          description: 'Handles incoming POST messages',
-          serviceEndpoint: messagingServiceEndpoint,
-        },
-      })
-
-      app.post(
-        options.defaultDID.messagingServiceEndpoint,
-        express.text({ type: '*/*' }),
-        async (req, res) => {
-          try {
-            const message = await agent.handleMessage({ raw: req.body, save: true })
-            console.log('Received message', message.type, message.id)
-            res.json({ id: message.id })
-          } catch (e) {
-            console.log(e)
-            res.send(e.message)
-          }
-        },
-      )
+    for (let router of server.use) {
+      app.use(...router)
     }
 
-    /**
-     * Handling 'did:web' requests ('/.well-known/did.json' and '/^\/(.+)\/did.json$/')
-     * warning: 'did:web' method requires HTTPS (that is one of the reasons to use ngrok for development)
-     */
-    console.log('📋 DID Document ' + baseUrl + didDocEndpoint)
-    console.log('📋 DID Documents ' + baseUrl + '/(.+)/did.json')
-    app.use(WebDidDocRouter({ getAgentForRequest }))
-
-    /**
-     * Serving homepage
-     */
-    app.get('/', async (req, res) => {
-      const links = [
-        { label: 'API Docs', url: options.apiDocsPath },
-        { label: 'API Schema', url: options.schemaPath },
-        { label: 'DID Document', url: didDocEndpoint },
-      ]
-
-      const template = options.homePageTemplate || __dirname + '/../views/home.html'
-      const rendered = await hbs.render(template, { links })
-      res.send(rendered)
-    })
-
-    app.listen(cmd.port || options.port, async () => {
-      console.log(`🚀 Cloud Agent ready at ${baseUrl}`)
+    app.listen(cmd.port || server.port, async () => {
+      console.log(`🚀 Cloud Agent ready at ${server.baseUrl}`)
     })
   })

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,23 +1,7 @@
 import express from 'express'
-var cors = require('cors')
-import program, { addOption } from 'commander'
-import ngrok from 'ngrok'
-import parse from 'url-parse'
-import { AgentRouter, ApiSchemaRouter, WebDidDocRouter, didDocEndpoint } from '@veramo/remote-server'
-import swaggerUi from 'swagger-ui-express'
-import { getAgent, getConfig } from './setup'
+import program from 'commander'
+import { getConfig } from './setup'
 import { createObjects } from './lib/objectCreator'
-import passport from 'passport'
-import Bearer from 'passport-http-bearer'
-import { IIdentifier } from '@veramo/core'
-const exphbs = require('express-handlebars')
-const hbs = exphbs.create({
-  helpers: {
-    toJSON: function (obj: object) {
-      return JSON.stringify(obj, null, 2)
-    },
-  },
-})
 
 program
   .command('server')
@@ -30,7 +14,6 @@ program
 
     try {
       const config = createObjects(getConfig(program.opts().config), { server: '/server' })
-
       server = config.server
     } catch (e) {
       console.log(e.message)

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -17,7 +17,7 @@ export const getConfig = (fileName: string): any => {
 
   const config = yaml.parse(fs.readFileSync(fileName).toString())
 
-  if (config?.version != 1) {
+  if (config?.version != 2) {
     console.log('Unsupported configuration file version:', config.version)
     process.exit(1)
   }

--- a/packages/remote-server/package.json
+++ b/packages/remote-server/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "@veramo/core": "^1.1.0",
     "@veramo/remote-client": "^1.1.0",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "passport": "^0.4.1",
+    "passport-http-bearer": "^1.0.1"
   },
   "devDependencies": {
     "@types/debug": "4.1.5",

--- a/packages/remote-server/package.json
+++ b/packages/remote-server/package.json
@@ -13,7 +13,8 @@
     "@veramo/remote-client": "^1.1.0",
     "debug": "^4.1.1",
     "passport": "^0.4.1",
-    "passport-http-bearer": "^1.0.1"
+    "passport-http-bearer": "^1.0.1",
+    "url-parse": "^1.4.7"
   },
   "devDependencies": {
     "@types/debug": "4.1.5",

--- a/packages/remote-server/src/agent-router.ts
+++ b/packages/remote-server/src/agent-router.ts
@@ -11,11 +11,6 @@ interface RequestWithAgent extends Request {
  */
 export interface AgentRouterOptions {
   /**
-   * Function that returns configured agent for specific request
-   */
-  getAgentForRequest: (req: Request) => Promise<IAgent>
-
-  /**
    * List of exposed methods
    */
   exposedMethods: Array<string>

--- a/packages/remote-server/src/agent-router.ts
+++ b/packages/remote-server/src/agent-router.ts
@@ -30,10 +30,6 @@ export interface AgentRouterOptions {
 export const AgentRouter = (options: AgentRouterOptions): Router => {
   const router = Router()
   router.use(json())
-  router.use(async (req: RequestWithAgent, res, next) => {
-    req.agent = await options.getAgentForRequest(req)
-    next()
-  })
 
   for (const exposedMethod of options.exposedMethods) {
     Debug('veramo:remote-server:initializing')(exposedMethod)

--- a/packages/remote-server/src/api-key-auth.ts
+++ b/packages/remote-server/src/api-key-auth.ts
@@ -1,0 +1,15 @@
+import passport from 'passport'
+import Bearer from 'passport-http-bearer'
+
+export function apiKeyAuth({ apiKey }: { apiKey: string }) {
+  passport.use(
+    new Bearer.Strategy((token, done) => {
+      if (!apiKey || apiKey === token) {
+        done(null, {}, { scope: 'all' })
+      } else {
+        done(null, false)
+      }
+    }),
+  )
+  return passport.authenticate('bearer', { session: false })
+}

--- a/packages/remote-server/src/api-schema-router.ts
+++ b/packages/remote-server/src/api-schema-router.ts
@@ -1,24 +1,16 @@
 import { IAgent } from '@veramo/core'
 import { Request, Router } from 'express'
 import { getOpenApiSchema } from '@veramo/remote-client'
-
-interface RequestWithAgent extends Request {
-  agent?: IAgent
-}
+import { RequestWithAgent } from './request-agent-router'
 
 /**
  * @public
  */
 export interface ApiSchemaRouterOptions {
   /**
-   * Function that returns configured agent for specific request
-   */
-  getAgentForRequest: (req: Request) => Promise<IAgent>
-
-  /**
    * List of exposed methods
    */
-  exposedMethods: Array<string>
+  exposedMethods?: Array<string>
 
   /**
    * Base path
@@ -53,17 +45,13 @@ export interface ApiSchemaRouterOptions {
  */
 export const ApiSchemaRouter = (options: ApiSchemaRouterOptions): Router => {
   const router = Router()
-  router.use(async (req: RequestWithAgent, res, next) => {
-    req.agent = await options.getAgentForRequest(req)
-    next()
-  })
 
   router.get('/', (req: RequestWithAgent, res) => {
     if (req.agent) {
       const openApiSchema = getOpenApiSchema(
         req.agent,
         '',
-        options.exposedMethods,
+        options.exposedMethods || req.agent?.availableMethods(),
         options.apiName,
         options.apiVersion,
       )

--- a/packages/remote-server/src/default-did.ts
+++ b/packages/remote-server/src/default-did.ts
@@ -1,0 +1,37 @@
+import parse from 'url-parse'
+
+import { IDIDManager, TAgent } from '@veramo/core'
+
+interface CreateDefaultDidOptions {
+  agent: TAgent<IDIDManager>
+  baseUrl: string
+  messagingServiceEndpoint?: string
+}
+
+export async function createDefaultDid(options: CreateDefaultDidOptions) {
+  if (!options.agent) throw Error('[createDefaultDid] Agent is required')
+  if (!options.baseUrl) throw Error('[createDefaultDid] baseUrl is required')
+
+  const hostname = parse(options.baseUrl).hostname
+
+  const serverIdentifier = await options?.agent?.didManagerGetOrCreate({
+    provider: 'did:web',
+    alias: hostname,
+  })
+  console.log('🆔', serverIdentifier?.did)
+
+  if (serverIdentifier && options.messagingServiceEndpoint) {
+    const messagingServiceEndpoint = options.baseUrl + options.messagingServiceEndpoint
+
+    console.log('📨 Messaging endpoint', messagingServiceEndpoint)
+    await options?.agent?.didManagerAddService({
+      did: serverIdentifier.did,
+      service: {
+        id: serverIdentifier.did + '#msg',
+        type: 'Messaging',
+        description: 'Handles incoming POST messages',
+        serviceEndpoint: messagingServiceEndpoint,
+      },
+    })
+  }
+}

--- a/packages/remote-server/src/get-agent-for-request.ts
+++ b/packages/remote-server/src/get-agent-for-request.ts
@@ -1,0 +1,5 @@
+export function getAgentForRequest(agent: any) {
+  return function (req: any) {
+    return agent
+  }
+}

--- a/packages/remote-server/src/get-agent-for-request.ts
+++ b/packages/remote-server/src/get-agent-for-request.ts
@@ -1,5 +1,0 @@
-export function getAgentForRequest(agent: any) {
-  return function (req: any) {
-    return agent
-  }
-}

--- a/packages/remote-server/src/index.ts
+++ b/packages/remote-server/src/index.ts
@@ -43,3 +43,4 @@ export { WebDidDocRouter, WebDidDocRouterOptions, didDocEndpoint } from './web-d
 export { getAgentForRequest } from './get-agent-for-request'
 export { apiKeyAuth } from './api-key-auth'
 export { RequestWithAgentRouter } from './request-agent-router'
+export { MessagingRouter } from './messaging-router'

--- a/packages/remote-server/src/index.ts
+++ b/packages/remote-server/src/index.ts
@@ -39,8 +39,8 @@
 
 export { AgentRouter, AgentRouterOptions } from './agent-router'
 export { ApiSchemaRouter, ApiSchemaRouterOptions } from './api-schema-router'
-export { WebDidDocRouter, WebDidDocRouterOptions, didDocEndpoint } from './web-did-doc-router'
-export { getAgentForRequest } from './get-agent-for-request'
+export { WebDidDocRouter, didDocEndpoint } from './web-did-doc-router'
 export { apiKeyAuth } from './api-key-auth'
 export { RequestWithAgentRouter } from './request-agent-router'
 export { MessagingRouter } from './messaging-router'
+export { createDefaultDid } from './default-did'

--- a/packages/remote-server/src/index.ts
+++ b/packages/remote-server/src/index.ts
@@ -40,3 +40,6 @@
 export { AgentRouter, AgentRouterOptions } from './agent-router'
 export { ApiSchemaRouter, ApiSchemaRouterOptions } from './api-schema-router'
 export { WebDidDocRouter, WebDidDocRouterOptions, didDocEndpoint } from './web-did-doc-router'
+export { getAgentForRequest } from './get-agent-for-request'
+export { apiKeyAuth } from './api-key-auth'
+export { RequestWithAgentRouter } from './request-agent-router'

--- a/packages/remote-server/src/messaging-router.ts
+++ b/packages/remote-server/src/messaging-router.ts
@@ -1,0 +1,49 @@
+import { IAgent, IMessageHandler, TAgent } from '@veramo/core'
+import { text, Request, Router } from 'express'
+
+interface RequestWithMessageHandler extends Request {
+  agent?: TAgent<IMessageHandler>
+}
+
+/**
+ * @public
+ */
+export interface MessagingRouterOptions {
+  /**
+   * Message metadata
+   */
+  metaData: {
+    type: string
+    value?: string
+  }
+}
+
+/**
+ * Creates a router for handling incoming messages
+ *
+ * @param options - Initialization option
+ * @returns Expressjs router
+ */
+export const MessagingRouter = (options: MessagingRouterOptions): Router => {
+  const router = Router()
+  router.use(text({ type: '*/*' }))
+  router.post('/', async (req: RequestWithMessageHandler, res) => {
+    try {
+      const message = await req.agent?.handleMessage({
+        raw: (req.body as any) as string,
+        metaData: [options.metaData],
+        save: true,
+      })
+
+      if (message) {
+        console.log('Received message', message.type, message.id)
+        res.json({ id: message.id })
+      }
+    } catch (e) {
+      console.log(e)
+      res.send(e.message)
+    }
+  })
+
+  return router
+}

--- a/packages/remote-server/src/request-agent-router.ts
+++ b/packages/remote-server/src/request-agent-router.ts
@@ -1,0 +1,32 @@
+import { IAgent } from '@veramo/core'
+import { Request, Router } from 'express'
+
+export interface RequestWithAgent extends Request {
+  agent?: IAgent
+}
+
+/**
+ * @public
+ */
+export interface RequestWithAgentRouterOptions {
+  /**
+   * Function that returns configured agent for specific request
+   */
+  getAgentForRequest: (req: Request) => Promise<IAgent>
+}
+
+/**
+ * Creates a router that adds veramo agent to the request object
+ *
+ * @param options - Initialization option
+ * @returns Expressjs router
+ */
+export const RequestWithAgentRouter = (options: RequestWithAgentRouterOptions): Router => {
+  const router = Router()
+  router.use(async (req: RequestWithAgent, res, next) => {
+    req.agent = await options.getAgentForRequest(req)
+    next()
+  })
+
+  return router
+}

--- a/packages/remote-server/src/request-agent-router.ts
+++ b/packages/remote-server/src/request-agent-router.ts
@@ -10,9 +10,14 @@ export interface RequestWithAgent extends Request {
  */
 export interface RequestWithAgentRouterOptions {
   /**
-   * Function that returns configured agent for specific request
+   * Optional. Pre-configured agent
    */
-  getAgentForRequest: (req: Request) => Promise<IAgent>
+  agent?: IAgent
+
+  /**
+   * Optional. Function that returns a Promise that resolves to a configured agent for specific request
+   */
+  getAgentForRequest?: (req: Request) => Promise<IAgent>
 }
 
 /**
@@ -24,7 +29,13 @@ export interface RequestWithAgentRouterOptions {
 export const RequestWithAgentRouter = (options: RequestWithAgentRouterOptions): Router => {
   const router = Router()
   router.use(async (req: RequestWithAgent, res, next) => {
-    req.agent = await options.getAgentForRequest(req)
+    if (options.agent) {
+      req.agent = options.agent
+    } else if (options.getAgentForRequest) {
+      req.agent = await options.getAgentForRequest(req)
+    } else {
+      throw Error('[RequestWithAgentRouter] agent or getAgentForRequest is required')
+    }
     next()
   })
 

--- a/packages/remote-server/src/web-did-doc-router.ts
+++ b/packages/remote-server/src/web-did-doc-router.ts
@@ -6,22 +6,14 @@ interface RequestWithAgentDIDManager extends Request {
 }
 
 export const didDocEndpoint = '/.well-known/did.json'
-/**
- * @public
- */
-export interface WebDidDocRouterOptions {
-  /**
-   * Function that returns configured agent for specific request
-   */
-  getAgentForRequest: (req: Request) => Promise<TAgent<IDIDManager>>
-}
+
 /**
  * Creates a router that serves `did:web` DID Documents
  *
  * @param options - Initialization option
  * @returns Expressjs router
  */
-export const WebDidDocRouter = (options: WebDidDocRouterOptions): Router => {
+export const WebDidDocRouter = (): Router => {
   const router = Router()
 
   const didDocForIdentifier = (identifier: IIdentifier) => {

--- a/packages/remote-server/src/web-did-doc-router.ts
+++ b/packages/remote-server/src/web-did-doc-router.ts
@@ -5,10 +5,6 @@ interface RequestWithAgentDIDManager extends Request {
   agent?: TAgent<IDIDManager>
 }
 
-interface RequestWithAgent extends Request {
-  agent?: IAgent
-}
-
 export const didDocEndpoint = '/.well-known/did.json'
 /**
  * @public
@@ -27,10 +23,6 @@ export interface WebDidDocRouterOptions {
  */
 export const WebDidDocRouter = (options: WebDidDocRouterOptions): Router => {
   const router = Router()
-  router.use(async (req: RequestWithAgent, res, next) => {
-    req.agent = await options.getAgentForRequest(req)
-    next()
-  })
 
   const didDocForIdentifier = (identifier: IIdentifier) => {
     const didDoc = {


### PR DESCRIPTION
#374

```yml
version: 2.0

constants:
  baseUrl: http://localhost:3332
  port: 3332
  secretKey: 29739248cad1bd1a0fc4d9b75cd4d2990de535baf5caadfdf8d8f86664aa830c
  databaseFile: ./database.sqlite
  methods:
    - keyManagerGetKeyManagementSystems
    - keyManagerCreate
    - keyManagerGet
    - keyManagerDelete
    - keyManagerImport
    - keyManagerEncryptJWE
    - keyManagerDecryptJWE
    - keyManagerSignJWT
    - keyManagerSignEthTX
    - didManagerGetProviders
    - didManagerFind
    - didManagerGet
    - didManagerCreate
    - didManagerGetOrCreate
    - didManagerImport
    - didManagerDelete
    - didManagerAddKey
    - didManagerRemoveKey
    - didManagerAddService
    - didManagerRemoveService
    - resolveDid
    - dataStoreGetMessage
    - dataStoreSaveMessage
    - dataStoreGetVerifiableCredential
    - dataStoreSaveVerifiableCredential
    - dataStoreGetVerifiablePresentation
    - dataStoreSaveVerifiablePresentation
    - dataStoreORMGetIdentifiers
    - dataStoreORMGetIdentifiersCount
    - dataStoreORMGetMessages
    - dataStoreORMGetMessagesCount
    - dataStoreORMGetVerifiableCredentialsByClaims
    - dataStoreORMGetVerifiableCredentialsByClaimsCount
    - dataStoreORMGetVerifiableCredentials
    - dataStoreORMGetVerifiableCredentialsCount
    - dataStoreORMGetVerifiablePresentations
    - dataStoreORMGetVerifiablePresentationsCount
    - handleMessage
    - sendMessageDIDCommAlpha1
    - createVerifiablePresentation
    - createVerifiableCredential
    - createSelectiveDisclosureRequest
    - getVerifiableCredentialsForSdr
    - validatePresentationAgainstSdr

# Data base
dbConnection:
  $require: typeorm?t=function#createConnection
  $args:
    - type: sqlite
      database:
        $ref: /constants/databaseFile
      synchronize: true
      logging: false
      entities:
        $require: '@veramo/data-store?t=object#Entities'

# Server configuration
server:
  baseUrl:
    $ref: /constants/baseUrl
  port:
    $ref: /constants/port
  use:
    # CORS
    - - $require: 'cors'

    # Add agent to the request object
    - - $require: '@veramo/remote-server?t=function#RequestWithAgentRouter'
        $args:
          - agent:
              $ref: /agent

    # DID Documents
    - - $require: '@veramo/remote-server?t=function#WebDidDocRouter'

    # API base path
    - - /messaging
      - $require: '@veramo/remote-server?t=function#MessagingRouter'
        $args:
          - metaData:
              type: DIDComm
              value: https

    # API base path
    - - /agent
      - $require: '@veramo/remote-server?t=function#apiKeyAuth'
        $args:
          - apiKey: test123
      - $require: '@veramo/remote-server?t=function#AgentRouter'
        $args:
          - exposedMethods:
              $ref: /constants/methods

    # Open API schema
    - - /open-api.json
      - $require: '@veramo/remote-server?t=function#ApiSchemaRouter'
        $args:
          - basePath: /agent
            securityScheme: bearer
            apiName: Agent
            apiVersion: '1.0.0'
            exposedMethods:
              $ref: /constants/methods

    # Swagger docs
    - - /api-docs
      - $require: swagger-ui-express?t=object#serve
      - $require: swagger-ui-express?t=function#setup
        $args:
          - null
          - swaggerOptions:
              url: '/open-api.json'

  # Execute during server initialization
  init:
    - $require: '@veramo/remote-server?t=function#createDefaultDid'
      $args:
        - agent:
            $ref: /agent
          baseUrl:
            $ref: /constants/baseUrl
          messagingServiceEndpoint: /messaging

# Message handler plugin
messageHandler:
  $require: '@veramo/message-handler#MessageHandler'
  $args:
    - messageHandlers:
        - $require: '@veramo/did-comm#DIDCommMessageHandler'
        - $require: '@veramo/did-jwt#JwtMessageHandler'
        - $require: '@veramo/credential-w3c#W3cMessageHandler'
        - $require: '@veramo/selective-disclosure#SdrMessageHandler'

# DID resolvers
didResolver:
  $require: '@veramo/did-resolver#DIDResolverPlugin'
  $args:
    - resolver:
        $require: did-resolver#Resolver
        $args:
          - ethr:
              $ref: /ethr-did-resolver
            web:
              $ref: /web-did-resolver
            io:
              $ref: /universal-resolver
            elem:
              $ref: /universal-resolver
            key:
              $ref: /universal-resolver
            ion:
              $ref: /universal-resolver
            sov:
              $ref: /universal-resolver

ethr-did-resolver:
  $require: ethr-did-resolver?t=function&p=/ethr#getResolver
  $args:
    - networks:
        - name: mainnet
          rpcUrl: https://mainnet.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
        - name: rinkeby
          rpcUrl: https://rinkeby.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
        - name: ropsten
          rpcUrl: https://ropsten.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
        - name: kovan
          rpcUrl: https://kovan.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
        - name: goerli
          rpcUrl: https://goerli.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
        - name: private
          rpcUrl: http://localhost:8545/
          registry: '0x05cc574b19a3c11308f761b3d7263bd8608bc532'

web-did-resolver:
  $require: web-did-resolver?t=function&p=/web#getResolver

universal-resolver:
  $require: '@veramo/did-resolver#UniversalResolver'
  $args:
    - url: https://dev.uniresolver.io/1.0/identifiers/

# Key Manager
keyManager:
  $require: '@veramo/key-manager#KeyManager'
  $args:
    - store:
        $require: '@veramo/data-store#KeyStore'
        $args:
          - $ref: /dbConnection
          - $require: '@veramo/kms-local#SecretBox'
            $args:
              - $ref: /constants/secretKey
      kms:
        local:
          $require: '@veramo/kms-local#KeyManagementSystem'

# DID Manager
didManager:
  $require: '@veramo/did-manager#DIDManager'
  $args:
    - store:
        $require: '@veramo/data-store#DIDStore'
        $args:
          - $ref: /dbConnection
      defaultProvider: did:ethr:rinkeby
      providers:
        did:ethr:
          $require: '@veramo/did-provider-ethr#EthrDIDProvider'
          $args:
            - defaultKms: local
              network: mainnet
              rpcUrl: https://mainnet.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
              gas: 1000001
              ttl: 31104001
        did:ethr:rinkeby:
          $require: '@veramo/did-provider-ethr#EthrDIDProvider'
          $args:
            - defaultKms: local
              network: rinkeby
              rpcUrl: https://rinkeby.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
              gas: 1000001
              ttl: 31104001
        did:ethr:ropsten:
          $require: '@veramo/did-provider-ethr#EthrDIDProvider'
          $args:
            - defaultKms: local
              network: ropsten
              rpcUrl: https://ropsten.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
              gas: 1000001
              ttl: 31104001
        did:ethr:kovan:
          $require: '@veramo/did-provider-ethr#EthrDIDProvider'
          $args:
            - defaultKms: local
              network: kovan
              rpcUrl: https://kovan.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
              gas: 1000001
              ttl: 31104001
        did:ethr:goerli:
          $require: '@veramo/did-provider-ethr#EthrDIDProvider'
          $args:
            - defaultKms: local
              network: goerli
              rpcUrl: https://goerli.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
              gas: 1000001
              ttl: 31104001
        did:web:
          $require: '@veramo/did-provider-web#WebDIDProvider'
          $args:
            - defaultKms: local

# Agent
agent:
  $require: '@veramo/core#Agent'
  $args:
    - schemaValidation: false
      plugins:
        - $ref: /keyManager
        - $ref: /didManager
        - $ref: /didResolver
        - $ref: /messageHandler
        - $require: '@veramo/did-comm#DIDComm'
        - $require: '@veramo/credential-w3c#CredentialIssuer'
        - $require: '@veramo/selective-disclosure#SelectiveDisclosure'
        - $require: '@veramo/data-store#DataStore'
          $args:
            - $ref: /dbConnection
        - $require: '@veramo/data-store#DataStoreORM'
          $args:
            - $ref: /dbConnection

```