### PR TITLE
feat(credential-w3c): align verification API between formats

### DIFF
--- a/__tests__/shared/credentialStatus.ts
+++ b/__tests__/shared/credentialStatus.ts
@@ -235,7 +235,7 @@ export default (testContext: {
 
       // TODO It`s an exception flow an it'd be better to throw an exception instead of returning false
       await expect(agent.verifyCredential({ credential: vc })).rejects.toThrow(
-        `invalid_config: The credential status can't be verified because there is no ICredentialStatusVerifier plugin installed.`,
+        `invalid_setup: The credential status can't be verified because there is no ICredentialStatusVerifier plugin installed.`,
       )
     })
   })

--- a/__tests__/shared/credentialStatus.ts
+++ b/__tests__/shared/credentialStatus.ts
@@ -102,9 +102,9 @@ export default (testContext: {
       })
       expect(vc).toHaveProperty('proof.jwt')
 
-      const verified = await agent.verifyCredential({ credential: vc })
+      const result = await agent.verifyCredential({ credential: vc })
       expect(callsCounter).toHaveBeenCalledTimes(1)
-      expect(verified).toBeTruthy()
+      expect(result.verified).toEqual(true)
     })
 
     it('should check credentialStatus for revoked JWT credential', async () => {
@@ -114,9 +114,9 @@ export default (testContext: {
       })
       expect(vc).toHaveProperty('proof.jwt')
 
-      const verified = await agent.verifyCredential({ credential: vc })
+      const result = await agent.verifyCredential({ credential: vc })
       expect(callsCounter).toHaveBeenCalledTimes(1)
-      expect(verified).toBeFalsy()
+      expect(result.verified).toEqual(false)
     })
 
     it('should fail checking credentialStatus with exception during verification', async () => {
@@ -152,9 +152,9 @@ export default (testContext: {
       })
       expect(vc).toHaveProperty('proof.jws')
 
-      const verified = await agent.verifyCredential({ credential: vc })
+      const result = await agent.verifyCredential({ credential: vc })
       expect(callsCounter).toHaveBeenCalledTimes(1)
-      expect(verified).toBeTruthy()
+      expect(result.verified).toEqual(true)
     })
 
     it('should check credentialStatus for revoked JSON-LD credential', async () => {
@@ -164,9 +164,9 @@ export default (testContext: {
       })
       expect(vc).toHaveProperty('proof.jws')
 
-      const verified = await agent.verifyCredential({ credential: vc })
+      const result = await agent.verifyCredential({ credential: vc })
       expect(callsCounter).toHaveBeenCalledTimes(1)
-      expect(verified).toBeFalsy()
+      expect(result.verified).toEqual(false)
     })
 
     it('should check credentialStatus for EIP712 credential', async () => {
@@ -176,9 +176,9 @@ export default (testContext: {
       })
       expect(vc).toHaveProperty('proof.proofValue')
 
-      const verified = await agent.verifyCredential({ credential: vc })
+      const result = await agent.verifyCredential({ credential: vc })
       expect(callsCounter).toHaveBeenCalledTimes(1)
-      expect(verified).toBeTruthy()
+      expect(result.verified).toEqual(true)
     })
 
     it('should check credentialStatus for revoked EIP712 credential', async () => {
@@ -188,9 +188,9 @@ export default (testContext: {
       })
       expect(vc).toHaveProperty('proof.proofValue')
 
-      const verified = await agent.verifyCredential({ credential: vc })
+      const result = await agent.verifyCredential({ credential: vc })
       expect(callsCounter).toHaveBeenCalledTimes(1)
-      expect(verified).toBeFalsy()
+      expect(result.verified).toEqual(false)
     })
   })
 
@@ -235,7 +235,7 @@ export default (testContext: {
 
       // TODO It`s an exception flow an it'd be better to throw an exception instead of returning false
       await expect(agent.verifyCredential({ credential: vc })).rejects.toThrow(
-        `The credential status can't be verified by the agent`,
+        `invalid_config: The credential status can't be verified because there is no ICredentialStatusVerifier plugin installed.`,
       )
     })
   })

--- a/__tests__/shared/verifiableDataJWT.ts
+++ b/__tests__/shared/verifiableDataJWT.ts
@@ -25,13 +25,9 @@ export default (testContext: {
     beforeAll(async () => {
       await testContext.setup()
       agent = testContext.getAgent()
+      identifier = await agent.didManagerCreate({ kms: 'local', provider: 'did:key' })
     })
     afterAll(testContext.tearDown)
-
-    it('should create identifier', async () => {
-      identifier = await agent.didManagerCreate({ kms: 'local' })
-      expect(identifier).toHaveProperty('did')
-    })
 
     it('should create verifiable credential in JWT', async () => {
       const verifiableCredential = await agent.createVerifiableCredential({

--- a/__tests__/shared/verifiableDataJWT.ts
+++ b/__tests__/shared/verifiableDataJWT.ts
@@ -7,9 +7,12 @@ import {
   IIdentifier,
   TAgent,
   TKeyType,
+  VerifiableCredential,
+  VerifiablePresentation,
 } from '../../packages/core/src'
 import { ICredentialIssuer } from '../../packages/credential-w3c/src'
 import { decodeJWT } from 'did-jwt'
+import { VC_JWT_ERROR } from 'did-jwt-vc'
 
 type ConfiguredAgent = TAgent<IDIDManager & ICredentialIssuer & IDataStore & IDataStoreORM>
 
@@ -270,7 +273,7 @@ export default (testContext: {
       }
 
       beforeAll(async () => {
-        const imported = await agent.didManagerImport(importedDID)
+        await agent.didManagerImport(importedDID)
       })
 
       it('signs JWT with ES256K', async () => {
@@ -293,6 +296,173 @@ export default (testContext: {
           type: ['VerifiableCredential', 'Example'],
           '@context': ['https://www.w3.org/2018/credentials/v1'],
         })
+      })
+    })
+
+    describe('credential verification policies', () => {
+      let credential: VerifiableCredential
+
+      beforeAll(async () => {
+        const issuanceDate = '2019-08-19T09:15:20.000Z' // 1566206120
+        const expirationDate = '2019-08-20T10:42:31.000Z' // 1566297751
+        credential = await agent.createVerifiableCredential({
+          proofFormat: 'jwt',
+          credential: {
+            issuer: identifier.did,
+            issuanceDate,
+            expirationDate,
+            credentialSubject: {
+              hello: 'world',
+            },
+          },
+        })
+      })
+
+      it('can verify credential at a particular time', async () => {
+        const result = await agent.verifyCredential({ credential })
+        expect(result.verified).toBe(false)
+        expect(result?.error?.errorCode).toEqual(VC_JWT_ERROR.INVALID_JWT)
+
+        const result2 = await agent.verifyCredential({
+          credential,
+          policies: { now: 1566297000 },
+        })
+        expect(result2.verified).toBe(true)
+      })
+
+      it('can override expiry check', async () => {
+        const result = await agent.verifyCredential({
+          credential,
+          policies: { expirationDate: false },
+        })
+        expect(result.verified).toBe(true)
+      })
+
+      it('can override issuance check', async () => {
+        const result = await agent.verifyCredential({
+          credential,
+          policies: { issuanceDate: false, now: 1565000000 },
+        })
+        expect(result.verified).toBe(true)
+      })
+
+      it('can override audience check', async () => {
+        const cred = await agent.createVerifiableCredential({
+          proofFormat: 'jwt',
+          credential: {
+            issuer: identifier.did,
+            aud: 'override me',
+            credentialSubject: {
+              hello: 'world',
+            },
+          },
+        })
+        const result = await agent.verifyCredential({ credential: cred })
+        expect(result.verified).toBe(false)
+        expect(result.error?.errorCode).toEqual(VC_JWT_ERROR.INVALID_AUDIENCE)
+
+        const result2 = await agent.verifyCredential({ credential: cred, policies: { audience: false } })
+        expect(result2.verified).toBe(true)
+      })
+
+      it('can override credentialStatus check', async () => {
+        const cred = await agent.createVerifiableCredential({
+          proofFormat: 'jwt',
+          credential: {
+            issuer: identifier.did,
+            credentialSubject: {
+              hello: 'world',
+            },
+            credentialStatus: {
+              id: 'override me',
+              type: 'ThisMethodDoesNotExist2022',
+            },
+          },
+        })
+        await expect(agent.verifyCredential({ credential: cred })).rejects.toThrow(/^invalid_setup:/)
+
+        const result2 = await agent.verifyCredential({
+          credential: cred,
+          policies: { credentialStatus: false },
+        })
+        expect(result2.verified).toBe(true)
+      })
+    })
+
+    describe('presentation verification policies', () => {
+      let credential: VerifiableCredential
+      let presentation: VerifiablePresentation
+
+      beforeAll(async () => {
+        const issuanceDate = '2019-08-19T09:15:20.000Z' // 1566206120
+        const expirationDate = '2019-08-20T10:42:31.000Z' // 1566297751
+        credential = await agent.createVerifiableCredential({
+          proofFormat: 'jwt',
+          credential: {
+            issuer: identifier.did,
+            credentialSubject: {
+              hello: 'world',
+            },
+          },
+        })
+        presentation = await agent.createVerifiablePresentation({
+          proofFormat: 'jwt',
+          presentation: {
+            holder: identifier.did,
+            verifiableCredential: [credential],
+            issuanceDate,
+            expirationDate,
+          },
+        })
+      })
+
+      it('can verify presentation at a particular time', async () => {
+        const result = await agent.verifyPresentation({ presentation })
+        expect(result.verified).toBe(false)
+        expect(result?.error?.errorCode).toEqual(VC_JWT_ERROR.INVALID_JWT)
+
+        const result2 = await agent.verifyPresentation({
+          presentation,
+          policies: { now: 1566297000 },
+        })
+        expect(result2.verified).toBe(true)
+      })
+
+      it('can override expiry check', async () => {
+        const result = await agent.verifyPresentation({
+          presentation,
+          policies: { expirationDate: false },
+        })
+        expect(result.verified).toBe(true)
+      })
+
+      it('can override issuance check', async () => {
+        const result = await agent.verifyPresentation({
+          presentation,
+          policies: { issuanceDate: false, now: 1565000000 },
+        })
+        expect(result.verified).toBe(true)
+      })
+
+      it('can override audience check', async () => {
+        const pres = await agent.createVerifiablePresentation({
+          proofFormat: 'jwt',
+          presentation: {
+            holder: identifier.did,
+            verifiableCredential: [credential],
+          },
+          challenge: '1234',
+          domain: 'example.com',
+        })
+        const result = await agent.verifyPresentation({ presentation: pres })
+        expect(result.verified).toBe(false)
+        expect(result.error?.errorCode).toEqual(VC_JWT_ERROR.INVALID_AUDIENCE)
+
+        const result2 = await agent.verifyPresentation({
+          presentation: pres,
+          policies: { audience: false },
+        })
+        expect(result2.verified).toBe(true)
       })
     })
   })

--- a/__tests__/shared/verifiableDataLD.ts
+++ b/__tests__/shared/verifiableDataLD.ts
@@ -72,7 +72,7 @@ export default (testContext: {
         credential: verifiableCredential,
       })
 
-      expect(result).toEqual(true)
+      expect(result.verified).toEqual(true)
     })
 
     it('should handleMessage with VC (non-JWT)', async () => {
@@ -98,20 +98,19 @@ export default (testContext: {
         hash: storedCredentialHash,
       })
 
+      // tamper with credential
       verifiableCredential.credentialSubject.name = 'Martin, the not so greats'
 
-      try {
-        await agent.handleMessage({
+      await expect(
+        agent.handleMessage({
           raw: JSON.stringify({
             body: verifiableCredential,
             type: 'w3c.vc',
           }),
           save: false,
           metaData: [{ type: 'LDS' }],
-        })
-      } catch (e) {
-        expect(e).toEqual(Error('Error verifying LD Verifiable Credential'))
-      }
+        }),
+      ).rejects.toThrow(/Verification error/)
     })
 
     it('should sign a verifiable presentation in LD', async () => {
@@ -164,7 +163,7 @@ export default (testContext: {
         domain,
       })
 
-      expect(result).toBeTruthy()
+      expect(result.verified).toEqual(true)
     })
 
     it('should handleMessage with VPs (non-JWT)', async () => {
@@ -244,7 +243,7 @@ export default (testContext: {
         credential: verifiableCredential,
       })
 
-      expect(result).toEqual(true)
+      expect(result.verified).toEqual(true)
     })
   })
 }

