### PR TITLE
chore(docs): use Array<T> instead of T[] to satisfy auto-docs tooling

### DIFF
--- a/packages/core/src/types/IIdentifier.ts
+++ b/packages/core/src/types/IIdentifier.ts
@@ -40,8 +40,8 @@ export interface IIdentifier {
  * Represents the minimum amount of information needed to import an {@link IIdentifier}
  */
 export type MinimalImportableIdentifier = {
-  keys: MinimalImportableKey[]
-  services?: IService[]
+  keys: Array<MinimalImportableKey>
+  services?: Array<IService>
 } & Omit<IIdentifier, 'keys' | 'services'>
 
 /**


### PR DESCRIPTION
This hotfix is meant to ease the automatic documentation generation flow, where one of the tools fails to interpret the original syntax.

There is no functional or semantic difference.