### PR TITLE
chore(build): fix newline in inline docs causing website build failures

### DIFF
--- a/packages/core/src/types/IDIDManager.ts
+++ b/packages/core/src/types/IDIDManager.ts
@@ -289,8 +289,8 @@ export interface IDIDManager extends IPluginMethodMap {
    * Creates and returns a new identifier
    *
    * @param args - Required. Arguments to create the identifier
-   * @param context - *RESERVED* This is filled by the framework when the method is called. This method's <a
-   *   href="/docs/agent/plugins#executing-plugin-methods">Execution context</a> requires an `agent` that has
+   * @param context - *RESERVED* This is filled by the framework when the method is called. This method's
+   *    <a href="/docs/agent/plugins#executing-plugin-methods">execution context</a> requires an `agent` that has
    *   {@link @veramo/core#IKeyManager} methods.
    *
    * @example
@@ -324,9 +324,10 @@ export interface IDIDManager extends IPluginMethodMap {
 
   /**
    * Returns an existing identifier or creates a new one for a specific alias
-   * @param args - The alias used for the search and the provider/kms/options used to create the DID when none is found.
-   * @param context - *RESERVED* This is filled by the framework when the method is called. This method's <a
-   *   href="/docs/agent/plugins#executing-plugin-methods">execution context</a> requires an `agent` that has
+   * @param args - The alias used for the search and the provider/kms/options used to create the DID when none is
+   *   found.
+   * @param context - *RESERVED* This is filled by the framework when the method is called. This method's
+   *    <a href="/docs/agent/plugins#executing-plugin-methods">execution context</a> requires an `agent` that has
    *   {@link @veramo/core#IKeyManager} methods.
    */
   didManagerGetOrCreate(
@@ -337,8 +338,8 @@ export interface IDIDManager extends IPluginMethodMap {
   /**
    * Updates the DID document of a managed {@link @veramo/core#IIdentifier | DID}.
    * @param args - the arguments necessary for the update. The options are specific for each DID provider.
-   * @param context - *RESERVED* This is filled by the framework when the method is called. This method's <a
-   *   href="/docs/agent/plugins#executing-plugin-methods">execution context</a> requires an `agent` that has
+   * @param context - *RESERVED* This is filled by the framework when the method is called. This method's
+   *   <a href="/docs/agent/plugins#executing-plugin-methods">execution context</a> requires an `agent` that has
    *   {@link @veramo/core#IKeyManager} methods.
    */
   didManagerUpdate(args: IDIDManagerUpdateArgs, context: IAgentContext<IKeyManager>): Promise<IIdentifier>

--- a/scripts/docs-build.ts
+++ b/scripts/docs-build.ts
@@ -85,8 +85,11 @@ async function main() {
       input.close()
 
       const header = ['---', `id: ${id}`, `title: ${title}`, `hide_title: true`, '---']
+      let outputString = header.concat(output).join('\n')
 
-      await writeFile(docPath, header.concat(output).join('\n'))
+      outputString = outputString.replace(/<a\nhref=/g, '<a href=')
+
+      await writeFile(docPath, outputString)
     } catch (err) {
       console.error(`Could not process ${docFile}: ${err}`)
     }


### PR DESCRIPTION
## What issue is this PR fixing

A newline in the inline documentation is causing the automatic deployment of the website to fail.
https://github.com/uport-project/veramo-website/actions/runs/3364937894/jobs/5579863804

## What is being changed
This PR fixes the errant newline and also adds a patch to the documentation processing script to prevent this from repeating.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because this is only a docs and tooling change.