--- a/packages/cli/src/credential.ts
+++ b/packages/cli/src/credential.ts
@@ -191,7 +191,7 @@ credential
     }
     try {
       const result = await agent.verifyCredential({ credential: credentialAsJSON })
-      if (result === true) {
+      if (result.verified === true) {
         console.log('Credential was verified successfully.')
       } else {
         console.error('Credential could not be verified.')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "debug": "^4.3.3",
-    "did-jwt-vc": "^3.0.1",
+    "did-jwt-vc": "^3.1.0",
     "events": "^3.2.0",
     "z-schema": "^5.0.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,14 +23,14 @@
   },
   "dependencies": {
     "debug": "^4.3.3",
-    "did-jwt-vc": "^3.0.0",
+    "did-jwt-vc": "^3.0.1",
     "events": "^3.2.0",
     "z-schema": "^5.0.2"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",
-    "did-resolver": "^4.0.0",
-    "credential-status": "^2.0.5",
+    "credential-status": "2.0.5",
+    "did-resolver": "4.0.0",
     "typescript": "4.7.3"
   },
   "files": [

--- a/packages/core/plugin.schema.json
+++ b/packages/core/plugin.schema.json
@@ -1119,7 +1119,8 @@
             {
               "type": "object"
             }
-          ]
+          ],
+          "description": "Represents a service endpoint URL or a map of URLs"
         },
         "IDIDManagerCreateArgs": {
           "type": "object",
@@ -2347,7 +2348,8 @@
             {
               "type": "object"
             }
-          ]
+          ],
+          "description": "Represents a service endpoint URL or a map of URLs"
         },
         "FindMessagesArgs": {
           "$ref": "#/components/schemas/FindArgs-TMessageColumns",

--- a/packages/core/src/types/IIdentifier.ts
+++ b/packages/core/src/types/IIdentifier.ts
@@ -131,4 +131,10 @@ export interface IService {
   description?: string
 }
 
+/**
+ * Represents a service endpoint URL or a map of URLs
+ * @see {@link https://www.w3.org/TR/did-core/#dfn-serviceendpoint | serviceEndpoint data model}
+ *
+ * @public
+ */
 export type IServiceEndpoint = string | Record<string, any>

--- a/packages/credential-ld/plugin.schema.json
+++ b/packages/credential-ld/plugin.schema.json
@@ -17,6 +17,9 @@
           "required": [
             "credential"
           ],
+          "additionalProperties": {
+            "description": "Any other options that can be forwarded to the lower level libraries"
+          },
           "description": "Encapsulates the parameters required to create a\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | W3C Verifiable Credential }"
         },
         "CredentialPayload": {
@@ -198,6 +201,9 @@
           "required": [
             "presentation"
           ],
+          "additionalProperties": {
+            "description": "Any other options that can be forwarded to the lower level libraries"
+          },
           "description": "Encapsulates the parameters required to create a\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | W3C Verifiable Presentation }"
         },
         "PresentationPayload": {
@@ -339,6 +345,9 @@
           "required": [
             "credential"
           ],
+          "additionalProperties": {
+            "description": "Any other options that can be forwarded to the lower level libraries"
+          },
           "description": "Encapsulates the parameters required to verify a\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | W3C Verifiable Credential }"
         },
         "IVerifyPresentationLDArgs": {
@@ -364,6 +373,9 @@
           "required": [
             "presentation"
           ],
+          "additionalProperties": {
+            "description": "Any other options that can be forwarded to the lower level libraries"
+          },
           "description": "Encapsulates the parameters required to verify a\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | W3C Verifiable Presentation }"
         }
       },

