### PR TITLE
feat(key-manager): implement JWE functionality directly in `key-manager`

### DIFF
--- a/packages/core/src/types/IKeyManager.ts
+++ b/packages/core/src/types/IKeyManager.ts
@@ -201,11 +201,11 @@ export interface IKeyManager extends IPluginMethodMap {
 
   /**
    * Compute a shared secret with the public key of another party.
-   * 
+   *
    * This computes the raw shared secret (the result of a Diffie-Hellman computation)
    * To use this for symmetric encryption you MUST apply a KDF on the result.
-   * 
-   * @param args {@link IKeyManagerSharedKeyArgs} 
+   *
+   * @param args {@link IKeyManagerSharedKeyArgs}
    * @returns a `Promise` that resolves to a hex encoded shared secret
    */
   keyManagerSharedSecret(args: IKeyManagerSharedSecretArgs): Promise<string>

--- a/packages/key-manager/src/abstract-key-management-system.ts
+++ b/packages/key-manager/src/abstract-key-management-system.ts
@@ -1,13 +1,11 @@
 import { IKey, TKeyType } from '@veramo/core'
-import { arrayify } from '@ethersproject/bytes'
+import { arrayify, hexlify } from '@ethersproject/bytes'
 import { serialize, Transaction } from '@ethersproject/transactions'
 import * as u8a from 'uint8arrays'
 
 export abstract class AbstractKeyManagementSystem {
   abstract createKey(args: { type: TKeyType; meta?: any }): Promise<Omit<IKey, 'kms'>>
   abstract deleteKey(args: { kid: string }): Promise<boolean>
-  abstract encryptJWE(args: { key: IKey; to: Omit<IKey, 'kms'>; data: string }): Promise<string>
-  abstract decryptJWE(args: { key: IKey; data: string }): Promise<string>
 
   /**@deprecated please use `sign({key, alg: 'eth_signTransaction', data: arrayify(serialize(transaction))})` instead */
   async signEthTX({ key, transaction }: { key: IKey; transaction: object }): Promise<string> {


### PR DESCRIPTION
The KMS is only used to compute shared secret, it doesn't need to deal with JWE directly.
This PR moves the responsibility of createJWE and decryptJWE to the `key-manager` layer which eventually uses the `shared secret` functionality of the KMS to perform the same task.

fixes #556