### PR TITLE
Credential status plugin for Veramo

### DIFF
--- a/packages/credential-ld/src/ld-credential-module.ts
+++ b/packages/credential-ld/src/ld-credential-module.ts
@@ -145,18 +145,23 @@ export class LdCredentialModule {
     fetchRemoteContexts: boolean = false,
     context: IAgentContext<IResolver>,
   ): Promise<boolean> {
+    const checkStatusFn =
+      typeof context.agent.checkCredentialStatus === 'function'
+        ? async ({ credential }: any) => {
+            const result = await context.agent.checkCredentialStatus({
+              credential,
+            })
+            return { verified: !result.revoked }
+          }
+        : void 0
+
     const result = await vc.verifyCredential({
       credential,
       suite: this.ldSuiteLoader.getAllSignatureSuites().map((x) => x.getSuiteForVerification()),
       documentLoader: this.getDocumentLoader(context, fetchRemoteContexts),
       purpose: new AssertionProofPurpose(),
       compactProof: false,
-      checkStatus: async ({ credential }: any) => {
-        const result = await context.agent.checkCredentialStatus({
-          credential,
-        });
-        return { verified: !result.revoked };
-      },
+      checkStatus: checkStatusFn,
     })
 
     if (result.verified) return true

--- a/packages/credential-ld/src/ld-credential-module.ts
+++ b/packages/credential-ld/src/ld-credential-module.ts
@@ -151,6 +151,12 @@ export class LdCredentialModule {
       documentLoader: this.getDocumentLoader(context, fetchRemoteContexts),
       purpose: new AssertionProofPurpose(),
       compactProof: false,
+      checkStatus: async ({ credential }: any) => {
+        const result = await context.agent.checkCredentialStatus({
+          credential,
+        });
+        return { verified: !result.revoked };
+      },
     })
 
     if (result.verified) return true

--- a/packages/credential-status/LICENSE
+++ b/packages/credential-status/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Consensys AG
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/credential-status/README.md
+++ b/packages/credential-status/README.md
@@ -1,0 +1,3 @@
+# Credential Revocation Status plugin for Veramo
+
+Veramo package which enables support for [status of W3C Verifiable Credentials](https://www.w3.org/TR/vc-data-model/#status).

--- a/packages/credential-status/api-extractor.json
+++ b/packages/credential-status/api-extractor.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "apiReport": {
+    "enabled": true,
+    "reportFolder": "./tmp",
+    "reportTempFolder": "./tmp"
+  },
+  "docModel": {
+    "enabled": true,
+    "apiJsonFilePath": "./tmp/<unscopedPackageName>.api.json"
+  },
+  "dtsRollup": {
+    "enabled": false
+  },
+  "mainEntryPointFilePath": "<projectFolder>/build/index.d.ts"
+}

--- a/packages/credential-status/jest.config.js
+++ b/packages/credential-status/jest.config.js
@@ -1,6 +1,3 @@
-const { pathsToModuleNameMapper } = require('ts-jest')
-const { compilerOptions } = require('./tsconfig.json')
-
 module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   collectCoverage: true,
@@ -19,6 +16,5 @@ module.exports = {
     },
   },
   testEnvironment: 'node',
-  automock: false,
-  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<root_dir>' }),
+  automock: false
 }

--- a/packages/credential-status/jest.config.js
+++ b/packages/credential-status/jest.config.js
@@ -1,0 +1,24 @@
+const { pathsToModuleNameMapper } = require('ts-jest')
+const { compilerOptions } = require('./tsconfig.json')
+
+module.exports = {
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!**/types/**', '!**/build/**', '!**/node_modules/**'],
+  coverageReporters: ['text', 'lcov', 'json'],
+  coverageDirectory: './coverage',
+  transform: {
+    '\\.jsx?$': 'babel-jest',
+    '\\.tsx?$': 'ts-jest',
+  },
+  transformIgnorePatterns: ['node_modules/(?!credential-status/)'],
+  testMatch: ['**/__tests__/**/*.test.*'],
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig.json',
+    },
+  },
+  testEnvironment: 'node',
+  automock: false,
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<root_dir>' }),
+}

