### PR TITLE
chore: Regenerate did-comm plugin schema

### DIFF
--- a/packages/did-comm/plugin.schema.json
+++ b/packages/did-comm/plugin.schema.json
@@ -172,7 +172,7 @@
           "required": [
             "data"
           ],
-          "deprecated": "Please use {@link IDIDComm.sendDIDCommMessage } instead. This will be removed in Veramo 4.0.\r\nInput arguments for {@link IDIDComm.sendMessageDIDCommAlpha1 }"
+          "deprecated": "Please use {@link IDIDComm.sendDIDCommMessage } instead. This will be removed in Veramo 4.0.\nInput arguments for {@link IDIDComm.sendMessageDIDCommAlpha1 }"
         },
         "IMessage": {
           "type": "object",


### PR DESCRIPTION
* Generating schema on Windows machine added extra escaped character. Regenerated on unix to remove.