--- a/packages/credential-ld/plugin.schema.json
+++ b/packages/credential-ld/plugin.schema.json
@@ -12,6 +12,10 @@
             "keyRef": {
               "type": "string",
               "description": "Optional. The key handle ( {@link  @veramo/core#IKey.kid | IKey.kid } ) from the internal database."
+            },
+            "fetchRemoteContexts": {
+              "type": "boolean",
+              "description": "Set this to true if you want the `@context` URLs to be fetched in case they are not preloaded.\n\nDefaults to `false`"
             }
           },
           "required": [
@@ -196,6 +200,10 @@
             "keyRef": {
               "type": "string",
               "description": "Optional. The key handle ( {@link  @veramo/core#IKey.kid | IKey.kid } ) from the internal database."
+            },
+            "fetchRemoteContexts": {
+              "type": "boolean",
+              "description": "Set this to true if you want the `@context` URLs to be fetched in case they are not preloaded.\n\nDefaults to `false`"
             }
           },
           "required": [
@@ -339,7 +347,7 @@
             },
             "fetchRemoteContexts": {
               "type": "boolean",
-              "description": "Set this to true if you want the `@context` URLs to be fetched in case they are not pre-loaded.\n\nDefaults to `false`"
+              "description": "Set this to true if you want the `@context` URLs to be fetched in case they are not preloaded.\n\nDefaults to `false`"
             }
           },
           "required": [
@@ -367,7 +375,7 @@
             },
             "fetchRemoteContexts": {
               "type": "boolean",
-              "description": "Set this to true if you want the `@context` URLs to be fetched in case they are not pre-loaded.\n\nDefaults to `false`"
+              "description": "Set this to true if you want the `@context` URLs to be fetched in case they are not preloaded.\n\nDefaults to `false`"
             }
           },
           "required": [

--- a/packages/credential-ld/src/__tests__/issue-verify-flow.test.ts
+++ b/packages/credential-ld/src/__tests__/issue-verify-flow.test.ts
@@ -91,11 +91,11 @@ describe('credential-LD full flow', () => {
 
     expect(verifiableCredential).toBeDefined()
 
-    const verified = await agent.verifyCredential({
+    const result = await agent.verifyCredential({
       credential: verifiableCredential,
     })
 
-    expect(verified).toBe(true)
+    expect(result.verified).toBe(true)
   })
 
   it('works with EcdsaSecp256k1RecoveryMethod2020 credentials', async () => {
@@ -113,11 +113,11 @@ describe('credential-LD full flow', () => {
 
     expect(verifiableCredential).toBeDefined()
 
-    const verified = await agent.verifyCredential({
+    const result = await agent.verifyCredential({
       credential: verifiableCredential,
     })
 
-    expect(verified).toBe(true)
+    expect(result.verified).toBe(true)
   })
 
   it('works with Ed25519Signature2018 credential and presentation', async () => {
@@ -144,12 +144,12 @@ describe('credential-LD full flow', () => {
 
     expect(verifiablePresentation).toBeDefined()
 
-    const verified = await agent.verifyPresentation({
+    const result = await agent.verifyPresentation({
       presentation: verifiablePresentation,
       challenge: 'VERAMO',
     })
 
-    expect(verified).toBe(true)
+    expect(result.verified).toBe(true)
   })
 
   it('works with EcdsaSecp256k1RecoveryMethod2020 credential and presentation', async () => {
@@ -179,11 +179,11 @@ describe('credential-LD full flow', () => {
 
     expect(verifiablePresentation).toBeDefined()
 
-    const verified = await agent.verifyPresentation({
+    const result = await agent.verifyPresentation({
       presentation: verifiablePresentation,
       challenge: 'VERAMO',
     })
 
-    expect(verified).toBe(true)
+    expect(result.verified).toBe(true)
   })
 })

--- a/packages/credential-ld/src/action-handler.ts
+++ b/packages/credential-ld/src/action-handler.ts
@@ -110,13 +110,19 @@ export class CredentialIssuerLD implements IAgentPlugin {
         args.keyRef,
       )
 
+      let { now } = args
+      if (typeof now === 'number') {
+        now = new Date(now * 1000)
+      }
+
       return await this.ldCredentialModule.signLDVerifiablePresentation(
         presentation,
         identifier.did,
         signingKey,
         verificationMethodId,
-        args.challenge,
-        args.domain,
+        args.challenge || '',
+        args.domain || '',
+        { ...args, now },
         context,
       )
     } catch (error) {
@@ -135,15 +141,10 @@ export class CredentialIssuerLD implements IAgentPlugin {
       MANDATORY_CREDENTIAL_CONTEXT,
     )
     const credentialType = processEntryToArray(args?.credential?.type, 'VerifiableCredential')
-    let issuanceDate = args?.credential?.issuanceDate || new Date().toISOString()
-    if (issuanceDate instanceof Date) {
-      issuanceDate = issuanceDate.toISOString()
-    }
     const credential: CredentialPayload = {
       ...args?.credential,
       '@context': credentialContext,
       type: credentialType,
-      issuanceDate,
     }
 
     const issuer = extractIssuer(credential)
@@ -164,11 +165,17 @@ export class CredentialIssuerLD implements IAgentPlugin {
         args.keyRef,
       )
 
+      let { now } = args
+      if (typeof now === 'number') {
+        now = new Date(now * 1000)
+      }
+
       return await this.ldCredentialModule.issueLDVerifiableCredential(
         credential,
         identifier.did,
         signingKey,
         verificationMethodId,
+        { ...args.options, now },
         context,
       )
     } catch (error) {
@@ -183,7 +190,18 @@ export class CredentialIssuerLD implements IAgentPlugin {
     context: IRequiredContext,
   ): Promise<boolean> {
     const credential = args.credential
-    return this.ldCredentialModule.verifyCredential(credential, args.fetchRemoteContexts || false, context)
+
+    let { now } = args
+    if (typeof now === 'number') {
+      now = new Date(now * 1000)
+    }
+
+    return this.ldCredentialModule.verifyCredential(
+      credential,
+      args.fetchRemoteContexts || false,
+      { ...args.options, now },
+      context,
+    )
   }
 
   /** {@inheritdoc ICredentialIssuerLD.verifyPresentationLD} */
@@ -192,11 +210,16 @@ export class CredentialIssuerLD implements IAgentPlugin {
     context: IRequiredContext,
   ): Promise<boolean> {
     const presentation = args.presentation
+    let { now } = args
+    if (typeof now === 'number') {
+      now = new Date(now * 1000)
+    }
     return this.ldCredentialModule.verifyPresentation(
       presentation,
       args.challenge,
       args.domain,
       args.fetchRemoteContexts || false,
+      { ...args.options, now },
       context,
     )
   }

--- a/packages/credential-ld/src/ld-credential-module.ts
+++ b/packages/credential-ld/src/ld-credential-module.ts
@@ -98,6 +98,7 @@ export class LdCredentialModule {
     issuerDid: string,
     key: IKey,
     verificationMethodId: string,
+    options: any,
     context: IAgentContext<RequiredAgentMethods>,
   ): Promise<VerifiableCredential> {
     const suite = this.ldSuiteLoader.getSignatureSuiteForKeyType(key.type)
@@ -107,6 +108,7 @@ export class LdCredentialModule {
     suite.preSigningCredModification(credential)
 
     return await vc.issue({
+      ...options,
       credential,
       suite: suite.getSuiteForSigning(key, issuerDid, verificationMethodId, context),
       documentLoader,
@@ -121,6 +123,7 @@ export class LdCredentialModule {
     verificationMethodId: string,
     challenge: string | undefined,
     domain: string | undefined,
+    options: any,
     context: IAgentContext<RequiredAgentMethods>,
   ): Promise<VerifiablePresentation> {
     const suite = this.ldSuiteLoader.getSignatureSuiteForKeyType(key.type)
@@ -129,6 +132,7 @@ export class LdCredentialModule {
     suite.preSigningPresModification(presentation)
 
     return await vc.signPresentation({
+      ...options,
       presentation,
       suite: suite.getSuiteForSigning(key, holderDid, verificationMethodId, context),
       challenge,
@@ -141,9 +145,11 @@ export class LdCredentialModule {
   async verifyCredential(
     credential: VerifiableCredential,
     fetchRemoteContexts: boolean = false,
+    options: any,
     context: IAgentContext<IResolver>,
   ): Promise<boolean> {
     const result = await vc.verifyCredential({
+      ...options,
       credential,
       suite: this.ldSuiteLoader.getAllSignatureSuites().map((x) => x.getSuiteForVerification()),
       documentLoader: this.getDocumentLoader(context, fetchRemoteContexts),
@@ -164,9 +170,11 @@ export class LdCredentialModule {
     challenge: string | undefined,
     domain: string | undefined,
     fetchRemoteContexts: boolean = false,
+    options: any,
     context: IAgentContext<IResolver>,
   ): Promise<boolean> {
     const result = await vc.verify({
+      ...options,
       presentation,
       suite: this.ldSuiteLoader.getAllSignatureSuites().map((x) => x.getSuiteForVerification()),
       documentLoader: this.getDocumentLoader(context, fetchRemoteContexts),

--- a/packages/credential-ld/src/ld-credential-module.ts
+++ b/packages/credential-ld/src/ld-credential-module.ts
@@ -102,7 +102,7 @@ export class LdCredentialModule {
     context: IAgentContext<RequiredAgentMethods>,
   ): Promise<VerifiableCredential> {
     const suite = this.ldSuiteLoader.getSignatureSuiteForKeyType(key.type)
-    const documentLoader = this.getDocumentLoader(context)
+    const documentLoader = this.getDocumentLoader(context, options.fetchRemoteContexts)
 
     // some suites can modify the incoming credential (e.g. add required contexts)
     suite.preSigningCredModification(credential)
@@ -127,7 +127,7 @@ export class LdCredentialModule {
     context: IAgentContext<RequiredAgentMethods>,
   ): Promise<VerifiablePresentation> {
     const suite = this.ldSuiteLoader.getSignatureSuiteForKeyType(key.type)
-    const documentLoader = this.getDocumentLoader(context)
+    const documentLoader = this.getDocumentLoader(context, options.fetchRemoteContexts)
 
     suite.preSigningPresModification(presentation)
 

--- a/packages/credential-ld/src/ld-credential-module.ts
+++ b/packages/credential-ld/src/ld-credential-module.ts
@@ -28,6 +28,7 @@ export class LdCredentialModule {
 
   private ldContextLoader: LdContextLoader
   ldSuiteLoader: LdSuiteLoader
+
   constructor(options: { ldContextLoader: LdContextLoader; ldSuiteLoader: LdSuiteLoader }) {
     this.ldContextLoader = options.ldContextLoader
     this.ldSuiteLoader = options.ldSuiteLoader
@@ -150,13 +151,12 @@ export class LdCredentialModule {
       checkStatus: async () => Promise.resolve({ verified: true }), // Fake method
     })
 
-    if (result.verified) return true
+    if (!result.verified) {
+      // result can include raw Error
+      debug(`Error verifying LD Credential: ${JSON.stringify(result, null, 2)}`)
+    }
 
-    // NOT verified.    
-    // result can include raw Error
-    debug(`Error verifying LD Verifiable Credential: ${JSON.stringify(result, null, 2)}`)
-    // console.log(JSON.stringify(result, null, 2));
-    throw Error('Error verifying LD Verifiable Credential')
+    return result
   }
 
   async verifyPresentation(
@@ -175,13 +175,10 @@ export class LdCredentialModule {
       compactProof: false,
     })
 
-    if (result.verified) return true
-
-    // NOT verified.
-
-    // result can include raw Error
-    console.log(`Error verifying LD Verifiable Presentation`)
-    console.log(JSON.stringify(result, null, 2))
-    throw Error('Error verifying LD Verifiable Presentation')
+    if (!result.verified) {
+      // result can include raw Error
+      debug(`Error verifying LD Presentation: ${JSON.stringify(result, null, 2)}`)
+    }
+    return result
   }
 }

--- a/packages/credential-ld/src/types.ts
+++ b/packages/credential-ld/src/types.ts
@@ -119,6 +119,11 @@ export interface ICreateVerifiablePresentationLDArgs {
    * Optional. The key handle ({@link @veramo/core#IKey.kid | IKey.kid}) from the internal database.
    */
   keyRef?: string
+
+  /**
+   * Any other options that can be forwarded to the lower level libraries
+   */
+  [x:string]: any
 }
 
 /**
@@ -142,7 +147,12 @@ export interface ICreateVerifiableCredentialLDArgs {
   /**
    * Optional. The key handle ({@link @veramo/core#IKey.kid | IKey.kid}) from the internal database.
    */
-  keyRef?: string
+  keyRef?: string,
+
+  /**
+   * Any other options that can be forwarded to the lower level libraries
+   */
+  [x:string]: any
 }
 
 /**
@@ -168,6 +178,11 @@ export interface IVerifyCredentialLDArgs {
    * Defaults to `false`
    */
   fetchRemoteContexts?: boolean
+
+  /**
+   * Any other options that can be forwarded to the lower level libraries
+   */
+  [x:string]: any
 }
 
 /**
@@ -203,6 +218,11 @@ export interface IVerifyPresentationLDArgs {
    * Defaults to `false`
    */
   fetchRemoteContexts?: boolean
+
+  /**
+   * Any other options that can be forwarded to the lower level libraries
+   */
+  [x:string]: any
 }
 
 /**

--- a/packages/credential-ld/src/types.ts
+++ b/packages/credential-ld/src/types.ts
@@ -121,6 +121,13 @@ export interface ICreateVerifiablePresentationLDArgs {
   keyRef?: string
 
   /**
+   * Set this to true if you want the `@context` URLs to be fetched in case they are not preloaded.
+   *
+   * Defaults to `false`
+   */
+  fetchRemoteContexts?: boolean
+
+  /**
    * Any other options that can be forwarded to the lower level libraries
    */
   [x:string]: any
@@ -150,6 +157,13 @@ export interface ICreateVerifiableCredentialLDArgs {
   keyRef?: string,
 
   /**
+   * Set this to true if you want the `@context` URLs to be fetched in case they are not preloaded.
+   *
+   * Defaults to `false`
+   */
+  fetchRemoteContexts?: boolean
+
+  /**
    * Any other options that can be forwarded to the lower level libraries
    */
   [x:string]: any
@@ -173,7 +187,7 @@ export interface IVerifyCredentialLDArgs {
   credential: VerifiableCredential
 
   /**
-   * Set this to true if you want the `@context` URLs to be fetched in case they are not pre-loaded.
+   * Set this to true if you want the `@context` URLs to be fetched in case they are not preloaded.
    *
    * Defaults to `false`
    */
@@ -213,7 +227,7 @@ export interface IVerifyPresentationLDArgs {
   domain?: string
 
   /**
-   * Set this to true if you want the `@context` URLs to be fetched in case they are not pre-loaded.
+   * Set this to true if you want the `@context` URLs to be fetched in case they are not preloaded.
    *
    * Defaults to `false`
    */

--- a/packages/credential-status/package.json
+++ b/packages/credential-status/package.json
@@ -12,7 +12,7 @@
     "@veramo/core": "^3.1.0",
     "@veramo/utils": "^3.1.0",
     "credential-status": "^2.0.5",
-    "did-jwt": "^6.5.0",
+    "did-jwt": "^6.6.0",
     "did-resolver": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/credential-status/package.json
+++ b/packages/credential-status/package.json
@@ -12,7 +12,7 @@
     "@veramo/core": "^3.1.0",
     "@veramo/utils": "^3.1.0",
     "credential-status": "^2.0.5",
-    "did-jwt": "^6.3.0",
+    "did-jwt": "^6.5.0",
     "did-resolver": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/credential-w3c/package.json
+++ b/packages/credential-w3c/package.json
@@ -20,7 +20,7 @@
     "@veramo/message-handler": "^3.1.4",
     "@veramo/utils": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt-vc": "^3.0.1",
+    "did-jwt-vc": "^3.1.0",
     "did-resolver": "^4.0.0",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.0"

--- a/packages/credential-w3c/package.json
+++ b/packages/credential-w3c/package.json
@@ -20,7 +20,7 @@
     "@veramo/message-handler": "^3.1.4",
     "@veramo/utils": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt-vc": "^3.0.0",
+    "did-jwt-vc": "^3.0.1",
     "did-resolver": "^4.0.0",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.0"

--- a/packages/credential-w3c/plugin.schema.json
+++ b/packages/credential-w3c/plugin.schema.json
@@ -25,6 +25,11 @@
             "keyRef": {
               "type": "string",
               "description": "[Optional] The ID of the key that should sign this credential. If this is not specified, the first matching key will be used."
+            },
+            "fetchRemoteContexts": {
+              "type": "boolean",
+              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not preloaded. The context definitions SHOULD rather be provided at startup instead of being fetched.",
+              "default": false
             }
           },
           "required": [
@@ -232,6 +237,11 @@
             "keyRef": {
               "type": "string",
               "description": "[Optional] The ID of the key that should sign this presentation. If this is not specified, the first matching key will be used."
+            },
+            "fetchRemoteContexts": {
+              "type": "boolean",
+              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not preloaded. The context definitions SHOULD rather be provided at startup instead of being fetched.",
+              "default": false
             }
           },
           "required": [
@@ -376,7 +386,7 @@
             },
             "fetchRemoteContexts": {
               "type": "boolean",
-              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not pre-loaded. The context definitions SHOULD rather be provided at startup instead of being fetched.",
+              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not preloaded. The context definitions SHOULD rather be provided at startup instead of being fetched.",
               "default": false
             },
             "policies": {

--- a/packages/credential-w3c/plugin.schema.json
+++ b/packages/credential-w3c/plugin.schema.json
@@ -31,6 +31,9 @@
             "credential",
             "proofFormat"
           ],
+          "additionalProperties": {
+            "description": "Any other options that can be forwarded to the lower level libraries"
+          },
           "description": "Encapsulates the parameters required to create a\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | W3C Verifiable Credential }"
         },
         "CredentialPayload": {
@@ -235,6 +238,9 @@
             "presentation",
             "proofFormat"
           ],
+          "additionalProperties": {
+            "description": "Any other options that can be forwarded to the lower level libraries"
+          },
           "description": "Encapsulates the parameters required to create a\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | W3C Verifiable Presentation }"
         },
         "PresentationPayload": {
@@ -382,7 +388,7 @@
             "credential"
           ],
           "additionalProperties": {
-            "description": "Other options can be specified for verification. They will be forwarded to the lower level modules. that performt the checks"
+            "description": "Other options can be specified for verification. They will be forwarded to the lower level modules. that perform the checks"
           },
           "description": "Encapsulates the parameters required to verify a\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | W3C Verifiable Credential }"
         },
@@ -410,13 +416,10 @@
               "description": "policy to skip the revocation check (credentialStatus) when set to `false`"
             }
           },
-          "required": [
-            "credentialStatus"
-          ],
           "additionalProperties": {
             "description": "Other options can be specified for verification. They will be forwarded to the lower level modules that perform the checks"
           },
-          "description": "These optional settings can be used to override some of the default checks that are performed on Presentations during verification."
+          "description": "These optional settings can be used to override some default checks that are performed on Presentations during verification."
         },
         "IVerifyResult": {
           "type": "object",
@@ -469,7 +472,7 @@
             },
             "fetchRemoteContexts": {
               "type": "boolean",
-              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not pre-loaded. The context definitions SHOULD rather be provided at startup instead of being fetched.",
+              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not preloaded. The context definitions SHOULD rather be provided at startup instead of being fetched.",
               "default": false
             },
             "policies": {
@@ -481,7 +484,7 @@
             "presentation"
           ],
           "additionalProperties": {
-            "description": "Other options can be specified for verification. They will be forwarded to the lower level modules. that performt the checks"
+            "description": "Other options can be specified for verification. They will be forwarded to the lower level modules. that perform the checks"
           },
           "description": "Encapsulates the parameters required to verify a\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | W3C Verifiable Presentation }"
         },

--- a/packages/credential-w3c/plugin.schema.json
+++ b/packages/credential-w3c/plugin.schema.json
@@ -372,6 +372,10 @@
               "type": "boolean",
               "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not pre-loaded. The context definitions SHOULD rather be provided at startup instead of being fetched.",
               "default": false
+            },
+            "policies": {
+              "$ref": "#/components/schemas/VerificationPolicies",
+              "description": "Overrides specific aspects of credential verification, where possible."
             }
           },
           "required": [
@@ -382,70 +386,33 @@
           },
           "description": "Encapsulates the parameters required to verify a\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | W3C Verifiable Credential }"
         },
-        "IVerifyPresentationArgs": {
-          "type": "object",
-          "properties": {
-            "presentation": {
-              "$ref": "#/components/schemas/W3CVerifiablePresentation",
-              "description": "The Verifiable Presentation object according to the\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | canonical model }  or the JWT representation.\n\nThe signer of the Presentation is verified based on the `holder` property of the `presentation` or the `iss` property of the JWT payload respectively"
-            },
-            "challenge": {
-              "type": "string",
-              "description": "Optional (only for JWT) string challenge parameter to verify the verifiable presentation against"
-            },
-            "domain": {
-              "type": "string",
-              "description": "Optional (only for JWT) string domain parameter to verify the verifiable presentation against"
-            },
-            "fetchRemoteContexts": {
-              "type": "boolean",
-              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not pre-loaded. The context definitions SHOULD rather be provided at startup instead of being fetched.",
-              "default": false
-            },
-            "policies": {
-              "$ref": "#/components/schemas/VerifyPresentationPolicies",
-              "description": "Verification Policies for the verifiable presentation These will also be forwarded to the lower level module"
-            }
-          },
-          "required": [
-            "presentation"
-          ],
-          "additionalProperties": {
-            "description": "Other options can be specified for verification. They will be forwarded to the lower level modules. that performt the checks"
-          },
-          "description": "Encapsulates the parameters required to verify a\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | W3C Verifiable Presentation }"
-        },
-        "W3CVerifiablePresentation": {
-          "anyOf": [
-            {
-              "$ref": "#/components/schemas/VerifiablePresentation"
-            },
-            {
-              "$ref": "#/components/schemas/CompactJWT"
-            }
-          ],
-          "description": "Represents a signed Verifiable Presentation (includes proof) in either JSON or compact JWT format. See  {@link  https://www.w3.org/TR/vc-data-model/#credentials | VC data model }"
-        },
-        "VerifyPresentationPolicies": {
+        "VerificationPolicies": {
           "type": "object",
           "properties": {
             "now": {
               "type": "number",
-              "description": "policy to over the now (current time) during the verification check"
+              "description": "policy to over the now (current time) during the verification check (UNIX time in seconds)"
             },
             "issuanceDate": {
               "type": "boolean",
-              "description": "policy to override the issuanceDate (nbf) timestamp check"
-            },
-            "issuedAtDate": {
-              "type": "boolean",
-              "description": "policy to override the issuedAtDate (iat) timestamp check"
+              "description": "policy to skip the issuanceDate (nbf) timestamp check when set to `false`"
             },
             "expirationDate": {
               "type": "boolean",
-              "description": "policy to override the expirationDate (exp) timestamp check"
+              "description": "policy to skip the expirationDate (exp) timestamp check when set to `false`"
+            },
+            "audience": {
+              "type": "boolean",
+              "description": "policy to skip the audience check when set to `false`"
+            },
+            "credentialStatus": {
+              "type": "boolean",
+              "description": "policy to skip the revocation check (credentialStatus) when set to `false`"
             }
           },
+          "required": [
+            "credentialStatus"
+          ],
           "additionalProperties": {
             "description": "Other options can be specified for verification. They will be forwarded to the lower level modules that perform the checks"
           },
@@ -484,6 +451,50 @@
             }
           },
           "description": "An error object, which can contain a code."
+        },
+        "IVerifyPresentationArgs": {
+          "type": "object",
+          "properties": {
+            "presentation": {
+              "$ref": "#/components/schemas/W3CVerifiablePresentation",
+              "description": "The Verifiable Presentation object according to the\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | canonical model }  or the JWT representation.\n\nThe signer of the Presentation is verified based on the `holder` property of the `presentation` or the `iss` property of the JWT payload respectively"
+            },
+            "challenge": {
+              "type": "string",
+              "description": "Optional (only for JWT) string challenge parameter to verify the verifiable presentation against"
+            },
+            "domain": {
+              "type": "string",
+              "description": "Optional (only for JWT) string domain parameter to verify the verifiable presentation against"
+            },
+            "fetchRemoteContexts": {
+              "type": "boolean",
+              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not pre-loaded. The context definitions SHOULD rather be provided at startup instead of being fetched.",
+              "default": false
+            },
+            "policies": {
+              "$ref": "#/components/schemas/VerificationPolicies",
+              "description": "Overrides specific aspects of credential verification, where possible."
+            }
+          },
+          "required": [
+            "presentation"
+          ],
+          "additionalProperties": {
+            "description": "Other options can be specified for verification. They will be forwarded to the lower level modules. that performt the checks"
+          },
+          "description": "Encapsulates the parameters required to verify a\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | W3C Verifiable Presentation }"
+        },
+        "W3CVerifiablePresentation": {
+          "anyOf": [
+            {
+              "$ref": "#/components/schemas/VerifiablePresentation"
+            },
+            {
+              "$ref": "#/components/schemas/CompactJWT"
+            }
+          ],
+          "description": "Represents a signed Verifiable Presentation (includes proof) in either JSON or compact JWT format. See  {@link  https://www.w3.org/TR/vc-data-model/#credentials | VC data model }"
         }
       },
       "methods": {
@@ -511,7 +522,7 @@
             "$ref": "#/components/schemas/IVerifyCredentialArgs"
           },
           "returnType": {
-            "type": "boolean"
+            "$ref": "#/components/schemas/IVerifyResult"
           }
         },
         "verifyPresentation": {

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -113,6 +113,15 @@ export interface ICreateVerifiablePresentationArgs {
   keyRef?: string
 
   /**
+   * When dealing with JSON-LD you also MUST provide the proper contexts.
+   * Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not preloaded.
+   * The context definitions SHOULD rather be provided at startup instead of being fetched.
+   *
+   * @default false
+   */
+  fetchRemoteContexts?: boolean
+
+  /**
    * Any other options that can be forwarded to the lower level libraries
    */
   [x: string]: any
@@ -164,6 +173,15 @@ export interface ICreateVerifiableCredentialArgs {
   keyRef?: string
 
   /**
+   * When dealing with JSON-LD you also MUST provide the proper contexts.
+   * Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not preloaded.
+   * The context definitions SHOULD rather be provided at startup instead of being fetched.
+   *
+   * @default false
+   */
+  fetchRemoteContexts?: boolean
+
+  /**
    * Any other options that can be forwarded to the lower level libraries
    */
   [x: string]: any
@@ -188,7 +206,7 @@ export interface IVerifyCredentialArgs {
 
   /**
    * When dealing with JSON-LD you also MUST provide the proper contexts.
-   * Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not pre-loaded.
+   * Set this to `true` ONLY if you want the '@context' URLs to be fetched in case they are not preloaded.
    * The context definitions SHOULD rather be provided at startup instead of being fetched.
    *
    * @default false

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -275,7 +275,7 @@ export interface VerificationPolicies {
   /**
    * policy to skip the revocation check (credentialStatus) when set to `false`
    */
-  credentialStatus: boolean
+  credentialStatus?: boolean
 
   /**
    * Other options can be specified for verification.
@@ -443,7 +443,7 @@ export class CredentialIssuer implements IAgentPlugin {
           verifiablePresentation = await context.agent.createVerifiablePresentationLD(args)
         } else {
           throw new Error(
-            'invalid_configuration: your agent does not seem to have ICredentialIssuerLD plugin installed',
+            'invalid_setup: your agent does not seem to have ICredentialIssuerLD plugin installed',
           )
         }
       } else if (args.proofFormat === 'EthereumEip712Signature2021') {
@@ -451,7 +451,7 @@ export class CredentialIssuer implements IAgentPlugin {
           verifiablePresentation = await context.agent.createVerifiablePresentationEIP712(args)
         } else {
           throw new Error(
-            'invalid_configuration: your agent does not seem to have ICredentialIssuerEIP712 plugin installed',
+            'invalid_setup: your agent does not seem to have ICredentialIssuerEIP712 plugin installed',
           )
         }
       } else {
@@ -519,7 +519,7 @@ export class CredentialIssuer implements IAgentPlugin {
           verifiableCredential = await context.agent.createVerifiableCredentialLD(args as any)
         } else {
           throw new Error(
-            'invalid_configuration: your agent does not seem to have ICredentialIssuerLD plugin installed',
+            'invalid_setup: your agent does not seem to have ICredentialIssuerLD plugin installed',
           )
         }
       } else if (args.proofFormat === 'EthereumEip712Signature2021') {
@@ -527,7 +527,7 @@ export class CredentialIssuer implements IAgentPlugin {
           verifiableCredential = await context.agent.createVerifiableCredentialEIP712(args as any)
         } else {
           throw new Error(
-            'invalid_configuration: your agent does not seem to have ICredentialIssuerEIP712 plugin installed',
+            'invalid_setup: your agent does not seem to have ICredentialIssuerEIP712 plugin installed',
           )
         }
       } else {
@@ -575,9 +575,9 @@ export class CredentialIssuer implements IAgentPlugin {
       try {
         verificationResult = await verifyCredentialJWT(jwt, resolver, {
           policies: {
-            nbf: args.policies?.issuanceDate,
-            iat: args.policies?.issuanceDate,
-            exp: args.policies?.expirationDate,
+            nbf: args.policies?.issuanceDate || args.policies?.nbf,
+            iat: args.policies?.issuanceDate || args.policies?.iat,
+            exp: args.policies?.expirationDate || args.policies?.exp,
             aud: args.policies?.audience,
             ...args.policies,
           },
@@ -596,7 +596,7 @@ export class CredentialIssuer implements IAgentPlugin {
     } else if (type == DocumentFormat.EIP712) {
       if (typeof context.agent.verifyCredentialEIP712 !== 'function') {
         throw new Error(
-          'invalid_configuration: your agent does not seem to have ICredentialIssuerEIP712 plugin installed',
+          'invalid_setup: your agent does not seem to have ICredentialIssuerEIP712 plugin installed',
         )
       }
 
@@ -610,9 +610,9 @@ export class CredentialIssuer implements IAgentPlugin {
           verificationResult = {
             verified: false,
             error: {
-              message: "invalid_signature: The signature does not match any of the issuer signing keys",
-              errorCode: "invalid_signature"
-            }
+              message: 'invalid_signature: The signature does not match any of the issuer signing keys',
+              errorCode: 'invalid_signature',
+            },
           }
         }
         verifiedCredential = <VerifiableCredential>credential
@@ -629,14 +629,14 @@ export class CredentialIssuer implements IAgentPlugin {
     } else if (type == DocumentFormat.JSONLD) {
       if (typeof context.agent.verifyCredentialLD !== 'function') {
         throw new Error(
-          'invalid_configuration: your agent does not seem to have ICredentialIssuerLD plugin installed',
+          'invalid_setup: your agent does not seem to have ICredentialIssuerLD plugin installed',
         )
       }
 
       verificationResult = await context.agent.verifyCredentialLD(args)
       verifiedCredential = <VerifiableCredential>credential
     } else {
-      throw new Error('Unknown credential type.')
+      throw new Error('invalid_argument: Unknown credential type.')
     }
 
     if (args.policies?.credentialStatus !== false && (await isRevoked(verifiedCredential, context))) {
@@ -707,7 +707,7 @@ export class CredentialIssuer implements IAgentPlugin {
       // JSON-LD
       if (typeof context.agent.verifyPresentationEIP712 !== 'function') {
         throw new Error(
-          'invalid_configuration: your agent does not seem to have ICredentialIssuerEIP712 plugin installed',
+          'invalid_setup: your agent does not seem to have ICredentialIssuerEIP712 plugin installed',
         )
       }
       try {
@@ -720,9 +720,9 @@ export class CredentialIssuer implements IAgentPlugin {
           return {
             verified: false,
             error: {
-              message: "invalid_signature: The signature does not match any of the issuer signing keys",
-              errorCode: "invalid_signature"
-            }
+              message: 'invalid_signature: The signature does not match any of the issuer signing keys',
+              errorCode: 'invalid_signature',
+            },
           }
         }
       } catch (e: any) {
@@ -742,7 +742,7 @@ export class CredentialIssuer implements IAgentPlugin {
         return result
       } else {
         throw new Error(
-          'invalid_configuration: your agent does not seem to have ICredentialIssuerLD plugin installed',
+          'invalid_setup: your agent does not seem to have ICredentialIssuerLD plugin installed',
         )
       }
     }
@@ -776,6 +776,6 @@ async function isRevoked(credential: VerifiableCredential, context: IContext): P
   }
 
   throw new Error(
-    `invalid_config: The credential status can't be verified because there is no ICredentialStatusVerifier plugin installed.`,
+    `invalid_setup: The credential status can't be verified because there is no ICredentialStatusVerifier plugin installed.`,
   )
 }

--- a/packages/credential-w3c/src/message-handler.ts
+++ b/packages/credential-w3c/src/message-handler.ts
@@ -6,7 +6,9 @@ import {
   normalizePresentation,
   validateJwtCredentialPayload,
   validateJwtPresentationPayload,
+  VC_ERROR,
 } from 'did-jwt-vc'
+import { JWT_ERROR } from 'did-jwt'
 import { ICredentialIssuer } from './action-handler'
 import { v4 as uuidv4 } from 'uuid'
 import Debug from 'debug'
@@ -32,6 +34,16 @@ export const MessageTypes = {
  * This interface can be used for static type checks, to make sure your application is properly initialized.
  */
 export type IContext = IAgentContext<IResolver & ICredentialIssuer>
+
+const validityErrors: string[] = [
+  JWT_ERROR.INVALID_JWT,
+  JWT_ERROR.INVALID_AUDIENCE,
+  JWT_ERROR.INVALID_SIGNATURE,
+  JWT_ERROR.NO_SUITABLE_KEYS,
+  VC_ERROR.SCHEMA_ERROR,
+  VC_ERROR.FORMAT_ERROR,
+  VC_ERROR.AUTH_ERROR,
+]
 
 /**
  * An implementation of the {@link @veramo/message-handler#AbstractMessageHandler}.
@@ -105,20 +117,23 @@ export class W3cMessageHandler extends AbstractMessageHandler {
       // verify credential
       const credential = message.data as VerifiableCredential
 
-      // throws on error.
-      await context.agent.verifyCredential({ credential })
-      message.id = computeEntryHash(message.raw || message.id || uuidv4())
-      message.type = MessageTypes.vc
-      message.from = extractIssuer(credential)
-      message.to = credential.credentialSubject.id
+      const result = await context.agent.verifyCredential({ credential })
+      if (result.verified) {
+        message.id = computeEntryHash(message.raw || message.id || uuidv4())
+        message.type = MessageTypes.vc
+        message.from = extractIssuer(credential)
+        message.to = credential.credentialSubject.id
 
-      if (credential.tag) {
-        message.threadId = credential.tag
+        if (credential.tag) {
+          message.threadId = credential.tag
+        }
+
+        message.createdAt = credential.issuanceDate
+        message.credentials = [credential]
+        return message
+      } else {
+        throw new Error(result.error?.message)
       }
-
-      message.createdAt = credential.issuanceDate
-      message.credentials = [credential]
-      return message
     }
 
     if (message.type === MessageTypes.vp && message.data) {
@@ -126,26 +141,29 @@ export class W3cMessageHandler extends AbstractMessageHandler {
       const presentation = message.data as VerifiablePresentation
 
       // throws on error.
-      await context.agent.verifyPresentation({
+      const result = await context.agent.verifyPresentation({
         presentation,
         // FIXME: HARDCODED CHALLENGE VERIFICATION FOR NOW
         challenge: 'VERAMO',
         domain: 'VERAMO',
       })
+      if (result.verified) {
+        message.id = computeEntryHash(message.raw || message.id || uuidv4())
+        message.type = MessageTypes.vp
+        message.from = presentation.holder
+        // message.to = presentation.verifier?.[0]
 
-      message.id = computeEntryHash(message.raw || message.id || uuidv4())
-      message.type = MessageTypes.vp
-      message.from = presentation.holder
-      // message.to = presentation.verifier?.[0]
+        if (presentation.tag) {
+          message.threadId = presentation.tag
+        }
 
-      if (presentation.tag) {
-        message.threadId = presentation.tag
+        // message.createdAt = presentation.issuanceDate
+        message.presentations = [presentation]
+        message.credentials = asArray(presentation.verifiableCredential).map(decodeCredentialToObject)
+        return message
+      } else {
+        throw new Error(result.error?.message)
       }
-
-      // message.createdAt = presentation.issuanceDate
-      message.presentations = [presentation]
-      message.credentials = asArray(presentation.verifiableCredential).map(decodeCredentialToObject)
-      return message
     }
 
     return super.handle(message, context)

--- a/packages/credential-w3c/src/message-handler.ts
+++ b/packages/credential-w3c/src/message-handler.ts
@@ -35,16 +35,6 @@ export const MessageTypes = {
  */
 export type IContext = IAgentContext<IResolver & ICredentialIssuer>
 
-const validityErrors: string[] = [
-  JWT_ERROR.INVALID_JWT,
-  JWT_ERROR.INVALID_AUDIENCE,
-  JWT_ERROR.INVALID_SIGNATURE,
-  JWT_ERROR.NO_SUITABLE_KEYS,
-  VC_ERROR.SCHEMA_ERROR,
-  VC_ERROR.FORMAT_ERROR,
-  VC_ERROR.AUTH_ERROR,
-]
-
 /**
  * An implementation of the {@link @veramo/message-handler#AbstractMessageHandler}.
  *

--- a/packages/did-comm/package.json
+++ b/packages/did-comm/package.json
@@ -21,7 +21,7 @@
     "@veramo/utils": "^3.1.4",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.5.0",
+    "did-jwt": "^6.6.0",
     "did-resolver": "^4.0.0",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.0"

--- a/packages/did-comm/package.json
+++ b/packages/did-comm/package.json
@@ -21,7 +21,7 @@
     "@veramo/utils": "^3.1.4",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.3.0",
+    "did-jwt": "^6.5.0",
     "did-resolver": "^4.0.0",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.0"

--- a/packages/did-jwt/package.json
+++ b/packages/did-jwt/package.json
@@ -12,7 +12,7 @@
     "@veramo/core": "^3.1.4",
     "@veramo/message-handler": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.3.0",
+    "did-jwt": "^6.5.0",
     "did-resolver": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/did-jwt/package.json
+++ b/packages/did-jwt/package.json
@@ -12,7 +12,7 @@
     "@veramo/core": "^3.1.4",
     "@veramo/message-handler": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.5.0",
+    "did-jwt": "^6.6.0",
     "did-resolver": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/did-jwt/src/message-handler.ts
+++ b/packages/did-jwt/src/message-handler.ts
@@ -3,6 +3,7 @@ import { AbstractMessageHandler, Message } from '@veramo/message-handler'
 import { verifyJWT, decodeJWT } from 'did-jwt'
 import Debug from 'debug'
 import { Resolvable } from 'did-resolver'
+
 const debug = Debug('veramo:did-jwt:message-handler')
 
 export type IContext = IAgentContext<IResolver>
@@ -18,10 +19,14 @@ export class JwtMessageHandler extends AbstractMessageHandler {
         const decoded = decodeJWT(message.raw)
         const audience = Array.isArray(decoded.payload.aud) ? decoded.payload.aud[0] : decoded.payload.aud
         const resolver = { resolve: (didUrl: string) => context.agent.resolveDid({ didUrl }) } as Resolvable
-        const verified = await verifyJWT(message.raw, { resolver, audience })
-        debug('Message.raw is a valid JWT')
-        message.addMetaData({ type: decoded.header.typ || 'JWT', value: decoded.header.alg })
-        message.data = verified.payload
+        const result = await verifyJWT(message.raw, { resolver, audience })
+        if (result.verified) {
+          debug('Message.raw is a valid JWT')
+          message.addMetaData({ type: decoded.header.typ || 'JWT', value: decoded.header.alg })
+          message.data = result.payload
+        } else {
+          debug(result)
+        }
       } catch (e: any) {
         debug(e.message)
       }

--- a/packages/did-provider-ethr/package.json
+++ b/packages/did-provider-ethr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veramo/did-provider-ethr",
-  "description": "Veramo ehtr-did based identity controller plugin.",
+  "description": "Veramo ethr-did based identity controller plugin.",
   "version": "3.1.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/did-provider-ethr/src/ethr-did-provider.ts
+++ b/packages/did-provider-ethr/src/ethr-did-provider.ts
@@ -190,7 +190,7 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
     const network = this.getNetworkFor(networkSpecifier)
     if (!network) {
       throw new Error(
-        `invalid_config: Cannot create did:ethr. There is no known configuration for network=${networkSpecifier}'`,
+        `invalid_setup: Cannot create did:ethr. There is no known configuration for network=${networkSpecifier}'`,
       )
     }
     if (typeof networkSpecifier === 'number') {

--- a/packages/did-resolver/src/resolver.ts
+++ b/packages/did-resolver/src/resolver.ts
@@ -36,7 +36,7 @@ export class DIDResolverPlugin implements IAgentPlugin {
       this.didResolver = new Resolver(resolverMap as Record<string, DIDResolver>)
     } else {
       throw Error(
-        'invalid_config: The DIDResolverPlugin must be initialized with a Resolvable or a map of methods to DIDResolver implementations',
+        'invalid_setup: The DIDResolverPlugin must be initialized with a Resolvable or a map of methods to DIDResolver implementations',
       )
     }
 

--- a/packages/key-manager/package.json
+++ b/packages/key-manager/package.json
@@ -14,7 +14,7 @@
     "@ethersproject/transactions": "^5.6.2",
     "@stablelib/ed25519": "^1.0.2",
     "@veramo/core": "^3.1.4",
-    "did-jwt": "^6.5.0",
+    "did-jwt": "^6.6.0",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.2"
   },

--- a/packages/key-manager/package.json
+++ b/packages/key-manager/package.json
@@ -14,12 +14,12 @@
     "@ethersproject/transactions": "^5.6.2",
     "@stablelib/ed25519": "^1.0.2",
     "@veramo/core": "^3.1.4",
-    "did-jwt": "^6.3.0",
+    "did-jwt": "^6.5.0",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@ethersproject/abstract-signer": "^5.6.2",
+    "@ethersproject/abstract-signer": "5.6.2",
     "typescript": "4.7.3"
   },
   "files": [

--- a/packages/kms-local/package.json
+++ b/packages/kms-local/package.json
@@ -22,7 +22,7 @@
     "@veramo/key-manager": "^3.1.4",
     "base-58": "^0.0.1",
     "debug": "^4.3.3",
-    "did-jwt": "^6.5.0",
+    "did-jwt": "^6.6.0",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/kms-local/package.json
+++ b/packages/kms-local/package.json
@@ -22,7 +22,7 @@
     "@veramo/key-manager": "^3.1.4",
     "base-58": "^0.0.1",
     "debug": "^4.3.3",
-    "did-jwt": "^6.3.0",
+    "did-jwt": "^6.5.0",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/selective-disclosure/package.json
+++ b/packages/selective-disclosure/package.json
@@ -19,7 +19,7 @@
     "@veramo/did-jwt": "^3.1.4",
     "@veramo/message-handler": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.3.0",
+    "did-jwt": "^6.5.0",
     "uuid": "^8.3.0"
   },
   "devDependencies": {

--- a/packages/selective-disclosure/package.json
+++ b/packages/selective-disclosure/package.json
@@ -19,7 +19,7 @@
     "@veramo/did-jwt": "^3.1.4",
     "@veramo/message-handler": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.5.0",
+    "did-jwt": "^6.6.0",
     "uuid": "^8.3.0"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,8 +15,8 @@
     "blakejs": "^1.1.1",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.3.0",
-    "did-jwt-vc": "^3.0.0",
+    "did-jwt": "^6.5.0",
+    "did-jwt-vc": "^3.0.1",
     "did-resolver": "^4.0.0",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,8 +15,8 @@
     "blakejs": "^1.1.1",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.3",
-    "did-jwt": "^6.5.0",
-    "did-jwt-vc": "^3.0.1",
+    "did-jwt": "^6.6.0",
+    "did-jwt-vc": "^3.1.0",
     "did-resolver": "^4.0.0",
     "uint8arrays": "^3.0.0",
     "uuid": "^8.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7958,18 +7958,18 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-did-jwt-vc@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/did-jwt-vc/-/did-jwt-vc-3.0.1.tgz#d390957ac54fbc6504cba5dbad6df410c54136f1"
-  integrity sha512-M4GvWC7WFXjyPXXVdxD+IP8+KUbyizxPFB2z8fErnYQfdQzWuPqz4PM4MkgI3I4V66lNKfn6bgUivXVTuP8i2Q==
+did-jwt-vc@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/did-jwt-vc/-/did-jwt-vc-3.1.0.tgz#aa7877c4c1f26ba11883604ac0ece30ca4fe78a4"
+  integrity sha512-8N54No9RQpbDM4a/aMiGc/tZWubtH8bqi7DLnO6B62AdWaNVKeS9ddcuANztSS1yTuypyzlyeeEtCTqEzpYgjA==
   dependencies:
-    did-jwt "^6.5.0"
+    did-jwt "^6.6.0"
     did-resolver "^4.0.0"
 
-did-jwt@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.3.0.tgz#6c7380a69fff97f95101ce03519fd34c0ee43594"
-  integrity sha512-kvwCDY6KZJZn9/LK+X4Co+X1brnZWr6fnP1NRVReTgSPFyA+20oZ+VCsmSnzzYUoPkQ/Pl54uOMlmRw69z5zBg==
+did-jwt@6.6.0, did-jwt@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.6.0.tgz#e7c932f7e3ff992b15aef7db3d530c81fb34902d"
+  integrity sha512-qSjXEEHS4fSbBHRCC/ObDzPVkCVvuXIfIiGWa03HNRr85gGkbxzBrxUsUbXfXo1CuzeCqmmZpK4nM4VWlZh6bQ==
   dependencies:
     "@stablelib/ed25519" "^1.0.2"
     "@stablelib/random" "^1.0.1"
@@ -7984,10 +7984,10 @@ did-jwt@^6.3.0:
     multiformats "^9.6.5"
     uint8arrays "^3.0.0"
 
-did-jwt@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.5.0.tgz#0179ed25db32c111a667563c0d7b54e5d6ecb939"
-  integrity sha512-yfdqk2N6+161Yeay4HMC5daic/HRIsc+W1r7JQlNtL14fmQyaPgJxnxpXdc7Qmwd+pMlfpi1oOEtraExDE6MzQ==
+did-jwt@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.3.0.tgz#6c7380a69fff97f95101ce03519fd34c0ee43594"
+  integrity sha512-kvwCDY6KZJZn9/LK+X4Co+X1brnZWr6fnP1NRVReTgSPFyA+20oZ+VCsmSnzzYUoPkQ/Pl54uOMlmRw69z5zBg==
   dependencies:
     "@stablelib/ed25519" "^1.0.2"
     "@stablelib/random" "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7403,7 +7403,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-credential-status@^2.0.5:
+credential-status@2.0.5, credential-status@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/credential-status/-/credential-status-2.0.5.tgz#59e34d30b85664160dd77a4357f1a1237cb7b2bc"
   integrity sha512-hh0pOcRidROn4MC1wF3vNURhPEMSzm3RcpFIl5PFVj5HWgCaZy16nXmrOl5cmr50Jhp2WV48cWbNMxh4OFWU+w==
@@ -7958,7 +7958,7 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-did-jwt-vc@^3.0.0:
+did-jwt-vc@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/did-jwt-vc/-/did-jwt-vc-3.0.1.tgz#d390957ac54fbc6504cba5dbad6df410c54136f1"
   integrity sha512-M4GvWC7WFXjyPXXVdxD+IP8+KUbyizxPFB2z8fErnYQfdQzWuPqz4PM4MkgI3I4V66lNKfn6bgUivXVTuP8i2Q==
@@ -8002,7 +8002,7 @@ did-jwt@^6.5.0:
     multiformats "^9.6.5"
     uint8arrays "^3.0.0"
 
-did-resolver@^4.0.0:
+did-resolver@4.0.0, did-resolver@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-4.0.0.tgz#fc8f657b4cd7f44c2921051fb046599fbe7d4b31"
   integrity sha512-/roxrDr9EnAmLs+s9T+8+gcpilMo+IkeytcsGO7dcxvTmVJ+0Rt60HtV8o0UXHhGBo0Q+paMH/0ffXz1rqGFYg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7958,7 +7958,7 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-did-jwt-vc@3.1.0:
+did-jwt-vc@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/did-jwt-vc/-/did-jwt-vc-3.1.0.tgz#aa7877c4c1f26ba11883604ac0ece30ca4fe78a4"
   integrity sha512-8N54No9RQpbDM4a/aMiGc/tZWubtH8bqi7DLnO6B62AdWaNVKeS9ddcuANztSS1yTuypyzlyeeEtCTqEzpYgjA==
@@ -7966,10 +7966,10 @@ did-jwt-vc@3.1.0:
     did-jwt "^6.6.0"
     did-resolver "^4.0.0"
 
-did-jwt@6.6.0, did-jwt@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.6.0.tgz#e7c932f7e3ff992b15aef7db3d530c81fb34902d"
-  integrity sha512-qSjXEEHS4fSbBHRCC/ObDzPVkCVvuXIfIiGWa03HNRr85gGkbxzBrxUsUbXfXo1CuzeCqmmZpK4nM4VWlZh6bQ==
+did-jwt@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.3.0.tgz#6c7380a69fff97f95101ce03519fd34c0ee43594"
+  integrity sha512-kvwCDY6KZJZn9/LK+X4Co+X1brnZWr6fnP1NRVReTgSPFyA+20oZ+VCsmSnzzYUoPkQ/Pl54uOMlmRw69z5zBg==
   dependencies:
     "@stablelib/ed25519" "^1.0.2"
     "@stablelib/random" "^1.0.1"
@@ -7984,10 +7984,10 @@ did-jwt@6.6.0, did-jwt@^6.6.0:
     multiformats "^9.6.5"
     uint8arrays "^3.0.0"
 
-did-jwt@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.3.0.tgz#6c7380a69fff97f95101ce03519fd34c0ee43594"
-  integrity sha512-kvwCDY6KZJZn9/LK+X4Co+X1brnZWr6fnP1NRVReTgSPFyA+20oZ+VCsmSnzzYUoPkQ/Pl54uOMlmRw69z5zBg==
+did-jwt@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.6.0.tgz#e7c932f7e3ff992b15aef7db3d530c81fb34902d"
+  integrity sha512-qSjXEEHS4fSbBHRCC/ObDzPVkCVvuXIfIiGWa03HNRr85gGkbxzBrxUsUbXfXo1CuzeCqmmZpK4nM4VWlZh6bQ==
   dependencies:
     "@stablelib/ed25519" "^1.0.2"
     "@stablelib/random" "^1.0.1"


### PR DESCRIPTION
## What issue is this PR fixing

fixes #935
fixes #954
fixes #375
fixes #989

## What is being changed
* Verification override policies are now defined for Credentials as well, and, where possible, applied to JSON-LD VC/VP too (see #935).
* Verification of credentials and presentations results in an object with a `verified` boolean property and an optional `error` object with a `message` and `errorCode`. Other properties can be added by the lower level libraries performing the verification (see #954).
* `verify*()` methods still throw errors, but only in case of exceptional situations, when the agent config does not support that kind of verification or when there is a problem with the arguments.
  * I'm still not sure if this is the right approach or if we should be catching these and creating response objects with error messages. **Please share your opinion if you have one.** If needed, this change can be added in another PR.
* VC/VP creation and verification now allows extra options to be used and forwarded to lower level libraries (fixes #989)

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests. (policies are applied by lower level libs which have their own unit tests for this)
* [x] I added integration tests.

## Details
Not all policies are applicable for non-JWT VC/VP.
For EIP712 VC/VP, none of the override policies are applicable yet.

This PR is a continuation of the work started by @daniyal-khalil