### PR TITLE
fix(did-ethr-provider): allow initialization with chainId number

### DIFF
--- a/__tests__/localAgent.test.ts
+++ b/__tests__/localAgent.test.ts
@@ -19,6 +19,7 @@ import { EthrDIDProvider } from '../packages/did-provider-ethr/src'
 import { WebDIDProvider } from '../packages/did-provider-web/src'
 import { KeyDIDProvider } from '../packages/did-provider-key/src'
 import { DIDComm, DIDCommMessageHandler, IDIDComm } from '../packages/did-comm/src'
+import { DIDCommHttpTransport } from '../packages/did-comm/src/transports/transports'
 import {
   SelectiveDisclosure,
   ISelectiveDisclosure,
@@ -34,11 +35,13 @@ import {
   DataStoreORM,
   ProfileDiscoveryProvider,
 } from '../packages/data-store/src'
+import { getDidKeyResolver } from '../packages/did-provider-key/src'
+import { IDIDDiscovery, DIDDiscovery } from '../packages/did-discovery/src'
+import { FakeDidProvider, FakeDidResolver } from './utils/fake-did'
+
 import { Resolver } from 'did-resolver'
 import { getResolver as ethrDidResolver } from 'ethr-did-resolver'
 import { getResolver as webDidResolver } from 'web-did-resolver'
-import { getDidKeyResolver } from '../packages/did-provider-key'
-import { IDIDDiscovery, DIDDiscovery } from '../packages/did-discovery'
 import fs from 'fs'
 
 jest.setTimeout(30000)
@@ -55,8 +58,6 @@ import didManager from './shared/didManager'
 import didComm from './shared/didcomm'
 import messageHandler from './shared/messageHandler'
 import didDiscovery from './shared/didDiscovery'
-import { FakeDidProvider, FakeDidResolver } from './utils/fake-did'
-import { DIDCommHttpTransport } from '../packages/did-comm/src/transports/transports'
 
 const databaseFile = 'local-database.sqlite'
 const infuraProjectId = '5ffc47f65c4042ce847ef66a3fa70d4c'
@@ -126,6 +127,12 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
             rpcUrl: 'https://rinkeby.infura.io/v3/' + infuraProjectId,
             gas: 1000001,
             ttl: 60 * 60 * 24 * 30 * 12 + 1,
+          }),
+          'did:ethr:421611': new EthrDIDProvider({
+            defaultKms: 'local',
+            network: 421611,
+            rpcUrl: 'https://arbitrum-rinkeby.infura.io/v3/' + infuraProjectId,
+            registry: '0x8f54f62CA28D481c3C30b1914b52ef935C1dF820',
           }),
           'did:web': new WebDIDProvider({
             defaultKms: 'local',

--- a/__tests__/localMemoryStoreAgent.test.ts
+++ b/__tests__/localMemoryStoreAgent.test.ts
@@ -26,10 +26,12 @@ import {
 } from '../packages/selective-disclosure/src'
 import { KeyManagementSystem } from '../packages/kms-local/src'
 import { Entities, IDataStoreORM, DataStore, DataStoreORM } from '../packages/data-store/src'
+import { getDidKeyResolver } from '../packages/did-provider-key/src'
+import { FakeDidProvider, FakeDidResolver } from './utils/fake-did'
+
 import { Resolver } from 'did-resolver'
 import { getResolver as ethrDidResolver } from 'ethr-did-resolver'
 import { getResolver as webDidResolver } from 'web-did-resolver'
-import { getDidKeyResolver } from '../packages/did-provider-key'
 import fs from 'fs'
 
 jest.setTimeout(30000)
@@ -45,7 +47,6 @@ import keyManager from './shared/keyManager'
 import didManager from './shared/didManager'
 import didComm from './shared/didcomm'
 import messageHandler from './shared/messageHandler'
-import { FakeDidProvider, FakeDidResolver } from './utils/fake-did'
 
 const databaseFile = 'local-database2.sqlite'
 const infuraProjectId = '5ffc47f65c4042ce847ef66a3fa70d4c'
@@ -112,6 +113,12 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
             rpcUrl: 'https://rinkeby.infura.io/v3/' + infuraProjectId,
             gas: 1000001,
             ttl: 60 * 60 * 24 * 30 * 12 + 1,
+          }),
+          'did:ethr:421611': new EthrDIDProvider({
+            defaultKms: 'local',
+            network: 421611,
+            rpcUrl: 'https://arbitrum-rinkeby.infura.io/v3/' + infuraProjectId,
+            registry: '0x8f54f62CA28D481c3C30b1914b52ef935C1dF820',
           }),
           'did:web': new WebDIDProvider({
             defaultKms: 'local',

--- a/__tests__/restAgent.test.ts
+++ b/__tests__/restAgent.test.ts
@@ -22,6 +22,7 @@ import { EthrDIDProvider } from '../packages/did-provider-ethr/src'
 import { WebDIDProvider } from '../packages/did-provider-web/src'
 import { KeyDIDProvider } from '../packages/did-provider-key/src'
 import { DIDComm, DIDCommMessageHandler, IDIDComm } from '../packages/did-comm/src'
+import { DIDCommHttpTransport } from '../packages/did-comm/src/transports/transports'
 import {
   SelectiveDisclosure,
   ISelectiveDisclosure,
@@ -38,17 +39,16 @@ import {
   ProfileDiscoveryProvider,
 } from '../packages/data-store/src'
 import { AgentRestClient } from '../packages/remote-client/src'
-import express from 'express'
-import { Server } from 'http'
 import { AgentRouter, RequestWithAgentRouter, MessagingRouter } from '../packages/remote-server/src'
+import { getDidKeyResolver } from '../packages/did-provider-key/src'
+import { IDIDDiscovery, DIDDiscovery } from '../packages/did-discovery/src'
+import { FakeDidProvider, FakeDidResolver } from './utils/fake-did'
+
 import { Resolver } from 'did-resolver'
 import { getResolver as ethrDidResolver } from 'ethr-did-resolver'
 import { getResolver as webDidResolver } from 'web-did-resolver'
-import { IDIDDiscovery, DIDDiscovery } from '../packages/did-discovery'
-import { FakeDidProvider, FakeDidResolver } from './utils/fake-did'
-// import { getUniversalResolver } from '../packages/did-resolver/src/universal-resolver'
-import { DIDCommHttpTransport } from '../packages/did-comm/src/transports/transports'
-import { getDidKeyResolver } from '../packages/did-provider-key/build'
+import express from 'express'
+import { Server } from 'http'
 import fs from 'fs'
 
 jest.setTimeout(30000)
@@ -135,6 +135,12 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
             rpcUrl: 'https://rinkeby.infura.io/v3/' + infuraProjectId,
             gas: 1000001,
             ttl: 60 * 60 * 24 * 30 * 12 + 1,
+          }),
+          'did:ethr:421611': new EthrDIDProvider({
+            defaultKms: 'local',
+            network: 421611,
+            rpcUrl: 'https://arbitrum-rinkeby.infura.io/v3/' + infuraProjectId,
+            registry: '0x8f54f62CA28D481c3C30b1914b52ef935C1dF820',
           }),
           'did:web': new WebDIDProvider({
             defaultKms: 'local',

--- a/__tests__/shared/didDiscovery.ts
+++ b/__tests__/shared/didDiscovery.ts
@@ -1,4 +1,4 @@
-import { IDIDDiscovery } from '../../packages/did-discovery'
+import { IDIDDiscovery } from '../../packages/did-discovery/src'
 import { TAgent, IDIDManager, IKeyManager, IIdentifier } from '../../packages/core/src'
 import { IDataStoreORM } from '../../packages/data-store/src'
 import { ICredentialIssuer } from '../../packages/credential-w3c/src'

--- a/__tests__/shared/didManager.ts
+++ b/__tests__/shared/didManager.ts
@@ -19,7 +19,7 @@ export default (testContext: {
 
     it('should get providers', async () => {
       const providers = await agent.didManagerGetProviders()
-      expect(providers).toEqual(['did:ethr', 'did:ethr:rinkeby', 'did:web', 'did:key', 'did:fake'])
+      expect(providers).toEqual(['did:ethr', 'did:ethr:rinkeby', 'did:ethr:421611', 'did:web', 'did:key', 'did:fake'])
     })
 
     let identifier: IIdentifier
@@ -31,6 +31,17 @@ export default (testContext: {
       expect(identifier.provider).toEqual('did:web')
       expect(identifier.alias).toEqual('example.com')
       expect(identifier.did).toEqual('did:web:example.com')
+      expect(identifier.keys.length).toEqual(1)
+      expect(identifier.services.length).toEqual(0)
+      expect(identifier.controllerKeyId).toEqual(identifier.keys[0].kid)
+    })
+
+    it('should create identifier using did:ethr:421611', async () => {
+      identifier = await agent.didManagerCreate({
+        provider: 'did:ethr:421611',
+      })
+      expect(identifier.provider).toEqual('did:ethr:421611')
+      expect(identifier.did).toMatch(/^did:ethr:421611:0x.*$/)
       expect(identifier.keys.length).toEqual(1)
       expect(identifier.services.length).toEqual(0)
       expect(identifier.controllerKeyId).toEqual(identifier.keys[0].kid)
@@ -109,7 +120,7 @@ export default (testContext: {
 
     it('should get identifiers', async () => {
       const allIdentifiers = await agent.didManagerFind()
-      expect(allIdentifiers.length).toEqual(4)
+      expect(allIdentifiers.length).toEqual(5)
 
       const aliceIdentifiers = await agent.didManagerFind({
         alias: 'alice',

--- a/__tests__/shared/keyManager.ts
+++ b/__tests__/shared/keyManager.ts
@@ -1,5 +1,4 @@
-import { IKey, TKeyType } from '@veramo/core'
-import { TAgent, IDIDManager, IKeyManager, IAgentOptions } from '../../packages/core/src'
+import { TAgent, IDIDManager, IKeyManager, IAgentOptions, IKey, TKeyType } from '../../packages/core/src'
 import { serialize, computeAddress } from '@ethersproject/transactions'
 
 type ConfiguredAgent = TAgent<IDIDManager & IKeyManager>

--- a/__tests__/shared/resolveDid.ts
+++ b/__tests__/shared/resolveDid.ts
@@ -1,5 +1,4 @@
-import { IDIDManager } from '@veramo/core'
-import { TAgent, IResolver, IAgentOptions } from '../../packages/core/src'
+import { TAgent, IResolver, IAgentOptions, IDIDManager } from '../../packages/core/src'
 
 type ConfiguredAgent = TAgent<IResolver & IDIDManager>
 

--- a/__tests__/shared/verifiableData.ts
+++ b/__tests__/shared/verifiableData.ts
@@ -1,8 +1,7 @@
-import { TAgent, IDIDManager, IIdentifier, IDataStore } from '../../packages/core/src'
+import { TAgent, IDIDManager, IIdentifier, IDataStore, TKeyType } from '../../packages/core/src'
 import { IDataStoreORM } from '../../packages/data-store/src'
 import { ICredentialIssuer } from '../../packages/credential-w3c/src'
 import { decodeJWT } from 'did-jwt'
-import { TKeyType } from '@veramo/core'
 
 type ConfiguredAgent = TAgent<IDIDManager & ICredentialIssuer & IDataStore & IDataStoreORM>
 

--- a/packages/did-provider-ethr/src/ethr-did-provider.ts
+++ b/packages/did-provider-ethr/src/ethr-did-provider.ts
@@ -25,7 +25,7 @@ export function toEthereumAddress(hexPublicKey: string): string {
  */
 export class EthrDIDProvider extends AbstractIdentifierProvider {
   private defaultKms: string
-  private network: string
+  private network: string | number
   private web3Provider?: Provider
   private rpcUrl?: string
   private gas?: number
@@ -34,7 +34,7 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
 
   constructor(options: {
     defaultKms: string
-    network: string
+    network: string | number
     rpcUrl?: string
     web3Provider?: Provider
     ttl?: number


### PR DESCRIPTION
This allows numbers to be used for the `network` parameter of `EthrDidProvider`.

```
'did:ethr:421611': new EthrDIDProvider({
  network: 421611,
  // ...
}),
```

This is a small workaround until EthrDidControler API can be improved to accept more flexible configuration.
fixes #677

I also rearranged some of the imports in the integration tests for easier development.