### PR TITLE
fix: prettier command didn't work anymore (globbing issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "yarn test --watch --verbose",
     "test:browser": "cd packages/test-react-app && yarn test:browser",
     "veramo": "cross-env ./packages/cli/bin/veramo.js",
-    "prettier": "prettier --write '{packages,docs,__tests__,!build}/**/*.{ts,js,json,md,yml}'",
+    "prettier": "prettier --write \"{packages,docs,__tests__,!build}/**/*.{ts,js,json,md,yml}\"",
     "build-clean": "rimraf ./packages/*/build ./packages/*/api ./packages/*/node_modules ./packages/*/tsconfig.tsbuildinfo && jest --clearCache",
     "publish:latest": "lerna publish --conventional-commits --include-merged-tags --create-release github --yes --dist-tag latest --registry https://registry.npmjs.org/:_authToken=${NPM_TOKEN}",
     "publish:next": "lerna publish --conventional-prerelease --force-publish --canary --no-git-tag-version --include-merged-tags --preid next --pre-dist-tag next --yes --registry https://registry.npmjs.org/:_authToken=${NPM_TOKEN}",


### PR DESCRIPTION
## What issue is this PR fixing
The prettier command used single punctuation marks ('), meaning globbing will not work, so replacing them with escaped double quotes (\") within the command solves the issue
## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [ ] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [x] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

## Details
If applicable, add screen captures, error messages or stack traces to help explain your problem.
