### PR TITLE
chore(ci): add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,26 @@
+---
+name: Bug fix
+about: Create a PR to improve this project
+title: ''
+labels: triage
+assignees: ''
+
+---
+
+**What issue is this PR fixing**
+Example:
+`closes #123`
+`fixes #456`
+
+**What is being changed**
+A clear description of what this PR brings.
+
+**Quality**
+* [ ] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally
+* [ ] I allow my PR to be updated
+* [ ] I added unit tests
+* [ ] I added integration tests
+* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.
+
+**Details**
+If applicable, add screen captures, error messages or stack traces to help explain your problem.

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,6 +1,6 @@
 ---
 name: Bug fix
-about: Create a PR to improve this project
+about: Create a PR to fix an issue
 title: ''
 labels: triage
 assignees: ''
@@ -12,14 +12,20 @@ Example:
 `closes #123`
 `fixes #456`
 
+Linking to an issue provides some context and a reason for the PR to be reviewed, as well as simplifying the release
+notes and changelogs that get generated automatically. If an issue is linked like this it will be automatically closed
+when the PR is merged.
+
 **What is being changed**
 A clear description of what this PR brings.
 
 **Quality**
-* [ ] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally
-* [ ] I allow my PR to be updated
-* [ ] I added unit tests
-* [ ] I added integration tests
+Check all that apply:
+
+* [ ] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
+* [ ] I allow my PR to be updated by the reviewers (to speed up the review process).
+* [ ] I added unit tests.
+* [ ] I added integration tests.
 * [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.
 
 **Details**


### PR DESCRIPTION
This adds a Github PR template.

Hopefully, if all these steps are taken before a PR is opened, we will have an easier time reviewing and accepting contributions.

Does the template make sense?