### PR TITLE
fix(deps): Bump `did-jwt`, `did-jwt-vc` as direct package deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ temp
 
 agent.yml
 data
+.vscode-upload.json

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "debug": "^4.3.3",
-    "did-jwt-vc": "^2.1.12",
+    "did-jwt-vc": "^2.1.13",
     "events": "^3.2.0",
     "z-schema": "^5.0.2"
   },

--- a/packages/credential-status/package.json
+++ b/packages/credential-status/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@veramo/core": "^3.1.0",
     "credential-status": "^2.0.3",
-    "did-jwt": "^6.1.2",
+    "did-jwt": "^6.2.0",
     "did-resolver": "^3.2.2"
   },
   "devDependencies": {

--- a/packages/credential-w3c/package.json
+++ b/packages/credential-w3c/package.json
@@ -20,7 +20,7 @@
     "@veramo/message-handler": "^3.1.4",
     "@veramo/utils": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt-vc": "^2.1.12",
+    "did-jwt-vc": "^2.1.13",
     "did-resolver": "^3.2.2",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.0"

--- a/packages/did-comm/package.json
+++ b/packages/did-comm/package.json
@@ -21,7 +21,7 @@
     "@veramo/utils": "^3.1.4",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.1.2",
+    "did-jwt": "^6.2.0",
     "did-resolver": "^3.2.2",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.0"

--- a/packages/did-jwt/package.json
+++ b/packages/did-jwt/package.json
@@ -12,7 +12,7 @@
     "@veramo/core": "^3.1.4",
     "@veramo/message-handler": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.1.2",
+    "did-jwt": "^6.2.0",
     "did-resolver": "^3.2.2"
   },
   "devDependencies": {

--- a/packages/key-manager/package.json
+++ b/packages/key-manager/package.json
@@ -14,7 +14,7 @@
     "@ethersproject/transactions": "^5.6.2",
     "@stablelib/ed25519": "^1.0.2",
     "@veramo/core": "^3.1.4",
-    "did-jwt": "^6.1.2",
+    "did-jwt": "^6.2.0",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.2"
   },

--- a/packages/kms-local/package.json
+++ b/packages/kms-local/package.json
@@ -22,7 +22,7 @@
     "@veramo/key-manager": "^3.1.4",
     "base-58": "^0.0.1",
     "debug": "^4.3.3",
-    "did-jwt": "^6.1.2",
+    "did-jwt": "^6.2.0",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/selective-disclosure/package.json
+++ b/packages/selective-disclosure/package.json
@@ -19,7 +19,7 @@
     "@veramo/did-jwt": "^3.1.4",
     "@veramo/message-handler": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.1.2",
+    "did-jwt": "^6.2.0",
     "uuid": "^8.3.0"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,8 +15,8 @@
     "blakejs": "^1.1.1",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.1.2",
-    "did-jwt-vc": "^2.1.12",
+    "did-jwt": "^6.2.0",
+    "did-jwt-vc": "^2.1.13",
     "did-resolver": "^3.2.2",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7984,18 +7984,36 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-did-jwt-vc@^2.1.12:
-  version "2.1.12"
-  resolved "https://registry.yarnpkg.com/did-jwt-vc/-/did-jwt-vc-2.1.12.tgz#2a3117114ea711c610fa6826009f23f8f3820b9a"
-  integrity sha512-FupgEyv4KxNVmHME/3T1q3QILiSVBMdAuI1vMRc0+7mt2W9Qx/b5qPXdjJSxx5I90J3jNkHoYS4uYJdv8VA/zg==
+did-jwt-vc@^2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/did-jwt-vc/-/did-jwt-vc-2.1.13.tgz#b14e0a0b3a9c005d7620535939362ed777ee5c95"
+  integrity sha512-BHbGDlFVvi9NTwxPXiIGvRMxdCBIV2VW6qzA4VxpYg2cnehI2bhEJWAwz+g355fDJgj0Grj157S6gzJjTcGqAw==
   dependencies:
-    did-jwt "^6.1.2"
+    did-jwt "^6.2.0"
     did-resolver "^3.2.2"
 
 did-jwt@^6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.1.2.tgz#adef6c3264ae4bcecac5d2cab5de8f3a3024ca03"
   integrity sha512-OkXsk5zUi2uwSWh2WiaGCLEPKon9HDfMT3mmUp0r7jFgyNWiEFTP9oCLYJq/SaVkKRZsImehrnd0+Ku9ivUvsw==
+  dependencies:
+    "@stablelib/ed25519" "^1.0.2"
+    "@stablelib/random" "^1.0.1"
+    "@stablelib/sha256" "^1.0.1"
+    "@stablelib/x25519" "^1.0.2"
+    "@stablelib/xchacha20poly1305" "^1.0.1"
+    bech32 "^2.0.0"
+    canonicalize "^1.0.8"
+    did-resolver "^3.2.2"
+    elliptic "^6.5.4"
+    js-sha3 "^0.8.0"
+    multiformats "^9.6.5"
+    uint8arrays "^3.0.0"
+
+did-jwt@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.2.0.tgz#5c4009871ad1ad85ec80c14c501a52991a16e7a1"
+  integrity sha512-BokZHvwStx4K5s3a/0TXs649b1Tjl5S9X4X80gQjdkQFlg33Z0qh/DTfctDI8dWyapMR69yUPtMlLdDxwWQEQQ==
   dependencies:
     "@stablelib/ed25519" "^1.0.2"
     "@stablelib/random" "^1.0.1"


### PR DESCRIPTION
Following respective released PRs ( [`did-jwt`](https://github.com/decentralized-identity/did-jwt/pull/235) & [`did-jwt-vc`](https://github.com/decentralized-identity/did-jwt-vc/pull/115)) .

Targets only direct Veramo packages.