### PR TITLE
fix(credential-eip712): add support for all did methods that use secp256k

### DIFF
--- a/packages/core/plugin.schema.json
+++ b/packages/core/plugin.schema.json
@@ -3224,7 +3224,7 @@
             "save": {
               "type": "boolean",
               "description": "Optional. If set to `true`, the message will be saved using\n {@link  @veramo/core#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage } \n<p/><p/>",
-              "deprecated": "Please call {@link @veramo/core#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} after\nhandling the message and determining that it must be saved."
+              "deprecated": "Please call {@link @veramo/core#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} after\r\nhandling the message and determining that it must be saved."
             }
           },
           "required": [
@@ -3560,7 +3560,7 @@
             "save": {
               "type": "boolean",
               "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core#IDataStore | storage plugin }  to be saved.",
-              "deprecated": "Please call\n{@link @veramo/core#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to save\nthe credential after creating it."
+              "deprecated": "Please call\r\n{@link @veramo/core#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to save\r\nthe credential after creating it."
             },
             "proofFormat": {
               "$ref": "#/components/schemas/ProofFormat",
@@ -3763,7 +3763,7 @@
             "save": {
               "type": "boolean",
               "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core#IDataStore | storage plugin }  to be saved. <p/><p/>",
-              "deprecated": "Please call\n{@link @veramo/core#IDataStore.dataStoreSaveVerifiablePresentation | dataStoreSaveVerifiablePresentation()} to\nsave the credential after creating it."
+              "deprecated": "Please call\r\n{@link @veramo/core#IDataStore.dataStoreSaveVerifiablePresentation | dataStoreSaveVerifiablePresentation()} to\r\nsave the credential after creating it."
             },
             "challenge": {
               "type": "string",

--- a/packages/credential-eip712/package.json
+++ b/packages/credential-eip712/package.json
@@ -16,9 +16,9 @@
   "dependencies": {
     "@metamask/eth-sig-util": "^4.0.1",
     "@veramo/core": "^4.0.0",
-    "@veramo/utils": "^4.0.0",
     "debug": "^4.3.3",
-    "eip-712-types-generation": "^0.1.6"
+    "eip-712-types-generation": "^0.1.6",
+    "@veramo/utils": "^4.0.0"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",

--- a/packages/credential-eip712/src/agent/CredentialEIP712.ts
+++ b/packages/credential-eip712/src/agent/CredentialEIP712.ts
@@ -85,7 +85,9 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
     if (!extendedKey)
       throw Error('key_not_found: The signing key is not available in the issuer DID document')
 
-    const chainId = getChainIdForDidEthr(extendedKey.meta.verificationMethod)
+    let chainId = 1
+    if (identifier.did.split(':')[1] === 'ethr')
+      chainId = getChainIdForDidEthr(extendedKey.meta.verificationMethod)
 
     const credential: CredentialPayload = {
       ...args?.credential,
@@ -235,8 +237,9 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
     const extendedKey = extendedKeys.find((key) => key.kid === keyRef)
     if (!extendedKey)
       throw Error('key_not_found: The signing key is not available in the issuer DID document')
-
-    const chainId = getChainIdForDidEthr(extendedKey.meta.verificationMethod)
+    let chainId = 1
+    if (identifier.did.split(':')[1] === 'ethr')
+      chainId = getChainIdForDidEthr(extendedKey.meta.verificationMethod)
     presentation['proof'] = {
       verificationMethod: extendedKey.meta.verificationMethod.id,
       created: issuanceDate,

--- a/packages/did-comm/plugin.schema.json
+++ b/packages/did-comm/plugin.schema.json
@@ -188,7 +188,7 @@
           "required": [
             "data"
           ],
-          "deprecated": "Please use {@link IDIDComm.sendDIDCommMessage } instead. This will be removed in Veramo 4.0.\nInput arguments for {@link IDIDComm.sendMessageDIDCommAlpha1 }"
+          "deprecated": "Please use {@link IDIDComm.sendDIDCommMessage } instead. This will be removed in Veramo 4.0.\r\nInput arguments for {@link IDIDComm.sendMessageDIDCommAlpha1 }"
         },
         "IMessage": {
           "type": "object",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,12 +19,14 @@
     "did-jwt-vc": "^3.1.0",
     "did-resolver": "^4.0.0",
     "uint8arrays": "^3.0.0",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "elliptic": "^6.5.4"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",
     "@types/uuid": "8.3.4",
-    "typescript": "4.7.3"
+    "typescript": "4.7.3",
+    "@types/elliptic": "6.4.14"
   },
   "files": [
     "build/**/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,6 +4594,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bn.js@*":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.1.tgz#b51e1b55920a4ca26e9285ff79936bbdec910682"
+  integrity sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==
+  dependencies:
+    "@types/node" "*"
+
 "@types/bn.js@^4.11.3":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
@@ -4659,6 +4666,13 @@
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
   dependencies:
     "@types/ms" "*"
+
+"@types/elliptic@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.14.tgz#7bbaad60567a588c1f08b10893453e6b9b4de48e"
+  integrity sha512-z4OBcDAU0GVwDTuwJzQCiL6188QvZMkvoERgcVjq0/mPM8jCfdwZ3x5zQEVoL9WCAru3aG5wl3Z5Ww5wBWn7ZQ==
+  dependencies:
+    "@types/bn.js" "*"
 
 "@types/eslint-scope@^3.7.3":
   version "3.7.3"


### PR DESCRIPTION
## What issue is this PR fixing

This PR fixes the issue (Fixes #991 ) with credential-eip712 library, where only did:ethr was supported, while every did method that uses secp256k should've been. 

Closes #991 

Linking to an issue provides some context and a reason for the PR to be reviewed, as well as simplifying the release
notes and changelogs that get generated automatically. If an issue is linked like this it will be automatically closed
when the PR is merged.

## What is being changed

### credential-eip712
- chainID is set to 1 for methods other than did:ethr

### utils
- function `getEthereumAddress` now generates an address for compressed and uncompressed `publicKeyHex`, `publicKeyBase58` and `publicKeyBase64`.
- added utility functions that extract bytes from public keys. Some bits from these functions are duplicated from [here](https://github.com/decentralized-identity/did-jwt/blob/86010a6f403619b85259b1790d9d21799716bd4b/src/VerifierAlgorithm.ts#L32) and can be later replaced with exported functions from this lib.
- adds support for 'EcdsaSecp256k1RecoveryMethod2019'

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `yarn`, `yarn build`, `yarn test` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because there arent any new features, and I am aware that a PR without tests will likely get rejected.