--- a/packages/credential-status/package.json
+++ b/packages/credential-status/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@veramo/credential-status",
+  "description": "Veramo plugin for resolving a credential status",
+  "version": "3.1.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "generate-plugin-schema": "yarn veramo dev generate-plugin-schema",
+    "start": "veramo server",
+    "build:watch": "tsc -b --watch",
+    "test:ci": "jest --config=jest.config.js",
+    "test": "jest --config=jest.config.js --coverage=false",
+    "test:watch": "yarn test --watch --verbose",
+    "clean": "rm -rf tmp && rm -rf database.sqlite && rm -rf build && rm tsconfig.tsbuildinfo"
+  },
+  "veramo": {
+    "pluginInterfaces": {
+      "ICheckCredentialStatus": "./src/types.ts"
+    }
+  },
+  "dependencies": {
+    "@veramo/core": "^3.1.0",
+    "credential-status": "^2.0.0",
+    "did-jwt": "^5.12.4",
+    "did-resolver": "^3.1.5"
+  },
+  "devDependencies": {
+    "@types/debug": "4.1.7",
+    "@types/jest": "27.4.1",
+    "@veramo/cli": "3.1.1",
+    "jest": "27.5.1",
+    "ts-jest": "27.1.3",
+    "typescript": "4.6.2"
+  },
+  "files": [
+    "build/**/*",
+    "src/**/*",
+    "plugin.schema.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "git@github.com:uport-project/veramo.git",
+  "author": "Konstantin Tsabolov <konstantin.tsabolov@spherity.com>",
+  "contributors": [],
+  "license": "Apache-2.0",
+  "keywords": []
+}

--- a/packages/credential-status/package.json
+++ b/packages/credential-status/package.json
@@ -12,7 +12,7 @@
     "test:ci": "jest --config=jest.config.js",
     "test": "jest --config=jest.config.js --coverage=false",
     "test:watch": "yarn test --watch --verbose",
-    "clean": "rm -rf tmp && rm -rf database.sqlite && rm -rf build && rm tsconfig.tsbuildinfo"
+    "clean": "rm -rf tmp && rm -rf build && rm tsconfig.tsbuildinfo"
   },
   "veramo": {
     "pluginInterfaces": {
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@veramo/core": "^3.1.0",
-    "credential-status": "^2.0.0",
+    "credential-status": "^2.0.2",
     "did-jwt": "^5.12.4",
     "did-resolver": "^3.1.5"
   },

--- a/packages/credential-status/plugin.schema.json
+++ b/packages/credential-status/plugin.schema.json
@@ -7,10 +7,14 @@
           "properties": {
             "credential": {
               "$ref": "#/components/schemas/CredentialJwtOrJSON"
+            },
+            "didDoc": {
+              "$ref": "#/components/schemas/DIDDocument"
             }
           },
           "required": [
-            "credential"
+            "credential",
+            "didDoc"
           ]
         },
         "CredentialJwtOrJSON": {
@@ -44,6 +48,240 @@
             "id"
           ],
           "description": "Represents a status method entry that could be embedded in a W3C Verifiable Credential. Normally, only credentials that list a status method would need to be verified by it.\n\nex: ```json credentialStatus: {   type: \"EthrStatusRegistry2019\",   id: \"rinkeby:0xregistryAddress\" } ``` See https://www.w3.org/TR/vc-data-model/#status"
