### PR TITLE
fix(ci): add GH_TOKEN for checkout and auto-release

### DIFF
--- a/.github/workflows/build-test-publish-on-push.yml
+++ b/.github/workflows/build-test-publish-on-push.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{secrets.GH_TOKEN}}
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
@@ -53,7 +54,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: test123
           POSTGRES_PORT: 5432
-        run: yarn test:integration        
+        run: yarn test:integration
       - run: yarn docs
 
       - name: run browser tests


### PR DESCRIPTION
This should authorize the build script to auto-release from `main`