### PR TITLE
fix(cli): update default CLI config to account for renamed class

### DIFF
--- a/packages/cli/default/default.yml
+++ b/packages/cli/default/default.yml
@@ -275,7 +275,7 @@ didDiscovery:
   $args:
     - providers:
         - $require: '@veramo/did-manager#AliasDiscoveryProvider'
-        - $require: '@veramo/data-store#ProfileDiscoveryProvider'
+        - $require: '@veramo/data-store#DataStoreDiscoveryProvider'
 
 # W3C credentialPlugin
 credentialIssuerLD:


### PR DESCRIPTION
BREAKING CHANGE: `ProfileDiscoveryProvider` has been renamed to `DataStoreDiscoveryProvider` in #597. Please update your config accordingly