### PR TITLE
feat(did-resolver): simplify DIDResolverPlugin constructor

### DIFF
--- a/__tests__/localAgent.test.ts
+++ b/__tests__/localAgent.test.ts
@@ -60,7 +60,6 @@ import { BrokenDiscoveryProvider, FakeDidProvider, FakeDidResolver } from '../pa
 import { DataSource } from 'typeorm'
 import { createGanacheProvider } from './utils/ganache-provider'
 import { createEthersProvider } from './utils/ethers-provider'
-import { Resolver } from 'did-resolver'
 import { getResolver as ethrDidResolver } from 'ethr-did-resolver'
 import { getResolver as webDidResolver } from 'web-did-resolver'
 import { contexts as credential_contexts } from '@transmute/credentials-context'
@@ -194,22 +193,20 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
         },
       }),
       new DIDResolverPlugin({
-        resolver: new Resolver({
-          ...ethrDidResolver({
-            infuraProjectId,
-            networks: [
-              {
-                name: 'ganache',
-                chainId: 1337,
-                provider,
-                registry,
-              },
-            ],
-          }),
-          ...webDidResolver(),
-          ...getDidKeyResolver(),
-          ...new FakeDidResolver(() => agent).getDidFakeResolver(),
+        ...ethrDidResolver({
+          infuraProjectId,
+          networks: [
+            {
+              name: 'ganache',
+              chainId: 1337,
+              provider,
+              registry,
+            },
+          ],
         }),
+        ...webDidResolver(),
+        ...getDidKeyResolver(),
+        ...new FakeDidResolver(() => agent).getDidFakeResolver(),
       }),
       new DataStore(dbConnection),
       new DataStoreORM(dbConnection),

--- a/packages/did-resolver/package.json
+++ b/packages/did-resolver/package.json
@@ -10,12 +10,13 @@
   },
   "dependencies": {
     "@veramo/core": "^3.1.4",
+    "@veramo/utils": "^3.1.4",
     "cross-fetch": "^3.1.4",
-    "debug": "^4.3.3"
+    "debug": "^4.3.3",
+    "did-resolver": "^3.2.2"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",
-    "did-resolver": "3.2.2",
     "ethr-did-resolver": "6.0.2",
     "typescript": "4.7.3",
     "web-did-resolver": "2.0.19"
@@ -32,10 +33,7 @@
   "repository": "git@github.com:uport-project/veramo.git",
   "author": "Simonas Karuzas <simonas.karuzas@mesh.xyz>",
   "contributors": [
-    {
-      "name": "Mircea Nistor",
-      "email": "mircea.nistor@mesh.xyz"
-    }
+    "Mircea Nistor <mircea.nistor@mesh.xyz"
   ],
   "license": "Apache-2.0",
   "keywords": []

--- a/packages/did-resolver/src/__tests__/integration.test.ts
+++ b/packages/did-resolver/src/__tests__/integration.test.ts
@@ -8,24 +8,27 @@ jest.setTimeout(60000)
 
 const providerConfig = {
   networks: [
-    { name: 'rinkeby', rpcUrl: 'https://rinkeby.infura.io/v3/6b734e0b04454df8a6ce234023c04f26' },
+    { name: 'rinkeby', rpcUrl: 'https://rinkeby.infura.io/v3/3586660d179141e3801c3895de1c2eba' },
+    { name: 'goerli', rpcUrl: 'https://goerli.infura.io/v3/3586660d179141e3801c3895de1c2eba' },
     { name: 'development', rpcUrl: 'http://localhost:7545' },
     // FIXME: add this example
     // { name: 'test', provider: TBD_add_example_of_custom_provider_usage },
   ],
 }
 
-/** This creates a resolver that supports the [ethr, web, key, elem] DID methods */
-let resolver = new Resolver({
+let resolverMap = {
   // resolve did:ethr using the embedded ethr-did-resolver
   ...getEthrResolver(providerConfig),
   // resolve did:web using the embedded web-did-resolver
   ...getWebDidResolver(),
   // resolve some other DID methods using the centralized `uniresolver.io` service
   ...getUniversalResolverFor(['key', 'elem']),
-})
+}
 
+/** This creates a resolver that supports the [ethr, web, key, elem] DID methods */
+let resolver = new Resolver(resolverMap)
 let resolverPlugin: DIDResolverPlugin = new DIDResolverPlugin({ resolver })
+let resolverPluginDirect: DIDResolverPlugin = new DIDResolverPlugin(resolverMap)
 
 describe('@veramo/did-resolver', () => {
   beforeAll(() => {})
@@ -89,45 +92,19 @@ describe('@veramo/did-resolver', () => {
     })
   })
 
-  //// Uniresolver is too unstable
-  // it('should resolve did:key using uniresolver', async () => {
-  //   expect.assertions(1)
-  //   const { didDocument } = await resolverPlugin.resolveDid({
-  //     didUrl: 'did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6',
-  //   })
-  //   expect(didDocument).toEqual({
-  //     '@context': ['https://w3id.org/did/v0.11'],
-  //     id: 'did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6',
-  //     publicKey: [
-  //       {
-  //         id: 'did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6',
-  //         type: 'Ed25519VerificationKey2018',
-  //         controller: 'did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6',
-  //         publicKeyBase58: '2QTnR7atrFu3Y7S6Xmmr4hTsMaL1KDh6Mpe9MgnJugbi',
-  //       },
-  //     ],
-  //     authentication: [
-  //       'did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6',
-  //     ],
-  //     assertionMethod: [
-  //       'did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6',
-  //     ],
-  //     capabilityDelegation: [
-  //       'did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6',
-  //     ],
-  //     capabilityInvocation: [
-  //       'did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6',
-  //     ],
-  //     keyAgreement: [
-  //       {
-  //         id: 'did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6LSbgq3GejX88eiAYWmZ9EiddS3GaXodvm8MJJyEH7bqXgz',
-  //         type: 'X25519KeyAgreementKey2019',
-  //         controller: 'did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6',
-  //         publicKeyBase58: '1eskLvf2fvy5A912VimK3DZRRzgwKayUKbHjpU589vE',
-  //       },
-  //     ],
-  //   })
-  // })
+  it('should resolve web DID using direct constructor', async () => {
+    expect.assertions(1)
+    const result = await resolverPluginDirect.resolveDid({ didUrl: 'did:web:did.actor:alice' })
+    expect(result?.didDocument?.id).toEqual('did:web:did.actor:alice')
+  })
+
+  it('should resolve ethr-did with RPC URL using direct constructor', async () => {
+    expect.assertions(1)
+    const result = await resolverPluginDirect.resolveDid({
+      didUrl: 'did:ethr:goerli:0xE6Fe788d8ca214A080b0f6aC7F48480b2AEfa9a6',
+    })
+    expect(result?.didDocument?.id).toEqual('did:ethr:goerli:0xE6Fe788d8ca214A080b0f6aC7F48480b2AEfa9a6')
+  })
 
   it('should fail predictably when unsupported method is resolved', async () => {
     expect.assertions(1)

--- a/packages/did-resolver/tsconfig.json
+++ b/packages/did-resolver/tsconfig.json
@@ -5,5 +5,12 @@
     "outDir": "build",
     "declarationDir": "build"
   },
-  "references": [{ "path": "../core" }]
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../utils"
+    }
+  ]
 }


### PR DESCRIPTION
## What issue is this PR fixing

fixes #976

## What is being changed
The `DIDResolverPlugin` now accepts a map of `DIDResolver` implementations as well, to simplify user required dependencies, config, and constructor.

If a `resolver` argument is provided, it will get used instead of the mapping to ensure backward compatibility and allow users to make extra configuration.

### old version:
```ts
import { Resolver } from 'did-resolver'

new DIDResolverPlugin({
  resolver: new Resolver({
    ...ethrResolver(),
    ...keyResolver(),
    ...ionResolver()
  })
})
```

### new version:
```ts
new DIDResolverPlugin({
  ...ethrResolver(),
  ...keyResolver(),
  ...ionResolver()
})
```

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [X] I added unit tests.
* [X] I added integration tests. (updated `localAgent.test.ts` to use the new config)
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.
