### PR TITLE
feat: add support for did:ethr signed/meta transactions

### DIFF
--- a/__tests__/localAgent.test.ts
+++ b/__tests__/localAgent.test.ts
@@ -84,6 +84,7 @@ import didCommWithEthrDidFlow from './shared/didCommWithEthrDidFlow'
 import utils from './shared/utils'
 import web3 from './shared/web3'
 import credentialStatus from './shared/credentialStatus'
+import ethrDidFlowSigned from "./shared/ethrDidFlowSigned";
 
 jest.setTimeout(60000)
 
@@ -278,4 +279,5 @@ describe('Local integration tests', () => {
   web3(testContext)
   didCommWithEthrDidFlow(testContext)
   credentialStatus(testContext)
+  ethrDidFlowSigned(testContext)
 })

--- a/__tests__/shared/ethrDidFlowSigned.ts
+++ b/__tests__/shared/ethrDidFlowSigned.ts
@@ -1,0 +1,139 @@
+// noinspection ES6PreferShortImport
+
+import {
+  IAgentOptions,
+  IDIDManager,
+  IIdentifier,
+  IKeyManager,
+  IMessageHandler,
+  IResolver,
+  TAgent,
+} from '../../packages/core/src'
+import {IDIDComm} from '../../packages/did-comm/src'
+// @ts-ignore
+import express from 'express'
+import {Server} from 'http'
+
+type ConfiguredAgent = TAgent<IDIDManager & IKeyManager & IResolver & IDIDComm & IMessageHandler>
+
+export async function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+export default (testContext: {
+  getAgent: () => ConfiguredAgent
+  setup: (options?: IAgentOptions) => Promise<boolean>
+  tearDown: () => Promise<boolean>
+}) => {
+  describe('did ethr controller signed interactions', () => {
+    let agent: ConfiguredAgent
+
+    let alice: IIdentifier
+    let bob: IIdentifier
+
+    let didCommEndpointServer: Server
+    let listeningPort = Math.round(Math.random() * 32000 + 2048)
+
+    beforeEach(async () => {
+      await testContext.setup()
+      agent = testContext.getAgent()
+
+      alice = await agent.didManagerImport({
+        controllerKeyId: 'alice-controller-key',
+        did: 'did:ethr:ganache:0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+        provider: 'did:ethr:ganache',
+        alias: 'alice-did-ethr',
+        keys: [
+          {
+            privateKeyHex: '0000000000000000000000000000000000000000000000000000000000000001',
+            kms: 'local',
+            type: 'Secp256k1',
+            kid: 'alice-controller-key',
+          },
+        ],
+      })
+
+      bob = await agent.didManagerImport({
+        controllerKeyId: 'bob-controller-key',
+        did: 'did:ethr:ganache:0x02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5',
+        provider: 'did:ethr:ganache',
+        alias: 'bob-did-ethr',
+        keys: [
+          {
+            privateKeyHex: '0000000000000000000000000000000000000000000000000000000000000002',
+            kms: 'local',
+            type: 'Secp256k1',
+            kid: 'bob-controller-key',
+          },
+        ],
+      })
+    })
+
+    afterAll(async () => {
+      await testContext.tearDown()
+    })
+
+    it('should add dummy service to alice did with bob sending the tx', async () => {
+      const result = await agent.didManagerAddService({
+        did: alice.did,
+        service: {
+          id: 'localhost-useless-endpoint',
+          type: 'DIDComm',
+          serviceEndpoint: `http://localhost:${listeningPort}/foobar`,
+          description: 'this endpoint will be removed',
+        }, options: {
+          metaIdentifier: bob.did
+        }
+      })
+
+      const resolution = await agent.resolveDid({ didUrl: alice.did })
+
+      expect(resolution?.didDocument?.service?.[0].serviceEndpoint).toEqual(`http://localhost:${listeningPort}/foobar`)
+    })
+
+    it('should remove dummy service to alice did with bob sending the tx', async () => {
+      await agent.didManagerAddService({
+        did: alice.did,
+        service: {
+          id: 'localhost-useless-endpoint',
+          type: 'DIDComm',
+          serviceEndpoint: `http://localhost:${listeningPort}/foobar`,
+          description: 'this endpoint will be removed',
+        }, options: {
+          metaIdentifier: bob.did
+        }
+      })
+
+      await agent.didManagerRemoveService({
+        did: alice.did,
+        id: "localhost-useless-endpoint",
+        options: {
+          metaIdentifier: bob.did
+        }
+      })
+
+      const resolution = await agent.resolveDid({ didUrl: alice.did })
+      expect(resolution?.didDocument?.service?.[0].serviceEndpoint).toBeFalsy()
+    })
+
+    it('should add verification key to alice did with bob sending the tx', async () => {
+      const keyToAdd = await agent.keyManagerCreate({type: 'Secp256k1', kms: 'local'})
+
+      const didBeforeChange = await agent.resolveDid({ didUrl: alice.did })
+
+      await agent.didManagerAddKey({
+        did: alice.did,
+        key: keyToAdd,
+        options: {
+          metaIdentifier: bob.did
+        }
+      })
+
+      // Give ganache some time to emit the event from the contract
+      await sleep(1000)
+
+      const didAfterchange = await agent.resolveDid({ didUrl: alice.did })
+      expect(didAfterchange?.didDocument?.service?.[0].serviceEndpoint).toBeFalsy()
+    })
+  })
+}

