### PR TITLE
Fix: return back to main handler

### DIFF
--- a/packages/did-comm/src/message-handler.ts
+++ b/packages/did-comm/src/message-handler.ts
@@ -121,7 +121,7 @@ export class DIDCommMessageHandler extends AbstractMessageHandler {
           message.addMetaData({ type: 'didCommMetaData', value: JSON.stringify(unpackedMessage.metaData) })
           context.agent.emit('DIDCommV2Message-received', unpackedMessage)
 
-          return message
+          return super.handle(message, context)
         } catch (e) {
           debug(`Could not unpack message as DIDComm v2: ${e}`)
         }


### PR DESCRIPTION
If a DIDComm v2 message is found and parsed, allow any additional processing to continue in subsequent message handlers.