+        },
+        "DIDDocument": {
+          "type": "object",
+          "properties": {
+            "authentication": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VerificationMethod"
+                  }
+                ]
+              }
+            },
+            "assertionMethod": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VerificationMethod"
+                  }
+                ]
+              }
+            },
+            "keyAgreement": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VerificationMethod"
+                  }
+                ]
+              }
+            },
+            "capabilityInvocation": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VerificationMethod"
+                  }
+                ]
+              }
+            },
+            "capabilityDelegation": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VerificationMethod"
+                  }
+                ]
+              }
+            },
+            "@context": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "https://www.w3.org/ns/did/v1"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "alsoKnownAs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "controller": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "verificationMethod": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/VerificationMethod"
+              }
+            },
+            "service": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ServiceEndpoint"
+              }
+            },
+            "publicKey": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/VerificationMethod"
+              },
+              "deprecated": true
+            }
+          },
+          "required": [
+            "id"
+          ]
+        },
+        "VerificationMethod": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "controller": {
+              "type": "string"
+            },
+            "publicKeyBase58": {
+              "type": "string"
+            },
+            "publicKeyBase64": {
+              "type": "string"
+            },
+            "publicKeyJwk": {
+              "type": "object",
+              "properties": {
+                "alg": {
+                  "type": "string"
+                },
+                "crv": {
+                  "type": "string"
+                },
+                "e": {
+                  "type": "string"
+                },
+                "ext": {
+                  "type": "boolean"
+                },
+                "key_ops": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "kid": {
+                  "type": "string"
+                },
+                "kty": {
+                  "type": "string"
+                },
+                "n": {
+                  "type": "string"
+                },
+                "use": {
+                  "type": "string"
+                },
+                "x": {
+                  "type": "string"
+                },
+                "y": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kty"
+              ]
+            },
+            "publicKeyHex": {
+              "type": "string"
+            },
+            "publicKeyMultibase": {
+              "type": "string"
+            },
+            "blockchainAccountId": {
+              "type": "string"
+            },
+            "ethereumAddress": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "type",
+            "controller"
+          ]
+        },
+        "ServiceEndpoint": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "serviceEndpoint": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "type",
+            "serviceEndpoint"
+          ]
         },
         "CredentialStatus": {
           "type": "object",

--- a/packages/credential-status/plugin.schema.json
+++ b/packages/credential-status/plugin.schema.json
@@ -1,0 +1,74 @@
+{
+  "ICheckCredentialStatus": {
+    "components": {
+      "schemas": {
+        "ICheckCredentialStatusArgs": {
+          "type": "object",
+          "properties": {
+            "credential": {
+              "$ref": "#/components/schemas/CredentialJwtOrJSON"
+            }
+          },
+          "required": [
+            "credential"
+          ]
+        },
+        "CredentialJwtOrJSON": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "credentialStatus": {
+                  "$ref": "#/components/schemas/StatusEntry"
+                }
+              }
+            }
+          ],
+          "description": "The Verifiable Credential or Presentation to be verified in either JSON/JSON-LD or JWT format."
+        },
+        "StatusEntry": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "id"
+          ],
+          "description": "Represents a status method entry that could be embedded in a W3C Verifiable Credential. Normally, only credentials that list a status method would need to be verified by it.\n\nex: ```json credentialStatus: {   type: \"EthrStatusRegistry2019\",   id: \"rinkeby:0xregistryAddress\" } ``` See https://www.w3.org/TR/vc-data-model/#status"
+        },
+        "CredentialStatus": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
+        }
+      },
+      "methods": {
+        "checkCredentialStatus": {
+          "description": "",
+          "arguments": {
+            "$ref": "#/components/schemas/ICheckCredentialStatusArgs"
+          },
+          "returnType": {
+            "$ref": "#/components/schemas/CredentialStatus"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/credential-status/src/__tests__/credential-status.test.ts
+++ b/packages/credential-status/src/__tests__/credential-status.test.ts
@@ -1,0 +1,73 @@
+import { createAgent } from '../../../core/src'
+import { CredentialStatusPlugin } from '../credential-status'
+import { DIDDocument } from 'did-resolver'
+
+describe('@veramo/credential-status', () => {
+  const referenceCredential = {
+    credentialStatus: {
+      type: 'ExoticStatusMethod2022',
+      id: 'some-exotic-id',
+    },
+  }
+  const referenceDoc = {} as DIDDocument
+
+  it('should check the credential status', async () => {
+    const expectedResult = {}
+    const checkStatus = jest.fn(async () => expectedResult)
+    const agent = createAgent({
+      plugins: [
+        new CredentialStatusPlugin({
+          ExoticStatusMethod2022: checkStatus,
+        }),
+      ],
+    })
+
+    const result = await agent.checkCredentialStatus({
+      credential: referenceCredential,
+      didDoc: referenceDoc,
+    })
+
+    expect(result).toStrictEqual(expectedResult)
+    expect(checkStatus).toBeCalledTimes(1)
+    expect(checkStatus).toBeCalledWith(referenceCredential, referenceDoc)
+  })
+
+  it('should not perform status check if no `credentialStatus` present', async () => {
+    const checkStatus = jest.fn()
+    const agent = createAgent({
+      plugins: [
+        new CredentialStatusPlugin({
+          ExoticStatusMethod2022: checkStatus,
+        }),
+      ],
+    })
+
+    const result = await agent.checkCredentialStatus({
+      credential: {},
+      didDoc: referenceDoc,
+    })
+
+    expect(result).toEqual({
+      message: 'credentialStatus property was not set on the original credential',
+      revoked: false,
+    })
+    expect(checkStatus).toBeCalledTimes(0)
+  })
+
+  it('should throw if unknown status check was provided', async () => {
+    const agent = createAgent({
+      plugins: [new CredentialStatusPlugin()],
+    })
+
+    await expect(() =>
+      agent.checkCredentialStatus({
+        credential: referenceCredential,
+        didDoc: referenceDoc,
+      }),
+    ).rejects.toThrow(
+      new Error(
+        `unknown_method: credentialStatus method ExoticStatusMethod2022 unknown. Validity can not be determined.`,
+      ),
+    )
+  })
+})

--- a/packages/credential-status/src/__tests__/credential-status.test.ts
+++ b/packages/credential-status/src/__tests__/credential-status.test.ts
@@ -12,6 +12,7 @@ describe('@veramo/credential-status', () => {
   const referenceDoc = {} as DIDDocument
 
   it('should check the credential status', async () => {
+    expect.assertions(3);
     const expectedResult = {}
     const checkStatus = jest.fn(async () => expectedResult)
     const agent = createAgent({
@@ -33,6 +34,7 @@ describe('@veramo/credential-status', () => {
   })
 
   it('should not perform status check if no `credentialStatus` present', async () => {
+    expect.assertions(2);
     const checkStatus = jest.fn()
     const agent = createAgent({
       plugins: [
@@ -55,6 +57,7 @@ describe('@veramo/credential-status', () => {
   })
 
   it('should throw if unknown status check was provided', async () => {
+    expect.assertions(1);
     const agent = createAgent({
       plugins: [new CredentialStatusPlugin()],
     })

--- a/packages/credential-status/src/credential-status.ts
+++ b/packages/credential-status/src/credential-status.ts
@@ -1,22 +1,19 @@
-import { IAgentContext, IAgentPlugin, IPluginMethodMap } from '@veramo/core';
-import { Status, StatusMethod } from 'credential-status';
-import { ICheckCredentialStatusArgs } from './types';
+import { IAgentContext, IAgentPlugin } from '@veramo/core'
+import { Status, StatusMethod } from 'credential-status'
+import { ICheckCredentialStatus, ICheckCredentialStatusArgs } from './types'
 
 export class CredentialStatusPlugin implements IAgentPlugin {
-  private readonly status: Status;
-  readonly methods: IPluginMethodMap;
+  private readonly status: Status
+  readonly methods: ICheckCredentialStatus
 
   constructor(registry: Record<string, StatusMethod> = {}) {
-    this.status = new Status(registry);
+    this.status = new Status(registry)
     this.methods = {
       checkCredentialStatus: this.checkCredentialStatus.bind(this),
-    };
+    }
   }
 
-  private async checkCredentialStatus(
-    args: ICheckCredentialStatusArgs,
-    context: IAgentContext<any>,
-  ) {
-    return this.status.checkStatus(args.credential, args.didDoc);
+  private async checkCredentialStatus(args: ICheckCredentialStatusArgs, context: IAgentContext<any>) {
+    return this.status.checkStatus(args.credential, args.didDoc)
   }
 }

--- a/packages/credential-status/src/credential-status.ts
+++ b/packages/credential-status/src/credential-status.ts
@@ -1,0 +1,22 @@
+import { IAgentContext, IAgentPlugin, IPluginMethodMap } from '@veramo/core';
+import { Status, StatusMethod } from 'credential-status';
+import { ICheckCredentialStatusArgs } from './types';
+
+export class CredentialStatusPlugin implements IAgentPlugin {
+  private readonly status: Status;
+  readonly methods: IPluginMethodMap;
+
+  constructor(registry: Record<string, StatusMethod> = {}) {
+    this.status = new Status(registry);
+    this.methods = {
+      checkCredentialStatus: this.checkCredentialStatus.bind(this),
+    };
+  }
+
+  private async checkCredentialStatus(
+    args: ICheckCredentialStatusArgs,
+    context: IAgentContext<any>,
+  ) {
+    return this.status.checkStatus(args.credential, args.didDoc);
+  }
+}

--- a/packages/credential-status/src/index.ts
+++ b/packages/credential-status/src/index.ts
@@ -1,3 +1,3 @@
 /* istanbul ignore file */
-export { CredentialStatusPlugin as CredentialStatusResolver } from './credential-status'
+export { CredentialStatusPlugin } from './credential-status'
 export * from './types'

--- a/packages/credential-status/src/index.ts
+++ b/packages/credential-status/src/index.ts
@@ -1,0 +1,3 @@
+/* istanbul ignore file */
+export { CredentialStatusPlugin as CredentialStatusResolver } from './credential-status'
+export * from './types'

--- a/packages/credential-status/src/types.ts
+++ b/packages/credential-status/src/types.ts
@@ -1,0 +1,22 @@
+import { IAgentContext, IPluginMethodMap } from '@veramo/core'
+import { CredentialJwtOrJSON, CredentialStatus } from 'credential-status'
+import { DIDDocument } from 'did-resolver'
+
+export interface ICheckCredentialStatusArgs {
+  credential: CredentialJwtOrJSON
+  didDoc: DIDDocument
+}
+
+export interface ICheckCredentialStatusResult {
+  revoked: boolean
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [x: string]: any
+}
+
+export interface ICheckCredentialStatus extends IPluginMethodMap {
+  checkCredentialStatus(
+    args: ICheckCredentialStatusArgs,
+    context: IAgentContext<any>,
+  ): Promise<CredentialStatus>
+}

--- a/packages/credential-status/tsconfig.json
+++ b/packages/credential-status/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.settings.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build",
+    "declarationDir": "build",
+    "skipLibCheck": true,
+    "paths": {
+      "credential-status": ["../../node_modules/credential-status/src/index.ts"],
+      "credential-status/*": ["../../node_modules/credential-status/src/*"]
+    }
+  },
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/credential-status/tsconfig.json
+++ b/packages/credential-status/tsconfig.json
@@ -4,11 +4,7 @@
     "rootDir": "src",
     "outDir": "build",
     "declarationDir": "build",
-    "skipLibCheck": true,
-    "paths": {
-      "credential-status": ["../../node_modules/credential-status/src/index.ts"],
-      "credential-status/*": ["../../node_modules/credential-status/src/*"]
-    }
+    "skipLibCheck": true
   },
   "references": [
     { "path": "../core" }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "core" },
     { "path": "credential-ld" },
+    { "path": "credential-status"},
     { "path": "credential-w3c" },
     { "path": "data-store" },
     { "path": "data-store-json" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,6 +2863,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@27.4.1":
+  version "27.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.1.tgz#185cbe2926eaaf9662d340cc02e548ce9e11ab6d"
+  integrity sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==
+  dependencies:
+    jest-matcher-utils "^27.0.0"
+    pretty-format "^27.0.0"
+
 "@types/jest@27.5.0":
   version "27.5.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.5.0.tgz#e04ed1824ca6b1dd0438997ba60f99a7405d4c7b"
@@ -4427,6 +4435,14 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+credential-status@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/credential-status/-/credential-status-2.0.0.tgz#daa59c4c98f4a5787bf7ae2b17779b046f55b99b"
+  integrity sha512-X/NDl6Yssh/4a6m9WxF1+er91agyXa7aiTejOODQwvWhzH0znF0J42LCl03ajHru/uK3Uccqew1LhARLClCL1Q==
+  dependencies:
+    did-jwt "^5.12.3"
+    did-resolver "^3.1.5"
+
 credentials-context@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/credentials-context/-/credentials-context-1.0.0.tgz#a63cb4b7e0a4ca4460d247b7c9370a58b10ebac9"
@@ -4727,6 +4743,24 @@ did-jwt@^5.12.3:
   version "5.12.3"
   resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-5.12.3.tgz#f4961b3d3e8f0b69c2bea08809df5e49ec3daa1d"
   integrity sha512-/aENag1/Mu4eCwMD62X/ZOV63hkXqpRxyriJP1z/8qL44ZpdwBvvL00so+YtDcTk/xHm3t0OEe6ATvvjNYPMCA==
+  dependencies:
+    "@stablelib/ed25519" "^1.0.2"
+    "@stablelib/random" "^1.0.1"
+    "@stablelib/sha256" "^1.0.1"
+    "@stablelib/x25519" "^1.0.1"
+    "@stablelib/xchacha20poly1305" "^1.0.1"
+    bech32 "^2.0.0"
+    canonicalize "^1.0.5"
+    did-resolver "^3.1.5"
+    elliptic "^6.5.4"
+    js-sha3 "^0.8.0"
+    multiformats "^9.4.10"
+    uint8arrays "^3.0.0"
+
+did-jwt@^5.12.4:
+  version "5.12.4"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-5.12.4.tgz#6357a550173b7155f2e5cf3b8ea3f8e8be180617"
+  integrity sha512-rFY7yIlE/79zB648Drn9vLiM+F4+3IzRkFvBcHelZqQmnPy037U9VWeeP/f2PlnQKgW5qbYXVJR5KftLfo58TA==
   dependencies:
     "@stablelib/ed25519" "^1.0.2"
     "@stablelib/random" "^1.0.1"
@@ -10974,6 +11008,20 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
+ts-jest@27.1.3:
+  version "27.1.3"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.3.tgz#1f723e7e74027c4da92c0ffbd73287e8af2b2957"
+  integrity sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==
+  dependencies:
+    bs-logger "0.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^27.0.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
 ts-jest@27.1.4:
   version "27.1.4"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.4.tgz#84d42cf0f4e7157a52e7c64b1492c46330943e00"
@@ -11150,6 +11198,11 @@ typeorm@0.2.45:
     xml2js "^0.4.23"
     yargs "^17.0.1"
     zen-observable-ts "^1.0.0"
+
+typescript@4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 typescript@4.6.4:
   version "4.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4435,10 +4435,10 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-credential-status@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/credential-status/-/credential-status-2.0.0.tgz#daa59c4c98f4a5787bf7ae2b17779b046f55b99b"
-  integrity sha512-X/NDl6Yssh/4a6m9WxF1+er91agyXa7aiTejOODQwvWhzH0znF0J42LCl03ajHru/uK3Uccqew1LhARLClCL1Q==
+credential-status@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/credential-status/-/credential-status-2.0.2.tgz#108d52c4ac466943e86d6f9e45c7cb7603ee7a52"
+  integrity sha512-Xm52ESIhGU1pxl/EfXbW2rh6R9u1KPyy+/N2dIVARVsVYjIZilu+uhscS0M+TruaOD4RXzGVYtipJif/t3qHsA==
   dependencies:
     did-jwt "^5.12.3"
     did-resolver "^3.1.5"


### PR DESCRIPTION
Hi folks. This is our another (first one was [here](https://github.com/uport-project/veramo/pull/814)) try of implementing support for the [`credentialStatus` field](https://www.w3.org/TR/vc-data-model/#status) of W3C credentials.
In fact, it's quite simple - just wrapping the [`credential-status`](https://github.com/uport-project/credential-status) library.

Any feedback is welcome and appreciated.