### PR TITLE
docs(did-comm): fix some inline documentation for DIDComm

### DIFF
--- a/packages/did-comm/src/types/IDIDComm.ts
+++ b/packages/did-comm/src/types/IDIDComm.ts
@@ -44,7 +44,7 @@ export interface IDIDComm extends IPluginMethodMap {
    *   {@link @veramo/core#IKeyManager} and {@link @veramo/core#IResolver} plugins in use.
    *   When calling this method, the `context` is supplied automatically by the framework.
    *
-   * @returns Promise\<\{message: string\}\> - a Promise that resolves to an object containing the serialized packed message
+   * @returns a Promise that resolves to an object containing the serialized packed `message` string
    *
    * @beta
    */
@@ -62,7 +62,7 @@ export interface IDIDComm extends IPluginMethodMap {
    *   {@link @veramo/core#IKeyManager} and {@link @veramo/core#IResolver} plugins in use.
    *   When calling this method, the `context` is supplied automatically by the framework.
    *
-   * @returns Promise<IUnpackedDIDCommMessage> - a Promise that resolves to an object containing
+   * @returns a Promise that resolves to an object containing
    *   the {@link IDIDCommMessage} and {@link DIDCommMessagePacking} used.
    *
    * @beta

--- a/packages/did-comm/src/types/message-types.ts
+++ b/packages/did-comm/src/types/message-types.ts
@@ -24,19 +24,32 @@ export interface IDIDCommMessage {
  * @beta
  */
 export enum DIDCommMessageMediaType {
+  /**
+   * A plain JSON DIDComm message
+   */
   PLAIN = 'application/didcomm-plain+json',
+  
+  /**
+   * A JWS signed DIDComm message
+   */
   SIGNED = 'application/didcomm-signed+json',
+
+  /**
+   * A JWE encrypted DIDComm message
+   */
   ENCRYPTED = 'application/didcomm-encrypted+json',
 }
 
 /**
  * The possible types of message packing.
  *
- * * `authcrypt`, `anoncrypt`, `anoncrypt+authcrypt`, and `anoncrypt+jws`
- * will produce {@link DIDCommMessageMediaType.ENCRYPTED} messages.
- * * `jws` will produce {@link DIDCommMessageMediaType.SIGNED} messages.
- * * `none` will produce {@link DIDCommMessageMediaType.PLAIN} messages.
- *
+ * <ul>
+ *  <li> `authcrypt`, `anoncrypt`, `anoncrypt+authcrypt`, and `anoncrypt+jws` will produce
+ * {@link DIDCommMessageMediaType.ENCRYPTED} messages.</li>
+ *  <li> `jws` will produce {@link DIDCommMessageMediaType.SIGNED} messages. </li>
+ *  <li> `none` will produce {@link DIDCommMessageMediaType.PLAIN} messages. </li>
+ * </ul>
+ * 
  * @beta
  */
 export type DIDCommMessagePacking =


### PR DESCRIPTION
The API docs website generator is broken because of this.