### PR TITLE
fix: deprecate the `save` parameter

### DIFF
--- a/packages/core/plugin.schema.json
+++ b/packages/core/plugin.schema.json
@@ -3163,7 +3163,8 @@
             },
             "save": {
               "type": "boolean",
-              "description": "Optional. If set to `true`, the message will be saved using  {@link  IDataStore.dataStoreSaveMessage | dataStoreSaveMessage }"
+              "description": "Optional. If set to `true`, the message will be saved using\n {@link  IDataStore.dataStoreSaveMessage | dataStoreSaveMessage } \n<p/><p/>",
+              "deprecated": "Please call {@link IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} after handling the\nmessage and determining that it must be saved."
             }
           },
           "required": [
@@ -3475,7 +3476,7 @@
       },
       "methods": {
         "handleMessage": {
-          "description": "Parses and optionally saves a message",
+          "description": "Parses a raw message.",
           "arguments": {
             "$ref": "#/components/schemas/IHandleMessageArgs"
           },

--- a/packages/core/src/types/IMessageHandler.ts
+++ b/packages/core/src/types/IMessageHandler.ts
@@ -1,4 +1,4 @@
-import { IPluginMethodMap, IAgentContext } from './IAgent'
+import { IAgentContext, IPluginMethodMap } from './IAgent'
 import { IMessage, IMetaData } from './IMessage'
 import { IDataStore } from './IDataStore'
 
@@ -18,18 +18,27 @@ export interface IHandleMessageArgs {
   metaData?: IMetaData[]
 
   /**
-   * Optional. If set to `true`, the message will be saved using {@link IDataStore.dataStoreSaveMessage | dataStoreSaveMessage}
+   * Optional. If set to `true`, the message will be saved using
+   * {@link IDataStore.dataStoreSaveMessage | dataStoreSaveMessage}
+   * <p/><p/>
+   * @deprecated Please call {@link IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} after handling the
+   *   message and determining that it must be saved.
    */
   save?: boolean
 }
 
 /**
- * Message handler interface
+ * Message handler plugin interface.
  * @public
  */
 export interface IMessageHandler extends IPluginMethodMap {
   /**
-   * Parses and optionally saves a message
+   * Parses a raw message.
+   *
+   * After the message is parsed, you can decide if it should be saved, and pass the result to
+   * {@link IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} to save it.
+   *
+   * @param args - The `raw` message to be handled along with optional `metadata` about the origin.
    * @param context - Execution context. Requires agent with {@link @veramo/core#IDataStore} methods
    */
   handleMessage(args: IHandleMessageArgs, context: IAgentContext<IDataStore>): Promise<IMessage>

--- a/packages/credential-w3c/plugin.schema.json
+++ b/packages/credential-w3c/plugin.schema.json
@@ -11,7 +11,8 @@
             },
             "save": {
               "type": "boolean",
-              "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core#IDataStore | storage plugin }  to be saved"
+              "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core#IDataStore | storage plugin }  to be saved.",
+              "deprecated": "Please call {@link IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()}to save the credential after creating it."
             },
             "proofFormat": {
               "$ref": "#/components/schemas/ProofFormat",
@@ -206,7 +207,8 @@
             },
             "save": {
               "type": "boolean",
-              "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core#IDataStore | storage plugin }  to be saved"
+              "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core#IDataStore | storage plugin }  to be saved. <p/><p/>",
+              "deprecated": "Please call\n{@link IDataStore.dataStoreSaveVerifiablePresentation | dataStoreSaveVerifiablePresentation()} to save the\ncredential after creating it."
             },
             "challenge": {
               "type": "string",


### PR DESCRIPTION
## What issue is this PR fixing

closes #966

## What is being changed

The message handler and the credential issuer plugin methods contain a `save` parameter that is used to automatically save messages, credentials and presentations to the `IDataStore` implementation.
BUT, this means that there is very tight coupling between those plugins and the data storage layer, which is very problematic for light-weight agents that don't need storage.
Marking this parameter as `@deprecated` and providing instructions on how to avoid it will allow us to remove it in the v5 release or later with plenty of time for users to adapt.

The rest of the changes are related to code formatting and adjustments of the inline docs.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because no functionality changes.