### PR TITLE
feat(remote-server): express did:web verification relationships in DIDDocument

### DIFF
--- a/packages/did-comm/src/utils.ts
+++ b/packages/did-comm/src/utils.ts
@@ -51,7 +51,7 @@ export function decodeJoseBlob(blob: string) {
 }
 
 export function isDefined<T>(arg: T): arg is Exclude<T, null | undefined> {
-  return typeof arg !== 'undefined'
+  return arg && typeof arg !== 'undefined'
 }
 
 export function createEcdhWrapper(secretKeyRef: string, context: IAgentContext<IKeyManager>): ECDH {
@@ -173,7 +173,7 @@ export async function mapIdentifierKeysToDoc(
     context,
   )
 
-  let localKeys = identifier.keys
+  let localKeys = identifier.keys.filter(isDefined)
   if (section === 'keyAgreement') {
     localKeys = convertIdentifierEncryptionKeys(identifier)
   }

--- a/packages/did-provider-web/src/web-did-provider.ts
+++ b/packages/did-provider-web/src/web-did-provider.ts
@@ -19,10 +19,11 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
   }
 
   async createIdentifier(
-    { kms, alias }: { kms?: string; alias?: string },
+    { kms, alias, options }: { kms?: string; alias?: string; options: any },
     context: IContext,
   ): Promise<Omit<IIdentifier, 'provider'>> {
-    const key = await context.agent.keyManagerCreate({ kms: kms || this.defaultKms, type: 'Secp256k1' })
+    const keyType = options?.keyType || 'Secp256k1'
+    const key = await context.agent.keyManagerCreate({ kms: kms || this.defaultKms, type: keyType })
 
     const identifier: Omit<IIdentifier, 'provider'> = {
       did: 'did:web:' + alias,

--- a/packages/remote-server/src/default-did.ts
+++ b/packages/remote-server/src/default-did.ts
@@ -33,5 +33,15 @@ export async function createDefaultDid(options: CreateDefaultDidOptions) {
         serviceEndpoint: messagingServiceEndpoint,
       },
     })
+    // list DIDCommMessaging service at the same endpoint
+    await options?.agent?.didManagerAddService({
+      did: serverIdentifier.did,
+      service: {
+        id: serverIdentifier.did + '#msg-didcomm',
+        type: 'DIDCommMessaging',
+        description: 'Handles incoming DIDComm messages',
+        serviceEndpoint: messagingServiceEndpoint,
+      },
+    })
   }
 }

--- a/packages/remote-server/src/default-did.ts
+++ b/packages/remote-server/src/default-did.ts
@@ -1,6 +1,6 @@
 import parse from 'url-parse'
 
-import { IDIDManager, TAgent } from '@veramo/core'
+import { IDIDManager, TAgent, TKeyType } from '@veramo/core'
 
 interface CreateDefaultDidOptions {
   agent: TAgent<IDIDManager>
@@ -17,6 +17,9 @@ export async function createDefaultDid(options: CreateDefaultDidOptions) {
   const serverIdentifier = await options?.agent?.didManagerGetOrCreate({
     provider: 'did:web',
     alias: hostname,
+    options: {
+      keyType: <TKeyType>'Ed25519',
+    },
   })
   console.log('🆔', serverIdentifier?.did)
 

--- a/packages/remote-server/src/web-did-doc-router.ts
+++ b/packages/remote-server/src/web-did-doc-router.ts
@@ -1,4 +1,4 @@
-import { IIdentifier, IDIDManager, TAgent } from '@veramo/core'
+import { IIdentifier, IDIDManager, TAgent, TKeyType } from '@veramo/core'
 import { Request, Router } from 'express'
 
 interface RequestWithAgentDIDManager extends Request {
@@ -6,6 +6,12 @@ interface RequestWithAgentDIDManager extends Request {
 }
 
 export const didDocEndpoint = '/.well-known/did.json'
+
+const keyMapping: Record<TKeyType, string> = {
+  Secp256k1: 'EcdsaSecp256k1VerificationKey2019',
+  Ed25519: 'Ed25519VerificationKey2018',
+  X25519: 'X25519KeyAgreementKey2019',
+}
 
 /**
  * Creates a router that serves `did:web` DID Documents
@@ -17,16 +23,27 @@ export const WebDidDocRouter = (): Router => {
   const router = Router()
 
   const didDocForIdentifier = (identifier: IIdentifier) => {
+    const allKeys = identifier.keys.map((key) => ({
+      id: identifier.did + '#' + key.kid,
+      type: keyMapping[key.type],
+      controller: identifier.did,
+      publicKeyHex: key.publicKeyHex,
+    }))
+    // ed25519 keys can also be converted to x25519 for key agreement
+    const keyAgreementKeyIds = allKeys
+      .filter((key) => ['Ed25519VerificationKey2018', 'X25519KeyAgreementKey2019'].includes(key.type))
+      .map((key) => key.id)
+    const signingKeyIds = allKeys
+      .filter((key) => key.type !== 'X25519KeyAgreementKey2019')
+      .map((key) => key.id)
+
     const didDoc = {
       '@context': 'https://w3id.org/did/v1',
       id: identifier.did,
-      verificationMethod: identifier.keys.map((key) => ({
-        id: identifier.did + '#' + key.kid,
-        type: key.type === 'Secp256k1' ? 'EcdsaSecp256k1VerificationKey2019' : 'Ed25519VerificationKey2018',
-        controller: identifier.did,
-        publicKeyHex: key.publicKeyHex,
-      })),
-      authentication: identifier.keys.map((key) => `${identifier.did}#${key.kid}`),
+      verificationMethod: allKeys,
+      authentication: signingKeyIds,
+      assertionMethod: signingKeyIds,
+      keyAgreement: keyAgreementKeyIds,
       service: identifier.services,
     }
 


### PR DESCRIPTION
fixes #618

Also contained in this PR:
* a fix for a potential bug in did-comm message unpacking when filtering local keys
* express `DIDCommMessaging` service for the default did:web document in `@veramo/remote-server`
* add an `Ed25519` key to the default did:web document in `@veramo/remote-server`

This makes the default did:web managed by the `@veramo/remote-server` DIDComm v2 capable