### PR TITLE
feat(key-manager): add method to compute a shared secret

### DIFF
--- a/__tests__/shared/keyManager.ts
+++ b/__tests__/shared/keyManager.ts
@@ -200,37 +200,48 @@ export default (testContext: {
       expect(typeof rawTx).toEqual('string')
     })
 
-    // it.todo('Should Encrypt/Decrypt')
     it('Should Encrypt/Decrypt', async () => {
       const message = 'foo bar'
-
       const senderKey = await agent.keyManagerCreate({
         kms: 'local',
         type: 'Ed25519',
       })
-
       const recipientKey = await agent.keyManagerCreate({
         kms: 'local',
         type: 'Ed25519',
       })
-
       const encrypted = await agent.keyManagerEncryptJWE({
         kid: senderKey.kid,
         to: recipientKey,
         data: message,
       })
-
       expect(typeof encrypted).toEqual('string')
-
       const decrypted = await agent.keyManagerDecryptJWE({
         kid: recipientKey.kid,
         data: encrypted,
       })
-
       expect(decrypted).toEqual(message)
     })
 
-    describe('using Secp256k1 testvectors', () => {
+    it('Should compute sharedSecret', async () => {
+      const kmsArray = await agent.keyManagerGetKeyManagementSystems()
+      const kms = kmsArray[0] || 'local'
+      await agent.keyManagerImport({
+        type: 'X25519',
+        kid: 'senderKey1',
+        publicKeyHex: 'c4f35b52cc5309e70a1954b00e757d2b134f3cde9beb8179312b5ce4198a1379',
+        privateKeyHex: 'c796444e0ee9ec8e1c57ae1334a5900c287426fa5177aa093ed9199573e34aca',
+        kms,
+      })
+      const receiverKey = {
+        type: <TKeyType>'X25519',
+        publicKeyHex: 'c1d9ca35bd2c86ad0d61f682c30b24c73045a96773d82ff3b21ebadf85c39244',
+      }
+      const secret = await agent.keyManagerSharedSecret({ secretKeyRef: 'senderKey1', publicKey: receiverKey })
+      expect(secret).toEqual('ee94c7fcf5298291029a3c3d59a8a05367a1806f36668a1f67f5ea8149097476')
+    })
+
+    describe('using Secp256k1 test vectors', () => {
       const importedKey = {
         kid: '04155ee0cbefeecd80de63a62b4ed8f0f97ac22a58f76a265903b9acab79bf018c7037e2bd897812170c92a4c978d6a10481491a37299d74c4bd412a111a4ac875',
         kms: 'local',
@@ -304,7 +315,7 @@ export default (testContext: {
       })
     })
 
-    describe('using Ed25519 testvectors', () => {
+    describe('using Ed25519 test vectors', () => {
       const importedKey = {
         kid: 'ea75250531f6834328ac210618253288e4c54632962a9708ca82e4a399f79000',
         kms: 'local',

--- a/packages/core/plugin.schema.json
+++ b/packages/core/plugin.schema.json
@@ -523,6 +523,38 @@
           ],
           "description": "Input arguments for  {@link  IKeyManager.keyManagerGet | keyManagerGet }"
         },
+        "IKeyManagerSharedSecretArgs": {
+          "type": "object",
+          "properties": {
+            "secretKeyRef": {
+              "type": "string",
+              "description": "The secret key handle (`kid`) as returned by  {@link  IKeyManager.keyManagerCreate | keyManagerCreate }"
+            },
+            "publicKey": {
+              "type": "object",
+              "properties": {
+                "publicKeyHex": {
+                  "type": "string",
+                  "description": "Public key"
+                },
+                "type": {
+                  "$ref": "#/components/schemas/TKeyType",
+                  "description": "Key type"
+                }
+              },
+              "required": [
+                "publicKeyHex",
+                "type"
+              ],
+              "description": "The public key of the other party. The `type` of key MUST be compatible with the type referenced by `secretKeyRef`"
+            }
+          },
+          "required": [
+            "secretKeyRef",
+            "publicKey"
+          ],
+          "description": "Input arguments for  {@link  IKeyManager.keyManagerSharedSecret | keyManagerSharedSecret }"
+        },
         "IKeyManagerSignArgs": {
           "type": "object",
           "properties": {
@@ -704,6 +736,15 @@
           },
           "returnType": {
             "type": "boolean"
+          }
+        },
+        "keyManagerSharedSecret": {
+          "description": "Compute a shared secret with the public key of another party.",
+          "arguments": {
+            "$ref": "#/components/schemas/IKeyManagerSharedSecretArgs"
+          },
+          "returnType": {
+            "type": "string"
           }
         },
         "keyManagerSign": {

--- a/packages/core/src/types/IKeyManager.ts
+++ b/packages/core/src/types/IKeyManager.ts
@@ -202,11 +202,11 @@ export interface IKeyManager extends IPluginMethodMap {
   /**
    * Compute a shared secret with the public key of another party.
    * 
-   * This computes the raw shared key (the result of a Diffie-Hellman computation )
+   * This computes the raw shared secret (the result of a Diffie-Hellman computation)
    * To use this for symmetric encryption you MUST apply a KDF on the result.
    * 
    * @param args {@link IKeyManagerSharedKeyArgs} 
-   * @returns a `Promise` that resolves to a hex encoded shared key
+   * @returns a `Promise` that resolves to a hex encoded shared secret
    */
   keyManagerSharedSecret(args: IKeyManagerSharedSecretArgs): Promise<string>
 

--- a/packages/core/src/types/IKeyManager.ts
+++ b/packages/core/src/types/IKeyManager.ts
@@ -94,7 +94,7 @@ export interface IKeyManagerSignArgs {
   /**
    * The algorithm to use for signing.
    * This must be one of the algorithms supported by the KMS for this key type.
-   * 
+   *
    * The algorithm used here should match one of the names listed in `IKey.meta.algorithms`
    */
   algorithm?: string
@@ -110,6 +110,24 @@ export interface IKeyManagerSignArgs {
   encoding?: 'utf-8' | 'base16' | 'base64' | 'hex'
 
   [x: string]: any
+}
+
+/**
+ * Input arguments for {@link IKeyManager.keyManagerSharedSecret | keyManagerSharedSecret}
+ * @public
+ */
+export interface IKeyManagerSharedSecretArgs {
+  /**
+   * The secret key handle (`kid`)
+   * as returned by {@link IKeyManager.keyManagerCreate | keyManagerCreate}
+   */
+  secretKeyRef: string,
+
+  /**
+   * The public key of the other party.
+   * The `type` of key MUST be compatible with the type referenced by `secretKeyRef`
+   */
+  publicKey: Pick<IKey, 'publicKeyHex' | 'type'>
 }
 
 /**
@@ -180,6 +198,17 @@ export interface IKeyManager extends IPluginMethodMap {
    * @param args
    */
   keyManagerSign(args: IKeyManagerSignArgs): Promise<string>
+
+  /**
+   * Compute a shared secret with the public key of another party.
+   * 
+   * This computes the raw shared key (the result of a Diffie-Hellman computation )
+   * To use this for symmetric encryption you MUST apply a KDF on the result.
+   * 
+   * @param args {@link IKeyManagerSharedKeyArgs} 
+   * @returns a `Promise` that resolves to a hex encoded shared key
+   */
+  keyManagerSharedSecret(args: IKeyManagerSharedSecretArgs): Promise<string>
 
   /**
    * Encrypts data

--- a/packages/key-manager/src/__tests__/default.test.ts
+++ b/packages/key-manager/src/__tests__/default.test.ts
@@ -1,4 +1,4 @@
-describe('did-manager', () => {
+describe('key-manager', () => {
   const a = 100
   it('should run a dummy test', () => {
     expect(a).toEqual(100)

--- a/packages/key-manager/src/abstract-key-management-system.ts
+++ b/packages/key-manager/src/abstract-key-management-system.ts
@@ -34,4 +34,6 @@ export abstract class AbstractKeyManagementSystem {
   }
 
   abstract sign(args: { key: IKey; algorithm?: string; data: Uint8Array; [x: string]: any }): Promise<string>
+
+  abstract sharedSecret(args: { myKey: IKey; theirKey: Pick<IKey, 'publicKeyHex' | 'type'> }): Promise<string>
 }

--- a/packages/key-manager/src/key-manager.ts
+++ b/packages/key-manager/src/key-manager.ts
@@ -153,7 +153,7 @@ export class KeyManager implements IAgentPlugin {
       (['Ed25519', 'X25519'].includes(myKey.type) && ['Ed25519', 'X25519'].includes(theirKey.type))
     ) {
     } else {
-      throw new Error('invalid_argument: the key types have to match to be able to compute a shared key')
+      throw new Error('invalid_argument: the key types have to match to be able to compute a shared secret')
     }
     const kms = this.getKms(myKey.kms)
     return kms.sharedSecret({ myKey, theirKey })

--- a/packages/kms-local/src/__tests__/kms-local.test.ts
+++ b/packages/kms-local/src/__tests__/kms-local.test.ts
@@ -1,0 +1,100 @@
+import { KeyManagementSystem } from '../key-management-system'
+import { IKey, TKeyType } from '@veramo/core'
+
+describe('@veramo/kms-local', () => {
+  it('should compute a shared secret Ed+Ed', async () => {
+    const kms = new KeyManagementSystem()
+    const myKey = {
+      type: 'Ed25519',
+      privateKeyHex:
+        'ed3991fa33d4df22c88b78249e4d73c509c640a873a66808ad5dce774334ce94ee5072bc20355b4cd5499e04ee70853591bffa1874b1b5467dedd648d5b89ecb',
+    } as IKey
+    const theirKey = {
+      type: <TKeyType>'Ed25519',
+      publicKeyHex: 'e1d1dc2afe59bb054c44ba23ba07561d15ba83f9d1c42568ac11351fbdfd87c6',
+    }
+
+    const secret = await kms.sharedSecret({ myKey, theirKey })
+    expect(secret).toEqual('2f1d171ad32fdbd10d1b06600d70223f7298809d4a3690fa03d6b4688c7b116a')
+  })
+
+  it('should compute a shared secret Ed+X', async () => {
+    const kms = new KeyManagementSystem()
+    const myKey = {
+      type: 'Ed25519',
+      privateKeyHex:
+        'ed3991fa33d4df22c88b78249e4d73c509c640a873a66808ad5dce774334ce94ee5072bc20355b4cd5499e04ee70853591bffa1874b1b5467dedd648d5b89ecb',
+    } as IKey
+    const theirKey = {
+      type: <TKeyType>'X25519',
+      publicKeyHex: '09c99ad2fdb13247d97f4343d05cc20930db0808697e89f8f3d111a40cb6ee35',
+    }
+
+    const secret = await kms.sharedSecret({ myKey, theirKey })
+    expect(secret).toEqual('2f1d171ad32fdbd10d1b06600d70223f7298809d4a3690fa03d6b4688c7b116a')
+  })
+
+  it('should compute a shared secret X+Ed', async () => {
+    const kms = new KeyManagementSystem()
+    const myKey = {
+      type: 'X25519',
+      privateKeyHex: '704380837434dde8a41bebcb75494578bf243fa19cd59e120a1de84e0815c84d',
+    } as IKey
+
+    const theirKey = {
+      type: <TKeyType>'Ed25519',
+      publicKeyHex: 'e1d1dc2afe59bb054c44ba23ba07561d15ba83f9d1c42568ac11351fbdfd87c6',
+    }
+
+    const secret = await kms.sharedSecret({ myKey, theirKey })
+    expect(secret).toEqual('2f1d171ad32fdbd10d1b06600d70223f7298809d4a3690fa03d6b4688c7b116a')
+  })
+
+  it('should compute a shared secret X+X', async () => {
+    const kms = new KeyManagementSystem()
+    const myKey = {
+      type: 'X25519',
+      privateKeyHex: '704380837434dde8a41bebcb75494578bf243fa19cd59e120a1de84e0815c84d',
+    } as IKey
+
+    const theirKey = {
+      type: <TKeyType>'X25519',
+      publicKeyHex: '09c99ad2fdb13247d97f4343d05cc20930db0808697e89f8f3d111a40cb6ee35',
+    }
+
+    const secret = await kms.sharedSecret({ myKey, theirKey })
+    expect(secret).toEqual('2f1d171ad32fdbd10d1b06600d70223f7298809d4a3690fa03d6b4688c7b116a')
+  })
+
+  it('should throw on invalid myKey type', async () => {
+    expect.assertions(1)
+    const kms = new KeyManagementSystem()
+    const myKey = {
+      type: 'Secp256k1',
+      privateKeyHex: '704380837434dde8a41bebcb75494578bf243fa19cd59e120a1de84e0815c84d',
+    } as IKey
+
+    const theirKey = {
+      type: <TKeyType>'X25519',
+      publicKeyHex: '09c99ad2fdb13247d97f4343d05cc20930db0808697e89f8f3d111a40cb6ee35',
+    }
+
+    expect(kms.sharedSecret({ myKey, theirKey })).rejects.toThrow('not_supported')
+  })
+
+  it('should throw on invalid theirKey type', async () => {
+    expect.assertions(1)
+    const kms = new KeyManagementSystem()
+    const myKey = {
+      type: 'X25519',
+      privateKeyHex: '704380837434dde8a41bebcb75494578bf243fa19cd59e120a1de84e0815c84d',
+    } as IKey
+
+    const theirKey = {
+      type: <TKeyType>'Secp256k1',
+      publicKeyHex: '09c99ad2fdb13247d97f4343d05cc20930db0808697e89f8f3d111a40cb6ee35',
+    }
+
+    expect(kms.sharedSecret({ myKey, theirKey })).rejects.toThrow('not_supported')
+  })
+})

--- a/packages/kms-local/src/key-management-system.ts
+++ b/packages/kms-local/src/key-management-system.ts
@@ -151,13 +151,13 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
     if (myKey.type === 'Ed25519') {
       myKeyBytes = convertSecretKeyToX25519(myKeyBytes)
     } else if (myKey.type !== 'X25519') {
-      throw new Error(`not_supported: can't compute shared key for type=${myKey.type}`)
+      throw new Error(`not_supported: can't compute shared secret for type=${myKey.type}`)
     }
     let theirKeyBytes = arrayify('0x' + theirKey.publicKeyHex)
     if (theirKey.type === 'Ed25519') {
       theirKeyBytes = convertPublicKeyToX25519(theirKeyBytes)
     } else if (theirKey.type !== 'X25519') {
-      throw new Error(`not_supported: can't compute shared key for type=${theirKey.type}`)
+      throw new Error(`not_supported: can't compute shared secret for type=${theirKey.type}`)
     }
     const shared = sharedKey(myKeyBytes, theirKeyBytes)
     return hexlify(shared).substring(2)


### PR DESCRIPTION
## What's here

* `key-manager` plugin exposes a new method that computes a shared key (Diffie Hellman) between a secret key the agent manages and a public key of another party, returning a promise that resolves to the hex encoding string of the shared key.
```ts
async keyManagerSharedKey({secretKeyRef: string, publicKey: {type: string, publicKeyHex: string}}): Promise<string>`
```
The result is the RAW shared secret (scalar multiplication in the case of ECC).
To use this for symmetric encryption, one would need to hash it to arrive at a shared Symmetric Key
* To do this, there is a new requirement of the `AbstractKeyManagementSystem` class for a new abstract method `sharedKey()`
* The `kms-local` package implements this new `sharedKey` method
* `kms-local` supports `Ed25519` & `X25519` keys for computing the shared key. Keys are converted to `X25519` if they are `Ed25519`

closes #541