### PR TITLE
Fixes #560, don't assume that message.data exists

### DIFF
--- a/packages/selective-disclosure/src/message-handler.ts
+++ b/packages/selective-disclosure/src/message-handler.ts
@@ -26,8 +26,8 @@ export class SdrMessageHandler extends AbstractMessageHandler {
     const meta = message.getLastMetaData()
 
     if (
-      message.data.type == MessageTypes.sdr &&
-      message.data.claims
+      message?.data?.type == MessageTypes.sdr &&
+      message?.data?.claims
     ) {
       debug('Message type is', MessageTypes.sdr)
 


### PR DESCRIPTION
Added optional chaining to the first if statement so that if message.data doesn't exist, the program doesn't fail.