### PR TITLE
feat: credentialStatus support

### DIFF
--- a/packages/credential-ld/plugin.schema.json
+++ b/packages/credential-ld/plugin.schema.json
@@ -331,6 +331,10 @@
               "type": "boolean",
               "description": "Set this to true if you want the '@context' URLs to be fetched in case they are not pre-loaded.",
               "default": false
+            },
+            "checkStatus": {
+              "description": "Optional function for checking credential status if `credentialStatus` is present on the credential",
+              "default": "undefined"
             }
           },
           "required": [

--- a/packages/credential-ld/src/__tests__/check-status-flow.test.ts
+++ b/packages/credential-ld/src/__tests__/check-status-flow.test.ts
@@ -1,0 +1,94 @@
+import { TAgent, IResolver, IKeyManager, IDIDManager, createAgent, VerifiableCredential, IIdentifier } from '@veramo/core';
+import { DIDManager, MemoryDIDStore } from '@veramo/did-manager';
+import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '@veramo/key-manager';
+import { Resolver } from 'did-resolver';
+import { CredentialIssuerLD, LdDefaultContexts, VeramoEd25519Signature2018 } from '..';
+import { ICredentialIssuer, CredentialIssuer } from '../../../credential-w3c/src';
+import { KeyDIDProvider, getDidKeyResolver } from '../../../did-provider-key/src';
+import { DIDResolverPlugin } from '../../../did-resolver/src';
+import { KeyManagementSystem } from '../../../kms-local/src';
+
+describe('Credential status check flow', () => {
+  let agent: TAgent<IResolver & IKeyManager & IDIDManager & ICredentialIssuer>;
+  let didKeyIdentifier: IIdentifier;
+
+  beforeAll(async () => {
+    agent = createAgent({
+      plugins: [
+        new KeyManager({
+          store: new MemoryKeyStore(),
+          kms: {
+            local: new KeyManagementSystem(new MemoryPrivateKeyStore()),
+          },
+        }),
+        new DIDManager({
+          providers: {
+            'did:key': new KeyDIDProvider({ defaultKms: 'local' }),
+          },
+          store: new MemoryDIDStore(),
+          defaultProvider: 'did:key',
+        }),
+        new DIDResolverPlugin({
+          resolver: new Resolver({ ...getDidKeyResolver() }),
+        }),
+        new CredentialIssuer(),
+        new CredentialIssuerLD({
+          contextMaps: [LdDefaultContexts],
+          suites: [new VeramoEd25519Signature2018()],
+        }),
+      ],
+    })
+
+    didKeyIdentifier = await agent.didManagerCreate()
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should call `checkStatus` for a credential WITH `credentialStatus`', async () => {
+    const checkStatus = jest.fn(() => ({ verified: true }));
+
+    const credentialWithStatus = await agent.createVerifiableCredential({
+      credential: {
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        issuer: didKeyIdentifier.did,
+        credentialSubject: {},
+        credentialStatus: {
+          id: 'https://example.com/credentials/status/1',
+          type: 'RevocationList2021',
+        },
+      },
+      proofFormat: 'lds',
+    });
+
+    await agent.verifyCredentialLD({
+      credential: credentialWithStatus,
+      fetchRemoteContexts: false,
+      checkStatus,
+    });
+
+    expect(checkStatus).toBeCalledTimes(1);
+  });
+
+  it('should not call `checkStatus` for a credential WITHOUT `credentialStatus`', async () => {
+    const checkStatus = jest.fn(() => ({ verified: true }))
+
+    const credentialWithStatus = await agent.createVerifiableCredential({
+      credential: {
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        issuer: didKeyIdentifier.did,
+        credentialSubject: {},
+      },
+      proofFormat: 'lds',
+    })
+
+    await agent.verifyCredentialLD({
+      credential: credentialWithStatus,
+      fetchRemoteContexts: false,
+      checkStatus,
+    })
+
+    expect(checkStatus).toBeCalledTimes(0);
+  });
+});

--- a/packages/credential-ld/src/action-handler.ts
+++ b/packages/credential-ld/src/action-handler.ts
@@ -183,7 +183,15 @@ export class CredentialIssuerLD implements IAgentPlugin {
     context: IRequiredContext,
   ): Promise<boolean> {
     const credential = args.credential
-    return this.ldCredentialModule.verifyCredential(credential, args.fetchRemoteContexts || false,  context)
+    if (typeof args.checkStatus === 'function') {
+      return this.ldCredentialModule.verifyCredential(
+        credential,
+        args.fetchRemoteContexts || false,
+        args.checkStatus,
+        context,
+      )
+    }
+    return this.ldCredentialModule.verifyCredential(credential, args.fetchRemoteContexts || false, context)
   }
 
   /** {@inheritdoc ICredentialIssuerLD.verifyPresentationLD} */

--- a/packages/credential-ld/src/types.ts
+++ b/packages/credential-ld/src/types.ts
@@ -168,6 +168,19 @@ export interface IVerifyCredentialLDArgs {
    * @default false
    */
   fetchRemoteContexts?: boolean
+
+  /**
+   * Optional function for checking credential status if `credentialStatus` is
+   * present on the credential
+   * NOTE: `ts-json-schema-generator` does not support functions, so need to use `any` here
+   *
+   * @default undefined
+   */
+  checkStatus?: any
+}
+
+export interface CheckStatusResult {
+  verified: true
 }
 
 /**


### PR DESCRIPTION
In order to support credential status checks a `checkStatus` function must be passed to vc.js's method `verifyCredential`. A signature of `verifyCredentialLD` method was changed to support the alternative call with `checkStatus` member.