--- a/__tests__/shared/keyManager.ts
+++ b/__tests__/shared/keyManager.ts
@@ -598,7 +598,28 @@ export default (testContext: {
       expect(address.toLowerCase()).toEqual(recovered)
     })
 
+    it('should sign keccak hash with eth_rawSign', async () => {
+      const importedKey = {
+        kid: 'imported_raw',
+        kms: 'local',
+        type: <TKeyType>'Secp256k1',
+        publicKeyHex:
+          '04155ee0cbefeecd80de63a62b4ed8f0f97ac22a58f76a265903b9acab79bf018c7037e2bd897812170c92a4c978d6a10481491a37299d74c4bd412a111a4ac875',
+        privateKeyHex: '31d1ec15ff8110442012fef0d1af918c0e09b2e2ab821bba52ecc85f8655ec63',
+      }
+
+      const key = await agent.keyManagerImport(importedKey)
+
+      const signature = await agent.keyManagerSign({
+        algorithm: 'eth_rawSign',
+        data: '9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658',
+        encoding: 'hex',
+        keyRef: key.kid,
+      })
+
+      expect(signature).toEqual(
+        '0x9d9e6c705cfa5f348de0c5174e70234c3b372d6bfca05fd11ffc5fe46eab996a3e4780d403b611395fd8548f2b101c3542c5e43848e486ea238da18fe0ffe6d0',
+      )
+    })
   })
-
-
 }

--- a/packages/did-provider-ethr/package.json
+++ b/packages/did-provider-ethr/package.json
@@ -19,7 +19,7 @@
     "@veramo/core": "^4.0.0",
     "@veramo/did-manager": "^4.0.0",
     "debug": "^4.3.3",
-    "ethr-did": "^2.2.4"
+    "ethr-did": "^2.3.0"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",

--- a/packages/kms-local/package.json
+++ b/packages/kms-local/package.json
@@ -23,7 +23,8 @@
     "base-58": "^0.0.1",
     "debug": "^4.3.3",
     "did-jwt": "^6.6.0",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^3.0.0",
+    "ethers": "^5.7.1"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",

--- a/packages/kms-local/src/key-management-system.ts
+++ b/packages/kms-local/src/key-management-system.ts
@@ -130,6 +130,8 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
         return await this.eth_signMessage(managedKey.privateKeyHex, data)
       } else if (['eth_signTypedData', 'EthereumEip712Signature2021'].includes(algorithm)) {
         return await this.eth_signTypedData(managedKey.privateKeyHex, data)
+      } else if (['eth_rawSign'].includes(algorithm)) {
+        return new SigningKey("0x" + managedKey.privateKeyHex).signDigest(data).compact
       }
     }
     throw Error(`not_supported: Cannot sign ${algorithm} using key of type ${managedKey.type}`)


### PR DESCRIPTION
This PR adds support for sending transactions on behalf of another did:ethr.  

This is archived via updates to the underlying dependencies https://github.com/uport-project/ethr-did & https://github.com/decentralized-identity/ethr-did-resolver. 

To keep abstraction intact, this behavior may be triggered by passing a `metaIdentifier` to a didManager action which is picked up by the `did-provider-ethr`. If a metaIdentifier is present the underlying controller is passed this identifier as a signer which then signs and pays for the transactions. 

The methods `addKey` & `addService` now detect this presence as well and prepare the transaction differently then. 
Overall we tried to keep changes to other plugins as minimal as possible. 

Some todo'ish items: 

- Right now only addKey and addService have meta capabilities. `changeOwner` and `addDelegate` are NOT implemented yet. @mirceanis - Not sure how to tackle this with the current AbstractIdentifierProvider. We would have to put these actions into the `updateIdentifier` method. But with the current abstraction the did-provider-ethr would receive a didDocument there. Not sure how to proceed here with a good approach. 
We could change the abstract signature of `updateIdentifier` to something more easily hand-able (like actions being passed down or something). 

- We had to introduce a new 'algorithm' to the kms-local provider. All other existing options for creating eth signatures either modify the input data, or hash it again. We just need clean digest with the `r, s and v` params easily accessible afterwards. 

- The tests for the did-provider-ethr changes will fail as i am awaiting an update to ethr-did which fixes an encoding bug we found.

- After some testing and fiddling around we also noticed that if this package does not pass any options down to did-ethr some defaults for transactions will be chosen, which could result in the transaction failing. Gaslimit and Gasprice are always overridden as defaults. AFAIK if etherjs is not passed anything it will make a best guess for determining these parameters. 