### PR TITLE
fix(remote-server): fix error when resolving local did:web

### DIFF
--- a/packages/remote-server/src/web-did-doc-router.ts
+++ b/packages/remote-server/src/web-did-doc-router.ts
@@ -52,7 +52,7 @@ export const WebDidDocRouter = (options: WebDidDocRouterOptions): Router => {
       authentication: signingKeyIds,
       assertionMethod: signingKeyIds,
       keyAgreement: keyAgreementKeyIds,
-      service: typeof options.services === 'undefined' ? identifier.services : [...options.services, ...identifier.services],
+      service: [...(options?.services || []), ...(identifier?.services || [])],
     }
 
     return didDoc


### PR DESCRIPTION
This resolves an error caused by trying to dereference an undefined object (`options`) during resolution of locally managed `did:web`