### PR TITLE
fix(ci): explicitly publish to `@latest` from `main` branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "veramo": "./packages/cli/bin/veramo.js",
     "prettier": "prettier --write '{packages,__tests__, !build}/**/*.{ts,js,json,md,yml}'",
     "build-clean": "rimraf ./packages/*/build ./packages/*/node_modules ./packages/*/tsconfig.tsbuildinfo && jest --clearCache",
-    "publish:latest": "lerna publish --conventional-commits --include-merged-tags --create-release github --yes --registry https://registry.npmjs.org/:_authToken=${NPM_TOKEN}",
+    "publish:latest": "lerna publish --conventional-commits --include-merged-tags --create-release github --yes --dist-tag latest --registry https://registry.npmjs.org/:_authToken=${NPM_TOKEN}",
     "publish:next": "lerna publish --conventional-prerelease --force-publish --canary --no-git-tag-version --include-merged-tags --preid next --pre-dist-tag next --yes --registry https://registry.npmjs.org/:_authToken=${NPM_TOKEN}"
   },
   "workspaces": [


### PR DESCRIPTION
This is an attempt to fix `lerna ERR! E400 Must associate a single dist tag with new publishes.` that [we got on `main`](https://github.com/uport-project/veramo/runs/2438794873?check_suite_focus=true#step:14:126).