### PR TITLE
Nickreynolds/verify jwt

### DIFF
--- a/packages/credential-w3c/package.json
+++ b/packages/credential-w3c/package.json
@@ -14,6 +14,7 @@
     "@veramo/did-resolver": "^4.1.1",
     "@veramo/message-handler": "^4.1.1",
     "@veramo/utils": "^4.1.1",
+    "canonicalize": "^1.0.8",
     "debug": "^4.3.3",
     "did-jwt-vc": "^3.1.0",
     "did-resolver": "^4.0.1",

--- a/packages/credential-w3c/src/__tests__/issue-verify-flow.test.ts
+++ b/packages/credential-w3c/src/__tests__/issue-verify-flow.test.ts
@@ -101,7 +101,26 @@ describe('credential-w3c full flow', () => {
     expect(response.verified).toBe(true)
   })
 
-  it.only('fails the verification of an expired credential', async () => {
+  it('fails the verification of a jwt credential with false value outside of proof', async () => {
+    const credential: CredentialPayload = {
+      issuer: didKeyIdentifier.did,
+      '@context': ['custom:example.context'],
+      credentialSubject: {
+        nothing: 'else matters',
+      },
+    }
+    const verifiableCredential1 = await agent.createVerifiableCredential({
+      credential,
+      proofFormat: 'jwt',
+    })
+
+    const modifiedCred = { ...verifiableCredential1, issuer: { id: 'fake' }}
+    const verifyResult = await agent.verifyCredential({ credential: modifiedCred })
+
+    expect(verifyResult.verified).toBeFalsy()
+  })
+
+  it('fails the verification of an expired credential', async () => {
     const presentationJWT =
       'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NjAyOTcyMTAsInZwIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJdLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6WyJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSjkuZXlKbGVIQWlPakUyTmpBeU9UY3lNVEFzSW5aaklqcDdJa0JqYjI1MFpYaDBJanBiSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk4eU1ERTRMMk55WldSbGJuUnBZV3h6TDNZeElpd2lZM1Z6ZEc5dE9tVjRZVzF3YkdVdVkyOXVkR1Y0ZENKZExDSjBlWEJsSWpwYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJbDBzSW1OeVpXUmxiblJwWVd4VGRXSnFaV04wSWpwN0ltNXZkR2hwYm1jaU9pSmxiSE5sSUcxaGRIUmxjbk1pZlgwc0ltNWlaaUk2TVRZMk1ESTVOekl4TUN3aWFYTnpJam9pWkdsa09tdGxlVHA2TmsxcmFWVTNVbk5hVnpOeWFXVmxRMjg1U25OMVVEUnpRWEZYZFdGRE0zbGhjbWwxWVZCMlVXcHRZVzVsWTFBaWZRLkZhdzBEUWNNdXpacEVkcy1LR3dOalMyM2IzbUEzZFhQWXBQcGJzNmRVSnhIOVBrZzVieGF3UDVwMlNPajdQM25IdEpCR3lwTjJ3NzRfZjc3SjF5dUJ3Il19LCJuYmYiOjE2NjAyOTcyMTAsImlzcyI6ImRpZDprZXk6ejZNa2lVN1JzWlczcmllZUNvOUpzdVA0c0FxV3VhQzN5YXJpdWFQdlFqbWFuZWNQIn0.YcYbyqVlD8YsTjVw0kCEs0P_ie6SFMakf_ncPntEjsmS9C4cKyiS50ZhNkOv0R3Roy1NrzX7h93WBU55KeJlCw'
 

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -299,7 +299,7 @@ export class CredentialPlugin implements IAgentPlugin {
 
           if(canonicalize(credentialCopy) !== canonicalize(verifiedCopy)) {
             verificationResult.verified = false
-            verificationResult.error = new Error('Credential does not match JWT signature')
+            verificationResult.error = new Error('Credential does not match JWT')
           }
         }
       } catch (e: any) {

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -41,6 +41,8 @@ import {
 import Debug from 'debug'
 import { Resolvable } from 'did-resolver'
 
+import canonicalize from 'canonicalize'
+
 const enum DocumentFormat {
   JWT,
   JSONLD,
@@ -274,6 +276,7 @@ export class CredentialPlugin implements IAgentPlugin {
 
       const resolver = { resolve: (didUrl: string) => context.agent.resolveDid({ didUrl }) } as Resolvable
       try {
+        // needs broader credential as well to check equivalence with jwt
         verificationResult = await verifyCredentialJWT(jwt, resolver, {
           ...otherOptions,
           policies: {
@@ -285,6 +288,20 @@ export class CredentialPlugin implements IAgentPlugin {
           },
         })
         verifiedCredential = verificationResult.verifiableCredential
+
+        // if credential was presented with other fields, make sure those fields match what's in the JWT
+        if (!(typeof credential === 'string')) {
+          const credentialCopy = JSON.parse(JSON.stringify(credential))
+          delete credentialCopy.proof.jwt
+
+          const verifiedCopy = JSON.parse(JSON.stringify(verifiedCredential))
+          delete verifiedCopy.proof.jwt
+
+          if(canonicalize(credentialCopy) !== canonicalize(verifiedCopy)) {
+            verificationResult.verified = false
+            verificationResult.error = new Error('Credential does not match JWT signature')
+          }
+        }
       } catch (e: any) {
         let { message, errorCode } = e
         return {

--- a/packages/did-provider-ion/package.json
+++ b/packages/did-provider-ion/package.json
@@ -19,6 +19,7 @@
     "@veramo/key-manager": "^4.1.1",
     "@veramo/kms-local": "^4.1.1",
     "base64url": "^3.0.1",
+    "canonicalize": "^1.0.8",
     "debug": "^4.3.3",
     "uint8arrays": "^3.0.0"
   },


### PR DESCRIPTION
## What issue is this PR fixing

`fixes #1070 `

## What is being changed

Update the `verifyCredential` function to check the other fields present in the credential object, to ensure they match what's in the JWT. Previously, only the `credential.proof.jwt` itself was verified.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [X] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

