### PR TITLE
fix(credential-w3c): added domain and challenge args to createVerifiablePresentationJwt

### DIFF
--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -373,7 +373,7 @@ export class CredentialIssuer implements IAgentPlugin {
         const jwt = await createVerifiablePresentationJwt(
           presentation as any,
           { did: identifier.did, signer, alg },
-          { removeOriginalFields: args.removeOriginalFields },
+          { removeOriginalFields: args.removeOriginalFields, challenge: args.challenge, domain: args.domain },
         )
         //FIXME: flagging this as a potential privacy leak.
         debug(jwt)


### PR DESCRIPTION
Added missing domain and challenge args to the createVerifiablePresentationJwt function.  This fixes an issue where creating a VP using the domain and challenge arguments would return VP with JWT with `aud: []` and without nonce field.

