### PR TITLE
feat: Create DIDComm JWE with multiple recipients

### DIFF
--- a/__tests__/shared/didCommPacking.ts
+++ b/__tests__/shared/didCommPacking.ts
@@ -129,5 +129,74 @@ export default (testContext: {
       expect(unpackedMessage.message).toEqual(message)
       expect(unpackedMessage.metaData).toEqual({ packing: 'authcrypt' })
     })
+
+    it('should pack and unpack message with multiple bcc recipients', async () => {
+      expect.assertions(2)
+
+      const originator = await agent.didManagerCreate({
+        provider: 'did:key',
+      })
+      const beneficiary1 = await agent.didManagerCreate({
+        provider: 'did:key',
+      })
+      const beneficiary2 = await agent.didManagerCreate({
+        provider: 'did:key',
+      })
+
+      const message = {
+        type: 'test',
+        from: originator.did,
+        to: originator.did,
+        id: 'test',
+        body: { hello: 'world' },
+      }
+      const packedMessage = await agent.packDIDCommMessage({
+        packing: 'authcrypt',
+        message,
+        options: { bcc: [beneficiary1.did, beneficiary2.did] },
+      })
+
+      // delete originator's key from local KMS
+      await agent.didManagerDelete({ did: originator.did })
+
+      // bcc'd beneficiaries should be able to decrypt
+      const unpackedMessage = await agent.unpackDIDCommMessage(packedMessage)
+      expect(unpackedMessage.message).toEqual(message)
+      expect(unpackedMessage.metaData).toEqual({ packing: 'authcrypt' })
+    })
+
+    it('should pack and fail unpacking message with multiple bcc recipients', async () => {
+      const originator = await agent.didManagerCreate({
+        provider: 'did:key',
+      })
+      const beneficiary1 = await agent.didManagerCreate({
+        provider: 'did:key',
+      })
+      const beneficiary2 = await agent.didManagerCreate({
+        provider: 'did:key',
+      })
+
+      const message = {
+        type: 'test',
+        from: originator.did,
+        to: originator.did,
+        id: 'test',
+        body: { hello: 'world' },
+      }
+      const packedMessage = await agent.packDIDCommMessage({
+        packing: 'authcrypt',
+        message,
+        options: { bcc: [beneficiary1.did, beneficiary2.did] },
+      })
+
+      // delete all keys
+      await agent.didManagerDelete({ did: originator.did })
+      await agent.didManagerDelete({ did: beneficiary1.did })
+      await agent.didManagerDelete({ did: beneficiary2.did })
+
+      await expect(agent.unpackDIDCommMessage(packedMessage)).rejects.toThrowError(
+        'unable to decrypt DIDComm message with any of the locally managed keys',
+      )
+    })
   })
 }

--- a/packages/did-comm/plugin.schema.json
+++ b/packages/did-comm/plugin.schema.json
@@ -34,6 +34,9 @@
             },
             "keyRef": {
               "type": "string"
+            },
+            "options": {
+              "$ref": "#/components/schemas/IDIDCommOptions"
             }
           },
           "required": [
@@ -96,6 +99,17 @@
             "anoncrypt+jws"
           ],
           "description": "The possible types of message packing.\n\n`authcrypt`, `anoncrypt`, `anoncrypt+authcrypt`, and `anoncrypt+jws` will produce `DIDCommMessageMediaType.ENCRYPTED` messages.\n\n`jws` will produce `DIDCommMessageMediaType.SIGNED` messages.\n\n`none` will produce `DIDCommMessageMediaType.PLAIN` messages."
+        },
+        "IDIDCommOptions": {
+          "type": "object",
+          "properties": {
+            "bcc": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         },
         "ISendDIDCommMessageArgs": {
           "type": "object",

--- a/packages/did-comm/src/types/IDIDComm.ts
+++ b/packages/did-comm/src/types/IDIDComm.ts
@@ -13,7 +13,12 @@ import {
   ISendMessageDIDCommAlpha1Args,
   IUnpackDIDCommMessageArgs,
 } from '../didcomm'
-import { DIDCommMessageMediaType, IPackedDIDCommMessage, IUnpackedDIDCommMessage } from './message-types'
+import {
+  DIDCommMessageMediaType,
+  IDIDCommOptions,
+  IPackedDIDCommMessage,
+  IUnpackedDIDCommMessage,
+} from './message-types'
 
 /**
  * DID Comm plugin interface for {@link @veramo/core#Agent}
@@ -39,6 +44,7 @@ export interface IDIDComm extends IPluginMethodMap {
    *   * args.packing - {@link DIDCommMessagePacking} - the packing method
    *   * args.keyRef - Optional - string - either an `id` of a {@link did-resolver#VerificationMethod}
    *     `kid` of a {@link @veramo/core#IKey} that will be used when `packing` is `jws` or `authcrypt`.
+   *   * args.options - {@link IDIDCommOptions} - optional options
    *
    * @param context - This method requires an agent that also has {@link @veramo/core#IDIDManager},
    *   {@link @veramo/core#IKeyManager} and {@link @veramo/core#IResolver} plugins in use.

--- a/packages/did-comm/src/types/message-types.ts
+++ b/packages/did-comm/src/types/message-types.ts
@@ -17,6 +17,9 @@ export interface IDIDCommMessage {
   from_prior?: string
   body: any
 }
+export interface IDIDCommOptions {
+  bcc?: string[]
+}
 
 /**
  * Represents different DIDComm v2 message encapsulation


### PR DESCRIPTION
**Problem:** We want to create a JWE for multiple recipients (ie.: different DID docs), by means of including these as recipients as well. Currently the JWE's recipients are only coming from the beneficiary's DID doc (keyAgreements).

**Proposal:** Extending the DIDCommMessage with a `bcc` field (~blind carbon copy) which is an array of additional beneficiary DIDs. Our proposed code resolves these into DIDdocs, and adds their keyAgreements into the recipients as well.

We don't care about sending DIDComm messages to the `bcc` recipients right now, but anyone can extend this logic in the future if so desired.

---

**Testing:** Proper unit test(s) can be added if necessary. But here's a POC test script for our use case:

```ts
import { IIdentifier } from "../../veramo/packages/core/build";
import { agent } from "./veramo/setup";

async function main() {
  const identifiers = await agent.didManagerFind();
  jwe(...identifiers);
}
async function jwe(
  originator?: IIdentifier,
  beneficiary1?: IIdentifier,
  beneficiary2?: IIdentifier
) {
  originator ||= await agent.didManagerCreate({
    kms: "local",
    provider: "did:key",
  });
  beneficiary1 ||= await agent.didManagerCreate({
    kms: "local",
    provider: "did:key",
  });
  beneficiary2 ||= await agent.didManagerCreate({
    kms: "local",
    provider: "did:key",
  });
  // these beneficiaries currently "live" in the same local database, but they can live anywhere apart.

  const message = {
    type: "test",
    from: originator.did,
    to: originator.did,
    bcc: [beneficiary1.did, beneficiary2.did],
    id: "test",
    body: { hello: "world" },
  };

  // create JWE
  const emsg = await agent.packDIDCommMessage({
    packing: "authcrypt",
    message,
  });
  console.dir(emsg, { depth: 10 });

  // decrypt JWE
  const msg = await agent.unpackDIDCommMessage({ message: emsg.message });
  console.dir(msg, { depth: 10 });
  // decryption is possible as long as we know the full `did:key` one of any of the recipients.
}

main().catch((e) => console.error(e));
```