### PR TITLE
fix(data-store): use looser typeorm version range to fix #1013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/uport-project/veramo/compare/v4.0.0...v4.0.1) (2022-09-23)
+
+
+### Bug Fixes
+
+* **ci:** add GH_TOKEN for checkout and auto-release ([#1009](https://github.com/uport-project/veramo/issues/1009)) ([1268bd2](https://github.com/uport-project/veramo/commit/1268bd28e5e6c84255d5f67b46fc88e004dd8fea))
+* **credential-w3c:** manually merge schemas for ICredentialPlugin ([#1008](https://github.com/uport-project/veramo/issues/1008)) ([cff1765](https://github.com/uport-project/veramo/commit/cff1765ea052960d2e0ca88042c4b9a9d4db7fad)), closes [#1007](https://github.com/uport-project/veramo/issues/1007)
+
+
+
+
+
 # [4.0.0](https://github.com/uport-project/veramo/compare/v3.1.5...v4.0.0) (2022-09-22)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0",
+  "version": "4.0.1",
   "packages": [
     "packages/*"
   ],

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/uport-project/veramo/compare/v4.0.0...v4.0.1) (2022-09-23)
+
+**Note:** Version bump only for package @veramo/cli
+
+
+
+
+
 # [4.0.0](https://github.com/uport-project/veramo/compare/v3.1.5...v4.0.0) (2022-09-22)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@veramo/cli",
   "description": "Veramo command line application.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "build/cli.js",
   "types": "build/cli.d.ts",
   "bin": {
@@ -19,7 +19,7 @@
     "@types/blessed": "^0.1.17",
     "@types/swagger-ui-express": "^4.1.3",
     "@veramo/core": "^4.0.0",
-    "@veramo/credential-w3c": "^4.0.0",
+    "@veramo/credential-w3c": "^4.0.1",
     "@veramo/data-store": "^4.0.0",
     "@veramo/did-comm": "^4.0.0",
     "@veramo/did-discovery": "^4.0.0",
@@ -34,7 +34,7 @@
     "@veramo/message-handler": "^4.0.0",
     "@veramo/remote-client": "^4.0.0",
     "@veramo/remote-server": "^4.0.0",
-    "@veramo/selective-disclosure": "^4.0.0",
+    "@veramo/selective-disclosure": "^4.0.1",
     "@veramo/url-handler": "^4.0.0",
     "blessed": "^0.1.81",
     "commander": "^9.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "sqlite3": "5.0.8",
     "swagger-ui-express": "^4.3.0",
     "ts-json-schema-generator": "^1.0.0",
-    "typeorm": "0.3.6",
+    "typeorm": "^0.3.10",
     "url-parse": "^1.5.4",
     "web-did-resolver": "^2.0.20",
     "ws": "^8.4.0",

--- a/packages/credential-w3c/CHANGELOG.md
+++ b/packages/credential-w3c/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/uport-project/veramo/compare/v4.0.0...v4.0.1) (2022-09-23)
+
+
+### Bug Fixes
+
+* **credential-w3c:** manually merge schemas for ICredentialPlugin ([#1008](https://github.com/uport-project/veramo/issues/1008)) ([cff1765](https://github.com/uport-project/veramo/commit/cff1765ea052960d2e0ca88042c4b9a9d4db7fad)), closes [#1007](https://github.com/uport-project/veramo/issues/1007)
+
+
+
+
+
 # [4.0.0](https://github.com/uport-project/veramo/compare/v3.1.5...v4.0.0) (2022-09-22)
 
 

--- a/packages/credential-w3c/package.json
+++ b/packages/credential-w3c/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@veramo/credential-w3c",
   "description": "Veramo plugin for working with W3C Verifiable Credentials & Presentations.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {

--- a/packages/data-store/package.json
+++ b/packages/data-store/package.json
@@ -15,7 +15,7 @@
     "@veramo/key-manager": "^4.0.0",
     "@veramo/utils": "^4.0.0",
     "debug": "^4.3.3",
-    "typeorm": "0.3.6"
+    "typeorm": "^0.3.10"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",
@@ -34,7 +34,7 @@
   "repository": "git@github.com:uport-project/veramo.git",
   "author": "Simonas Karuzas <simonas.karuzas@mesh.xyz>",
   "contributors": [
-    "Mircea Nistor mircea.nistor@mesh.xyz"
+    "Mircea Nistor <mircea.nistor@mesh.xyz>"
   ],
   "license": "Apache-2.0",
   "keywords": []

--- a/packages/selective-disclosure/CHANGELOG.md
+++ b/packages/selective-disclosure/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/uport-project/veramo/compare/v4.0.0...v4.0.1) (2022-09-23)
+
+**Note:** Version bump only for package @veramo/selective-disclosure
+
+
+
+
+
 # [4.0.0](https://github.com/uport-project/veramo/compare/v3.1.5...v4.0.0) (2022-09-22)
 
 

--- a/packages/selective-disclosure/package.json
+++ b/packages/selective-disclosure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@veramo/selective-disclosure",
   "description": "Veramo plugin to enable the uPort selective disclosure protocol with W3C compatibility.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@veramo/core": "^4.0.0",
-    "@veramo/credential-w3c": "^4.0.0",
+    "@veramo/credential-w3c": "^4.0.1",
     "@veramo/did-jwt": "^4.0.0",
     "@veramo/message-handler": "^4.0.0",
     "debug": "^4.3.3",

--- a/packages/test-react-app/CHANGELOG.md
+++ b/packages/test-react-app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/uport-project/veramo/compare/v4.0.0...v4.0.1) (2022-09-23)
+
+**Note:** Version bump only for package @veramo/test-react-app
+
+
+
+
+
 # [4.0.0](https://github.com/uport-project/veramo/compare/v3.1.5...v4.0.0) (2022-09-22)
 
 

--- a/packages/test-react-app/package.json
+++ b/packages/test-react-app/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@veramo/test-react-app",
   "description": "This package is only meant for testing that veramo core dependencies function in a react environment.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": true,
   "dependencies": {
     "@veramo/core": "^4.0.0",
     "@veramo/credential-ld": "^4.0.0",
-    "@veramo/credential-w3c": "^4.0.0",
+    "@veramo/credential-w3c": "^4.0.1",
     "@veramo/data-store": "^4.0.0",
     "@veramo/did-comm": "^4.0.0",
     "@veramo/did-jwt": "^4.0.0",
@@ -18,7 +18,7 @@
     "@veramo/key-manager": "^4.0.0",
     "@veramo/kms-local": "^4.0.0",
     "@veramo/message-handler": "^4.0.0",
-    "@veramo/selective-disclosure": "^4.0.0",
+    "@veramo/selective-disclosure": "^4.0.1",
     "@veramo/test-utils": "^4.0.0",
     "@veramo/url-handler": "^4.0.0",
     "@veramo/utils": "^4.0.0",

--- a/packages/test-react-app/package.json
+++ b/packages/test-react-app/package.json
@@ -28,7 +28,7 @@
     "react": "18.1.0",
     "react-dom": "18.1.0",
     "stream": "npm:stream-browserify",
-    "typeorm": "0.3.6",
+    "typeorm": "^0.3.10",
     "web-did-resolver": "^2.0.20",
     "web-vitals": "^2.1.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17599,10 +17599,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typeorm@0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.6.tgz#65203443a1b684bb746785913fe2b0877aa991c0"
-  integrity sha512-DRqgfqcelMiGgWSMbBmVoJNFN2nPNA3EeY2gC324ndr2DZoGRTb9ILtp2oGVGnlA+cu5zgQ6it5oqKFNkte7Aw==
+typeorm@^0.3.10:
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.10.tgz#aa2857fd4b078c912ca693b7eee01b6535704458"
+  integrity sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==
   dependencies:
     "@sqltools/formatter" "^1.2.2"
     app-root-path "^3.0.0"


### PR DESCRIPTION
## What issue is this PR fixing

fixes #1013

## What is being changed
The typeorm version in use was fixed to 0.3.6, disallowing user controlled upgrades to other compatible versions.
This PR bumps typeorm to 0.3.10 and uses a compatibility version range (^0.3.10)

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because there is no new functionality.