### PR TITLE
feat(sdr): returns UniqueVerifiableCredential

### DIFF
--- a/__tests__/shared/handleSdrMessage.ts
+++ b/__tests__/shared/handleSdrMessage.ts
@@ -117,7 +117,8 @@ export default (testContext: {
         },
       })
 
-      expect(credentials[0].credentials[0]).toHaveProperty('proof.jwt')
+      expect(credentials[0].credentials[0]).toHaveProperty('hash')
+      expect(credentials[0].credentials[0]).toHaveProperty('verifiableCredential.proof.jwt')
     })
 
     it('should create verifiable presentation', async () => {
@@ -138,7 +139,7 @@ export default (testContext: {
           '@context': ['https://www.w3.org/2018/credentials/v1'],
           type: ['VerifiablePresentation'],
           issuanceDate: new Date().toISOString(),
-          verifiableCredential: credentials[0].credentials,
+          verifiableCredential: credentials[0].credentials.map(c => c.verifiableCredential),
         },
         proofFormat: 'jwt',
         save: true,

--- a/packages/cli/src/sdr.ts
+++ b/packages/cli/src/sdr.ts
@@ -303,13 +303,13 @@ sdr
         name: item.claimType + ' ' + (item.essential ? '(essential)' : '') + item.reason,
         choices: item.credentials.map((c) => ({
           name:
-            c.credentialSubject[item.claimType] +
+            c.verifiableCredential.credentialSubject[item.claimType] +
             ' (' +
-            c.type.join(',') +
+            c.verifiableCredential.type.join(',') +
             ') issued by: ' +
-            c.issuer.id +
+            c.verifiableCredential.issuer.id +
             ' ' +
-            shortDate(c.issuanceDate) +
+            shortDate(c.verifiableCredential.issuanceDate) +
             ' ago',
           value: c,
         })),

--- a/packages/selective-disclosure/plugin.schema.json
+++ b/packages/selective-disclosure/plugin.schema.json
@@ -369,7 +369,7 @@
             "credentials": {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/VerifiableCredential"
+                "$ref": "#/components/schemas/UniqueVerifiableCredential"
               }
             }
           },
@@ -378,6 +378,21 @@
             "credentials"
           ],
           "description": "The credentials that make up a response of a Selective Disclosure"
+        },
+        "UniqueVerifiableCredential": {
+          "type": "object",
+          "properties": {
+            "hash": {
+              "type": "string"
+            },
+            "verifiableCredential": {
+              "$ref": "#/components/schemas/VerifiableCredential"
+            }
+          },
+          "required": [
+            "hash",
+            "verifiableCredential"
+          ]
         },
         "IValidatePresentationAgainstSdrArgs": {
           "type": "object",

--- a/packages/selective-disclosure/src/__tests__/validate-presentation.test.ts
+++ b/packages/selective-disclosure/src/__tests__/validate-presentation.test.ts
@@ -91,7 +91,7 @@ describe('@veramo/selective-disclosure-helper', () => {
 
     const result = await actionHandler.validatePresentationAgainstSdr({ presentation, sdr }, context)
 
-    expect(result.claims[0].credentials[0].credentialSubject['firstName']).toEqual('Alice')
+    expect(result.claims[0].credentials[0].verifiableCredential.credentialSubject['firstName']).toEqual('Alice')
     expect(result.valid).toEqual(true)
   })
 

--- a/packages/selective-disclosure/src/action-handler.ts
+++ b/packages/selective-disclosure/src/action-handler.ts
@@ -19,6 +19,7 @@ import {
 } from './types'
 import { schema } from './'
 import { createJWT } from 'did-jwt'
+import { blake2bHex } from 'blakejs'
 import Debug from 'debug'
 
 /**
@@ -148,7 +149,7 @@ export class SelectiveDisclosure implements IAgentPlugin {
 
       result.push({
         ...credentialRequest,
-        credentials: credentials.map((c) => c.verifiableCredential),
+        credentials,
       })
     }
     return result
@@ -214,7 +215,10 @@ export class SelectiveDisclosure implements IAgentPlugin {
 
       claims.push({
         ...credentialRequest,
-        credentials,
+        credentials: credentials.map(vc => ({
+          hash: blake2bHex(JSON.stringify(vc)),
+          verifiableCredential: vc
+        })),
       })
     }
     return { valid, claims }

--- a/packages/selective-disclosure/src/types.ts
+++ b/packages/selective-disclosure/src/types.ts
@@ -3,10 +3,9 @@ import {
   IDIDManager,
   IKeyManager,
   IPluginMethodMap,
-  VerifiableCredential,
   VerifiablePresentation,
 } from '@veramo/core'
-import { IDataStoreORM } from '@veramo/data-store'
+import { IDataStoreORM, UniqueVerifiableCredential } from '@veramo/data-store'
 import { ICredentialIssuer } from '@veramo/credential-w3c'
 
 /**
@@ -113,7 +112,7 @@ export interface ICredentialRequestInput {
  * @beta
  */
 export interface ICredentialsForSdr extends ICredentialRequestInput {
-  credentials: VerifiableCredential[]
+  credentials: UniqueVerifiableCredential[]
 }
 
 /**


### PR DESCRIPTION
BREAKING CHANGE:
`getVerifiableCredentialsForSdr` and `validatePresentationAgainstSdr`
now returns `UniqueVerifiableCredential ` (`{ hash: string, verifiableCredential: VerifiableCredential }`)
instead of `VerifiableCredential`

Fixes: #496