### PR TITLE
feat(remote-server): use 2020 key types in web did doc router

### DIFF
--- a/packages/credential-ld/src/__tests__/issue-verify-ed25519-2020.test.ts
+++ b/packages/credential-ld/src/__tests__/issue-verify-ed25519-2020.test.ts
@@ -1,0 +1,145 @@
+import {
+    createAgent,
+    CredentialPayload,
+    ICredentialPlugin,
+    IDIDManager,
+    IIdentifier,
+    IKeyManager,
+    IResolver,
+    TAgent,
+  } from '../../../core/src'
+  import { CredentialPlugin } from '../../../credential-w3c/src'
+  import { DIDManager, MemoryDIDStore } from '../../../did-manager/src'
+  import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-manager/src'
+  import { KeyManagementSystem } from '../../../kms-local/src'
+  import { DIDResolverPlugin } from '../../../did-resolver/src'
+  import { ContextDoc } from '../types'
+  import { CredentialIssuerLD } from '../action-handler'
+  import { LdDefaultContexts } from '../ld-default-contexts'
+  import { VeramoEd25519Signature2020 } from '../suites/Ed25519Signature2020'
+  import { Resolver } from 'did-resolver'
+  import { FakeDidProvider, FakeDidResolver } from '../../../test-utils/src/fake-did'
+  import { jest } from '@jest/globals'
+  
+  jest.setTimeout(300000)
+  
+  const customContext: Record<string, ContextDoc> = {
+    'custom:example.context': {
+      '@context': {
+        nothing: 'custom:example.context#blank',
+      },
+    },
+  }
+  
+  describe('credential-LD full flow', () => {
+    let didFakeIdentifier: IIdentifier
+    let agent: TAgent<IResolver & IKeyManager & IDIDManager & ICredentialPlugin>
+  
+    beforeAll(async () => {
+      agent = createAgent({
+        plugins: [
+          new KeyManager({
+            store: new MemoryKeyStore(),
+            kms: {
+              local: new KeyManagementSystem(new MemoryPrivateKeyStore()),
+            },
+          }),
+          new DIDManager({
+            providers: {
+              'did:fake': new FakeDidProvider(),
+            },
+            store: new MemoryDIDStore(),
+            defaultProvider: 'did:fake',
+          }),
+          new DIDResolverPlugin({
+            resolver: new Resolver({
+              ...new FakeDidResolver(() => agent, true).getDidFakeResolver(),
+            }),
+          }),
+          new CredentialPlugin(),
+          new CredentialIssuerLD({
+            contextMaps: [LdDefaultContexts, customContext],
+            suites: [new VeramoEd25519Signature2020()],
+          }),
+        ],
+      })
+      didFakeIdentifier = await agent.didManagerImport({
+        did: 'did:fake:z6MkgbqNU4uF9NKSz5BqJQ4XKVHuQZYcUZP8pXGsJC8nTHwo',
+        keys: [
+          {
+            type: 'Ed25519',
+            kid: 'didcomm-senderKey-1',
+            publicKeyHex: '1fe9b397c196ab33549041b29cf93be29b9f2bdd27322f05844112fad97ff92a',
+            privateKeyHex:
+              'b57103882f7c66512dc96777cbafbeb2d48eca1e7a867f5a17a84e9a6740f7dc1fe9b397c196ab33549041b29cf93be29b9f2bdd27322f05844112fad97ff92a',
+            kms: 'local',
+          },
+        ],
+        services: [
+          {
+            id: 'msg1',
+            type: 'DIDCommMessaging',
+            serviceEndpoint: 'http://localhost:3002/messaging',
+          },
+        ],
+        provider: 'did:fake',
+        alias: 'sender',
+      })
+    })
+  
+    it('works with Ed25519Signature2020 credential', async () => {
+      const credential: CredentialPayload = {
+        issuer: didFakeIdentifier.did,
+        '@context': ['custom:example.context'],
+        credentialSubject: {
+          nothing: 'else matters',
+        },
+      }
+      const verifiableCredential = await agent.createVerifiableCredential({
+        credential,
+        proofFormat: 'lds',
+      })
+  
+      expect(verifiableCredential).toBeDefined()
+      console.log("verifiableCredential: ", verifiableCredential)
+  
+      const result = await agent.verifyCredential({
+        credential: verifiableCredential,
+      })
+      console.log("result: ", result)
+  
+      expect(result.verified).toBe(true)
+    })
+  
+    it('works with Ed25519Signature2020 credential and presentation', async () => {
+      const credential: CredentialPayload = {
+        issuer: didFakeIdentifier.did,
+        '@context': ['custom:example.context'],
+        credentialSubject: {
+          nothing: 'else matters',
+        },
+      }
+      const verifiableCredential1 = await agent.createVerifiableCredential({
+        credential,
+        proofFormat: 'lds',
+      })
+  
+      const verifiablePresentation = await agent.createVerifiablePresentation({
+        presentation: {
+          verifiableCredential: [verifiableCredential1],
+          holder: didFakeIdentifier.did,
+        },
+        challenge: 'VERAMO',
+        proofFormat: 'lds',
+      })
+  
+      expect(verifiablePresentation).toBeDefined()
+  
+      const result = await agent.verifyPresentation({
+        presentation: verifiablePresentation,
+        challenge: 'VERAMO',
+      })
+  
+      expect(result.verified).toBe(true)
+    })
+  })

--- a/packages/credential-ld/src/ld-credential-module.ts
+++ b/packages/credential-ld/src/ld-credential-module.ts
@@ -149,6 +149,10 @@ export class LdCredentialModule {
     options: any,
     context: IAgentContext<IResolver>,
   ): Promise<boolean> {
+    const allSuites = this.ldSuiteLoader.getAllSignatureSuites()
+    console.log("allSuites: ", allSuites)
+    const mappedSuites = allSuites.map((x) => x.getSuiteForVerification())
+    console.log("mappedSuites: ", mappedSuites)
     const result = await vc.verifyCredential({
       ...options,
       credential,

--- a/packages/credential-ld/src/suites/Ed25519Signature2020.ts
+++ b/packages/credential-ld/src/suites/Ed25519Signature2020.ts
@@ -3,6 +3,7 @@ import { CredentialPayload, DIDDocument, IAgentContext, IKey, TKeyType } from '@
 import * as u8a from 'uint8arrays'
 import { Ed25519Signature2020 } from '@digitalcredentials/ed25519-signature-2020'
 import { Ed25519VerificationKey2020 } from '@digitalcredentials/ed25519-verification-key-2020'
+import { hexToMultibase } from '@veramo/utils'
 
 /**
  * Veramo wrapper for the Ed25519Signature2020 suite by digitalcredentials
@@ -10,8 +11,6 @@ import { Ed25519VerificationKey2020 } from '@digitalcredentials/ed25519-verifica
  * @alpha This API is experimental and is very likely to change or disappear in future releases without notice.
  */
 export class VeramoEd25519Signature2020 extends VeramoLdSignature {
-  private readonly MULTIBASE_BASE58BTC_PREFIX = 'z'
-  private readonly MULTICODEC_PREFIX = [0xed, 0x01]
 
   getSupportedVerificationType(): string {
     return 'Ed25519VerificationKey2020'
@@ -48,7 +47,7 @@ export class VeramoEd25519Signature2020 extends VeramoLdSignature {
     const verificationKey = new Ed25519VerificationKey2020({
       id,
       controller,
-      publicKeyMultibase: this.preSigningKeyModification(u8a.fromString(key.publicKeyHex, 'hex')),
+      publicKeyMultibase: hexToMultibase(key.publicKeyHex),
       // signer: () => signer,
       // type: this.getSupportedVerificationType(),
     })
@@ -71,10 +70,5 @@ export class VeramoEd25519Signature2020 extends VeramoLdSignature {
 
   preDidResolutionModification(didUrl: string, didDoc: DIDDocument): void {
     // nothing to do here
-  }
-
-  preSigningKeyModification(key: Uint8Array): string {
-    const modifiedKey = u8a.concat([this.MULTICODEC_PREFIX, key])
-    return `${this.MULTIBASE_BASE58BTC_PREFIX}${u8a.toString(modifiedKey, 'base58btc')}`
   }
 }

--- a/packages/remote-server/package.json
+++ b/packages/remote-server/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@veramo/core-types": "^5.1.2",
-    "@veramo/remote-client": "^5.1.2",
+    "@veramo/remote-client": "^5.1.2",    
+    "@veramo/utils": "^5.1.2",
     "debug": "^4.3.3",
     "did-resolver": "^4.0.1",
     "express": "^4.18.2",

--- a/packages/remote-server/src/web-did-doc-router.ts
+++ b/packages/remote-server/src/web-did-doc-router.ts
@@ -1,6 +1,7 @@
 import { IIdentifier, IDIDManager, TAgent, TKeyType } from '@veramo/core-types'
 import { Request, Router } from 'express'
 import { ServiceEndpoint } from 'did-resolver'
+import { hexToMultibase } from '@veramo/utils'
 
 interface RequestWithAgentDIDManager extends Request {
   agent?: TAgent<IDIDManager>
@@ -15,9 +16,9 @@ export const didDocEndpoint = '/.well-known/did.json'
 
 const keyMapping: Record<TKeyType, string> = {
   Secp256k1: 'EcdsaSecp256k1VerificationKey2019',
-  Secp256r1: 'EcdsaSecp256r1VerificationKey2019',
-  Ed25519: 'Ed25519VerificationKey2018',
-  X25519: 'X25519KeyAgreementKey2019',
+  Secp256r1: 'EcdsaSecp256r1VerificationKey2019',  
+  Ed25519: 'Ed25519VerificationKey2020',
+  X25519: 'X25519KeyAgreementKey2020',
   Bls12381G1: 'Bls12381G1Key2020',
   Bls12381G2: 'Bls12381G2Key2020',
 }
@@ -44,15 +45,15 @@ export const WebDidDocRouter = (options: WebDidDocRouterOptions): Router => {
     const allKeys = identifier.keys.map((key) => ({
       id: identifier.did + '#' + key.kid,
       type: keyMapping[key.type],
-      controller: identifier.did,
-      publicKeyHex: key.publicKeyHex,
+      controller: identifier.did,      
+      publicKeyMultibase: hexToMultibase(key.publicKeyHex),
     }))
     // ed25519 keys can also be converted to x25519 for key agreement
     const keyAgreementKeyIds = allKeys
-      .filter((key) => ['Ed25519VerificationKey2018', 'X25519KeyAgreementKey2019'].includes(key.type))
+      .filter((key) => ['Ed25519VerificationKey2020', 'X25519KeyAgreementKey2020'].includes(key.type))
       .map((key) => key.id)
     const signingKeyIds = allKeys
-      .filter((key) => key.type !== 'X25519KeyAgreementKey2019')
+      .filter((key) => key.type !== 'X25519KeyAgreementKey2020')
       .map((key) => key.id)
 
     const didDoc = {

--- a/packages/test-utils/src/fake-did.ts
+++ b/packages/test-utils/src/fake-did.ts
@@ -88,10 +88,12 @@ export class FakeDidProvider extends AbstractIdentifierProvider {
 }
 
 export class FakeDidResolver {
-  getAgent: () => TAgent<IDIDManager>
+  getAgent: () => TAgent<IDIDManager>  
+  private force2020: boolean
 
-  constructor(getAgent: () => TAgent<IDIDManager>) {
-    this.getAgent = getAgent
+  constructor(getAgent: () => TAgent<IDIDManager>, force2020: boolean = false) {
+    this.getAgent = getAgent    
+    this.force2020 = force2020
   }
 
   resolveFakeDid: DIDResolver = async (
@@ -111,10 +113,10 @@ export class FakeDidResolver {
             vm.type = 'EcdsaSecp256k1VerificationKey2019'
             break
           case 'Ed25519':
-            vm.type = 'Ed25519VerificationKey2018'
+            vm.type = this.force2020 ? 'Ed25519VerificationKey2020' : 'Ed25519VerificationKey2018'
             break
           case 'X25519':
-            vm.type = 'X25519KeyAgreementKey2019'
+            vm.type = this.force2020 ? 'X25519KeyAgreementKey2020' :'X25519KeyAgreementKey2019'
             break
           default:
             break

--- a/packages/utils/src/encodings.ts
+++ b/packages/utils/src/encodings.ts
@@ -143,3 +143,19 @@ export function base58ToBytes(s: string): Uint8Array {
 export function bytesToBase58(byteArray: Uint8Array): string {
   return u8a.toString(byteArray, 'base58btc')
 }
+
+export const MULTIBASE_BASE58BTC_PREFIX = 'z'
+export const MULTICODEC_PREFIX = [0xed, 0x01]
+
+/**
+ * Converts a hex string to the multibase representation
+ * 
+ * @param hexString the string to be converted
+ * 
+ * @public 
+ */
+export function hexToMultibase(hexString: string): string {
+  const hexBytes = u8a.fromString(hexString, 'hex')
+  const modifiedKey = u8a.concat([MULTICODEC_PREFIX, hexBytes])
+  return `${MULTIBASE_BASE58BTC_PREFIX}${u8a.toString(modifiedKey, 'base58btc')}`
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,29 +179,29 @@ importers:
       '@transmute/credentials-context': 0.7.0-unstable.79
       '@types/blessed': 0.1.19
       '@types/swagger-ui-express': 4.1.3
-      '@veramo/core': 5.1.2
-      '@veramo/core-types': 5.1.2
-      '@veramo/credential-eip712': 5.1.2
-      '@veramo/credential-ld': 5.1.2
-      '@veramo/credential-w3c': 5.1.2
-      '@veramo/data-store': 5.1.2_pg@8.8.0+sqlite3@5.1.4
-      '@veramo/did-comm': 5.1.2
-      '@veramo/did-discovery': 5.1.2
-      '@veramo/did-jwt': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/did-provider-ethr': 5.1.2
-      '@veramo/did-provider-key': 5.1.2
-      '@veramo/did-provider-pkh': 5.1.2
-      '@veramo/did-provider-web': 5.1.2
-      '@veramo/did-resolver': 5.1.2
-      '@veramo/key-manager': 5.1.2
-      '@veramo/kms-local': 5.1.2
-      '@veramo/message-handler': 5.1.2
-      '@veramo/remote-client': 5.1.2
-      '@veramo/remote-server': 5.1.2_express@4.18.2
-      '@veramo/selective-disclosure': 5.1.2
-      '@veramo/url-handler': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core': link:../core
+      '@veramo/core-types': link:../core-types
+      '@veramo/credential-eip712': link:../credential-eip712
+      '@veramo/credential-ld': link:../credential-ld
+      '@veramo/credential-w3c': link:../credential-w3c
+      '@veramo/data-store': link:../data-store
+      '@veramo/did-comm': link:../did-comm
+      '@veramo/did-discovery': link:../did-discovery
+      '@veramo/did-jwt': link:../did-jwt
+      '@veramo/did-manager': link:../did-manager
+      '@veramo/did-provider-ethr': link:../did-provider-ethr
+      '@veramo/did-provider-key': link:../did-provider-key
+      '@veramo/did-provider-pkh': link:../did-provider-pkh
+      '@veramo/did-provider-web': link:../did-provider-web
+      '@veramo/did-resolver': link:../did-resolver
+      '@veramo/key-manager': link:../key-manager
+      '@veramo/kms-local': link:../kms-local
+      '@veramo/message-handler': link:../message-handler
+      '@veramo/remote-client': link:../remote-client
+      '@veramo/remote-server': link:../remote-server
+      '@veramo/selective-disclosure': link:../selective-disclosure
+      '@veramo/url-handler': link:../url-handler
+      '@veramo/utils': link:../utils
       blessed: 0.1.81
       commander: 10.0.0
       console-table-printer: 2.11.1
@@ -254,7 +254,7 @@ importers:
       typescript: 4.9.4
       z-schema: ^5.0.5
     dependencies:
-      '@veramo/core-types': 5.1.2
+      '@veramo/core-types': link:../core-types
       debug: 4.3.4
       events: 3.3.0
       z-schema: 5.0.5
@@ -290,8 +290,8 @@ importers:
       typescript: 4.9.4
     dependencies:
       '@metamask/eth-sig-util': 5.0.2
-      '@veramo/core-types': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/utils': link:../utils
       debug: 4.3.4
       eip-712-types-generation: 0.1.6
     devDependencies:
@@ -328,8 +328,8 @@ importers:
       '@transmute/ed25519-signature-2018': 0.7.0-unstable.79
       '@transmute/json-web-signature': 0.7.0-unstable.79
       '@veramo-community/lds-ecdsa-secp256k1-recovery2020': github.com/uport-project/EcdsaSecp256k1RecoverySignature2020/ab0db52de6f4e6663ef271a48009ba26e688ef9b
-      '@veramo/core-types': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/utils': link:../utils
       cross-fetch: 3.1.5
       debug: 4.3.4
       did-resolver: 4.0.1
@@ -349,8 +349,8 @@ importers:
       did-resolver: ^4.0.1
       typescript: 4.9.4
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/utils': link:../utils
       credential-status: 2.0.5
       did-jwt: 6.11.0
       did-resolver: 4.0.1
@@ -375,9 +375,9 @@ importers:
       uint8arrays: ^3.0.0
       uuid: ^9.0.0
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/message-handler': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/message-handler': link:../message-handler
+      '@veramo/utils': link:../utils
       canonicalize: 1.0.8
       debug: 4.3.4
       did-jwt: 6.11.0
@@ -386,7 +386,7 @@ importers:
       uint8arrays: 3.1.1
       uuid: 9.0.0
     optionalDependencies:
-      '@veramo/credential-ld': 5.1.2
+      '@veramo/credential-ld': link:../credential-ld
     devDependencies:
       '@types/debug': 4.1.7
       '@types/uuid': 9.0.0
@@ -408,11 +408,11 @@ importers:
       typescript: 4.9.4
       uuid: ^9.0.0
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-discovery': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/key-manager': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/did-discovery': link:../did-discovery
+      '@veramo/did-manager': link:../did-manager
+      '@veramo/key-manager': link:../key-manager
+      '@veramo/utils': link:../utils
       debug: 4.3.4
       did-jwt-vc: 3.1.0
       typeorm: 0.3.11_sqlite3@5.1.4
@@ -439,10 +439,10 @@ importers:
       uuid: ^9.0.0
     dependencies:
       '@ungap/structured-clone': 1.0.1
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/key-manager': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/did-manager': link:../did-manager
+      '@veramo/key-manager': link:../key-manager
+      '@veramo/utils': link:../utils
       debug: 4.3.4
       did-jwt-vc: 3.1.0
       uuid: 9.0.0
@@ -471,9 +471,9 @@ importers:
     dependencies:
       '@ethersproject/signing-key': 5.7.0
       '@stablelib/ed25519': 1.0.3
-      '@veramo/core-types': 5.1.2
-      '@veramo/message-handler': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/message-handler': link:../message-handler
+      '@veramo/utils': link:../utils
       cross-fetch: 3.1.5
       debug: 4.3.4
       did-jwt: 6.11.0
@@ -492,7 +492,7 @@ importers:
       debug: ^4.3.3
       typescript: 4.9.4
     dependencies:
-      '@veramo/core-types': 5.1.2
+      '@veramo/core-types': link:../core-types
       debug: 4.3.4
     devDependencies:
       '@types/debug': 4.1.7
@@ -508,8 +508,8 @@ importers:
       did-resolver: ^4.0.1
       typescript: 4.9.4
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/message-handler': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/message-handler': link:../message-handler
       debug: 4.3.4
       did-jwt: 6.11.0
       did-resolver: 4.0.1
@@ -523,8 +523,8 @@ importers:
       '@veramo/did-discovery': ^5.1.2
       typescript: 4.9.4
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-discovery': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/did-discovery': link:../did-discovery
     devDependencies:
       typescript: 4.9.4
 
@@ -555,8 +555,8 @@ importers:
       '@ethersproject/providers': 5.7.2
       '@ethersproject/signing-key': 5.7.0
       '@ethersproject/transactions': 5.7.0
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/did-manager': link:../did-manager
       debug: 4.3.4
       ethr-did: 2.3.6
     devDependencies:
@@ -594,10 +594,10 @@ importers:
       '@stablelib/ed25519': 1.0.3
       '@stablelib/sha256': 1.0.1
       '@trust/keyto': 1.0.1
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/key-manager': 5.1.2
-      '@veramo/kms-local': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/did-manager': link:../did-manager
+      '@veramo/key-manager': link:../key-manager
+      '@veramo/kms-local': link:../kms-local
       canonicalize: 1.0.8
       cross-fetch: 3.1.5
       debug: 4.3.4
@@ -620,9 +620,9 @@ importers:
       elliptic: ^6.5.4
       typescript: 4.9.4
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/did-manager': link:../did-manager
+      '@veramo/utils': link:../utils
       debug: 4.3.4
       did-resolver: 4.0.1
       elliptic: 6.5.4
@@ -648,8 +648,8 @@ importers:
       '@transmute/did-key-ed25519': 0.3.0-unstable.10
       '@transmute/did-key-secp256k1': 0.3.0-unstable.10
       '@transmute/did-key-x25519': 0.3.0-unstable.10
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/did-manager': link:../did-manager
       debug: 4.3.4
       did-resolver: 4.0.1
       multibase: 4.0.6
@@ -676,8 +676,8 @@ importers:
       '@ethersproject/bignumber': 5.7.0
       '@ethersproject/signing-key': 5.7.0
       '@ethersproject/transactions': 5.7.0
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/did-manager': link:../did-manager
       caip: 1.1.0
       debug: 4.3.4
       did-resolver: 4.0.1
@@ -693,8 +693,8 @@ importers:
       debug: ^4.3.3
       typescript: 4.9.4
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/did-manager': link:../did-manager
       debug: 4.3.4
     devDependencies:
       '@types/debug': 4.1.7
@@ -712,8 +712,8 @@ importers:
       typescript: 4.9.4
       web-did-resolver: ^2.0.21
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/utils': link:../utils
       cross-fetch: 3.1.5
       debug: 4.3.4
       did-resolver: 4.0.1
@@ -743,7 +743,7 @@ importers:
       '@ethersproject/strings': 5.7.0
       '@ethersproject/transactions': 5.7.0
       '@stablelib/ed25519': 1.0.3
-      '@veramo/core-types': 5.1.2
+      '@veramo/core-types': link:../core-types
       debug: 4.3.4
       did-jwt: 6.11.0
       uint8arrays: 3.1.1
@@ -789,8 +789,8 @@ importers:
       '@stablelib/nacl': 1.0.4
       '@stablelib/random': 1.0.2
       '@stablelib/x25519': 1.0.3
-      '@veramo/core-types': 5.1.2
-      '@veramo/key-manager': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/key-manager': link:../key-manager
       base-58: 0.0.1
       debug: 4.3.4
       did-jwt: 6.11.0
@@ -815,8 +815,8 @@ importers:
       '@ethersproject/providers': 5.7.2
       '@ethersproject/strings': 5.7.0
       '@ethersproject/transactions': 5.7.0
-      '@veramo/core-types': 5.1.2
-      '@veramo/key-manager': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/key-manager': link:../key-manager
       debug: 4.3.4
     devDependencies:
       '@types/debug': 4.1.7
@@ -829,7 +829,7 @@ importers:
       debug: ^4.3.4
       typescript: 4.9.4
     dependencies:
-      '@veramo/core-types': 5.1.2
+      '@veramo/core-types': link:../core-types
       debug: 4.3.4
     devDependencies:
       '@types/debug': 4.1.7
@@ -844,7 +844,7 @@ importers:
       openapi-types: 12.1.0
       typescript: 4.9.4
     dependencies:
-      '@veramo/core-types': 5.1.2
+      '@veramo/core-types': link:../core-types
       cross-fetch: 3.1.5
       debug: 4.3.4
       openapi-types: 12.1.0
@@ -861,6 +861,7 @@ importers:
       '@types/url-parse': 1.4.8
       '@veramo/core-types': ^5.1.2
       '@veramo/remote-client': ^5.1.2
+      '@veramo/utils': ^5.1.2
       debug: ^4.3.3
       did-resolver: ^4.0.1
       express: ^4.18.2
@@ -869,8 +870,9 @@ importers:
       typescript: 4.9.4
       url-parse: ^1.5.4
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/remote-client': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/remote-client': link:../remote-client
+      '@veramo/utils': link:../utils
       debug: 4.3.4
       did-resolver: 4.0.1
       express: 4.18.2
@@ -897,9 +899,9 @@ importers:
       typescript: 4.9.4
       uuid: ^9.0.0
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/message-handler': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/message-handler': link:../message-handler
+      '@veramo/utils': link:../utils
       debug: 4.3.4
       did-jwt: 6.11.0
       uuid: 9.0.0
@@ -969,29 +971,29 @@ importers:
       web-did-resolver: ^2.0.21
       web-vitals: ^3.1.1
     dependencies:
-      '@veramo/core': 5.1.2
-      '@veramo/core-types': 5.1.2
-      '@veramo/credential-ld': 5.1.2
-      '@veramo/credential-w3c': 5.1.2
-      '@veramo/data-store': 5.1.2
-      '@veramo/data-store-json': 5.1.2
-      '@veramo/did-comm': 5.1.2
-      '@veramo/did-jwt': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/did-provider-ethr': 5.1.2
-      '@veramo/did-provider-jwk': 5.1.2
-      '@veramo/did-provider-key': 5.1.2
-      '@veramo/did-provider-pkh': 5.1.2
-      '@veramo/did-provider-web': 5.1.2
-      '@veramo/did-resolver': 5.1.2
-      '@veramo/key-manager': 5.1.2
-      '@veramo/kms-local': 5.1.2
-      '@veramo/kms-web3': 5.1.2
-      '@veramo/message-handler': 5.1.2
-      '@veramo/selective-disclosure': 5.1.2
+      '@veramo/core': link:../core
+      '@veramo/core-types': link:../core-types
+      '@veramo/credential-ld': link:../credential-ld
+      '@veramo/credential-w3c': link:../credential-w3c
+      '@veramo/data-store': link:../data-store
+      '@veramo/data-store-json': link:../data-store-json
+      '@veramo/did-comm': link:../did-comm
+      '@veramo/did-jwt': link:../did-jwt
+      '@veramo/did-manager': link:../did-manager
+      '@veramo/did-provider-ethr': link:../did-provider-ethr
+      '@veramo/did-provider-jwk': link:../did-provider-jwk
+      '@veramo/did-provider-key': link:../did-provider-key
+      '@veramo/did-provider-pkh': link:../did-provider-pkh
+      '@veramo/did-provider-web': link:../did-provider-web
+      '@veramo/did-resolver': link:../did-resolver
+      '@veramo/key-manager': link:../key-manager
+      '@veramo/kms-local': link:../kms-local
+      '@veramo/kms-web3': link:../kms-web3
+      '@veramo/message-handler': link:../message-handler
+      '@veramo/selective-disclosure': link:../selective-disclosure
       '@veramo/test-utils': link:../test-utils
-      '@veramo/url-handler': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/url-handler': link:../url-handler
+      '@veramo/utils': link:../utils
       buffer: 6.0.3
       crypto: /crypto-browserify/3.12.0
       did-resolver: 4.0.1
@@ -1038,10 +1040,10 @@ importers:
       did-resolver: ^4.0.1
       typescript: 4.9.4
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-discovery': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/utils': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/did-discovery': link:../did-discovery
+      '@veramo/did-manager': link:../did-manager
+      '@veramo/utils': link:../utils
       did-resolver: 4.0.1
     devDependencies:
       typescript: 4.9.4
@@ -1058,8 +1060,8 @@ importers:
       typescript: 4.9.4
       url-parse: ^1.5.4
     dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/message-handler': 5.1.2
+      '@veramo/core-types': link:../core-types
+      '@veramo/message-handler': link:../message-handler
       cross-fetch: 3.1.5
       debug: 4.3.4
       url-parse: 1.5.10
@@ -1092,7 +1094,7 @@ importers:
       '@ethersproject/signing-key': 5.7.0
       '@ethersproject/transactions': 5.7.0
       '@stablelib/ed25519': 1.0.3
-      '@veramo/core-types': 5.1.2
+      '@veramo/core-types': link:../core-types
       blakejs: 1.2.1
       credential-status: 2.0.5
       cross-fetch: 3.1.5
@@ -6509,465 +6511,6 @@ packages:
       invariant: 2.2.4
     dev: false
     optional: true
-
-  /@veramo/core-types/5.1.2:
-    resolution: {integrity: sha512-IVmbcn9yBE8v/x29nGvScCT9sIKu/iYJ8+dqN3jIVL2t//HRvNhrHsxw83Wb6DGqr46r0ebM+kEnPfZAAxdk/w==}
-    dependencies:
-      credential-status: 2.0.5
-      debug: 4.3.4
-      did-jwt-vc: 3.1.0
-      did-resolver: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@veramo/core/5.1.2:
-    resolution: {integrity: sha512-0ees7TekZ4h7dXPsaqu+6ZM5rc4BAqoW/zfiAzM0mAD2anaTyygbKqfjUAMVijdOv6/tyL8Yv3ez74zXYgT+ew==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      debug: 4.3.4
-      events: 3.3.0
-      z-schema: 5.0.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@veramo/credential-eip712/5.1.2:
-    resolution: {integrity: sha512-cPNUqmrBJIvVgWxIXhhjM20LXyo6cPO5/yDCxtNfmfOMdL4Bxf0lKZ+dnTM2ZJLvCit6Js/6IZSMFieEb6goOg==}
-    dependencies:
-      '@metamask/eth-sig-util': 5.0.2
-      '@veramo/core-types': 5.1.2
-      '@veramo/utils': 5.1.2
-      debug: 4.3.4
-      eip-712-types-generation: 0.1.6
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@veramo/credential-ld/5.1.2:
-    resolution: {integrity: sha512-cq+UcFIEIAUIT0aQbDWBkbGdg5+utyGgYhmekBTRsbXUuDO0TC25HNK4ceYuL+FRPaYHl24vPUuKd609if2L7w==}
-    dependencies:
-      '@digitalcredentials/ed25519-signature-2020': 3.0.2
-      '@digitalcredentials/ed25519-verification-key-2020': 4.0.0
-      '@digitalcredentials/jsonld': 5.2.1
-      '@digitalcredentials/jsonld-signatures': 9.3.1
-      '@digitalcredentials/vc': 5.0.0
-      '@transmute/credentials-context': 0.7.0-unstable.79
-      '@transmute/ed25519-signature-2018': 0.7.0-unstable.79
-      '@transmute/json-web-signature': 0.7.0-unstable.79
-      '@veramo-community/lds-ecdsa-secp256k1-recovery2020': github.com/uport-project/EcdsaSecp256k1RecoverySignature2020/ab0db52de6f4e6663ef271a48009ba26e688ef9b
-      '@veramo/core-types': 5.1.2
-      '@veramo/utils': 5.1.2
-      cross-fetch: 3.1.5
-      debug: 4.3.4
-      did-resolver: 4.0.1
-      uint8arrays: 3.1.1
-    transitivePeerDependencies:
-      - domexception
-      - encoding
-      - expo
-      - react-native
-      - supports-color
-      - web-streams-polyfill
-    dev: false
-
-  /@veramo/credential-w3c/5.1.2:
-    resolution: {integrity: sha512-1sVDVxFWHwpSdeEgIWmHtUiIy0aDFKMPgEn+d02xGDhXnWlyUdT5OCDLULsKDma/owajkq0RTrbeSpe+63+0pg==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/message-handler': 5.1.2
-      '@veramo/utils': 5.1.2
-      canonicalize: 1.0.8
-      debug: 4.3.4
-      did-jwt: 6.11.0
-      did-jwt-vc: 3.1.0
-      did-resolver: 4.0.1
-      uint8arrays: 3.1.1
-      uuid: 9.0.0
-    optionalDependencies:
-      '@veramo/credential-ld': 5.1.2
-    transitivePeerDependencies:
-      - domexception
-      - encoding
-      - expo
-      - react-native
-      - supports-color
-      - web-streams-polyfill
-    dev: false
-
-  /@veramo/data-store-json/5.1.2:
-    resolution: {integrity: sha512-9K/ATugDrnEIrykvPfsc3gEx/RPzevU/18RMp9YG8DGNjingHOvjLMAdYpm0LOX9kId/YQyprodZ64A81xW1VA==}
-    dependencies:
-      '@ungap/structured-clone': 1.0.1
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/key-manager': 5.1.2
-      '@veramo/utils': 5.1.2
-      debug: 4.3.4
-      did-jwt-vc: 3.1.0
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@veramo/data-store/5.1.2:
-    resolution: {integrity: sha512-9VtEI7oXD+kiRuTttwBgyZXwqacFEvlUr7KGcMiopC/pPpj2AfFaSkNnzE1TRcF1LoR4r78OFiI1IGJaiNTMWg==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-discovery': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/key-manager': 5.1.2
-      '@veramo/utils': 5.1.2
-      debug: 4.3.4
-      did-jwt-vc: 3.1.0
-      typeorm: 0.3.12
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - '@google-cloud/spanner'
-      - '@sap/hana-client'
-      - better-sqlite3
-      - encoding
-      - hdb-pool
-      - ioredis
-      - mongodb
-      - mssql
-      - mysql2
-      - oracledb
-      - pg
-      - pg-native
-      - pg-query-stream
-      - redis
-      - sql.js
-      - sqlite3
-      - supports-color
-      - ts-node
-      - typeorm-aurora-data-api-driver
-    dev: false
-
-  /@veramo/data-store/5.1.2_pg@8.8.0+sqlite3@5.1.4:
-    resolution: {integrity: sha512-9VtEI7oXD+kiRuTttwBgyZXwqacFEvlUr7KGcMiopC/pPpj2AfFaSkNnzE1TRcF1LoR4r78OFiI1IGJaiNTMWg==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-discovery': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/key-manager': 5.1.2
-      '@veramo/utils': 5.1.2
-      debug: 4.3.4
-      did-jwt-vc: 3.1.0
-      typeorm: 0.3.12_pg@8.8.0+sqlite3@5.1.4
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - '@google-cloud/spanner'
-      - '@sap/hana-client'
-      - better-sqlite3
-      - encoding
-      - hdb-pool
-      - ioredis
-      - mongodb
-      - mssql
-      - mysql2
-      - oracledb
-      - pg
-      - pg-native
-      - pg-query-stream
-      - redis
-      - sql.js
-      - sqlite3
-      - supports-color
-      - ts-node
-      - typeorm-aurora-data-api-driver
-    dev: false
-
-  /@veramo/did-comm/5.1.2:
-    resolution: {integrity: sha512-VNIVgTz+U1/YUfnGwlwfl4CAbU5nBU7uKu4UF8Y6FmavzHdRwVBB9jblBchoqtRwLY5r8ukpwFWD2HylzS03vA==}
-    dependencies:
-      '@ethersproject/signing-key': 5.7.0
-      '@stablelib/ed25519': 1.0.3
-      '@veramo/core-types': 5.1.2
-      '@veramo/message-handler': 5.1.2
-      '@veramo/utils': 5.1.2
-      cross-fetch: 3.1.5
-      debug: 4.3.4
-      did-jwt: 6.11.0
-      did-resolver: 4.0.1
-      uint8arrays: 3.1.1
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@veramo/did-discovery/5.1.2:
-    resolution: {integrity: sha512-+Gl2KaCpF4DgrYP71/9Pg40bcIWE1V4g0qEda3qHhy+xqK5qS9bNHlfEmYsK1Wx52FhVZlEWvA7HbQCgQ094ng==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@veramo/did-jwt/5.1.2:
-    resolution: {integrity: sha512-6zk4O/bENz2q1SsDJI8/ItL7zFfkBxAhSFOSiTFyOUn1w6XG7TdDQqSdWnvVEvIE2AV0vDmg/npaF1kBvHg7wQ==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/message-handler': 5.1.2
-      debug: 4.3.4
-      did-jwt: 6.11.0
-      did-resolver: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@veramo/did-manager/5.1.2:
-    resolution: {integrity: sha512-cp847YVlNzXZS2L8x/h3LIeH3qv1WEeHdXdVq2yDvAVFIr69X84K2eGlSueTUGc3Jkk+vUL82GYsOW8aVZ25Lg==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-discovery': 5.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@veramo/did-provider-ethr/5.1.2:
-    resolution: {integrity: sha512-bsecW15NkgU5edYehJprzeOzEX4eStFqvrD2L+scb9p+pwIc5587WCkaVP6dlWnerv03tlFgN+eRxe1EJl0TWQ==}
-    dependencies:
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/providers': 5.7.2
-      '@ethersproject/signing-key': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      debug: 4.3.4
-      ethr-did: 2.3.6
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /@veramo/did-provider-jwk/5.1.2:
-    resolution: {integrity: sha512-nEZbNQifRHj/Q6fnl5BMkbvryawGiTuV45gNNp0G6G3ElC8u32seuv4c14+Atq14NZjesId/1QTDnEGmx6qB5A==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      '@veramo/utils': 5.1.2
-      debug: 4.3.4
-      did-resolver: 4.0.1
-      elliptic: 6.5.4
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@veramo/did-provider-key/5.1.2:
-    resolution: {integrity: sha512-BvrGCmZ5eyPPLcOWNO5sXSmWFpRWTagwhIzQI0lrBphcuDeJxvpW3S3jACYO3SbiC/ksM+rGICG+OAcbagUeDw==}
-    dependencies:
-      '@transmute/did-key-ed25519': 0.3.0-unstable.10
-      '@transmute/did-key-secp256k1': 0.3.0-unstable.10
-      '@transmute/did-key-x25519': 0.3.0-unstable.10
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      debug: 4.3.4
-      did-resolver: 4.0.1
-      multibase: 4.0.6
-      multicodec: 3.2.1
-    transitivePeerDependencies:
-      - domexception
-      - encoding
-      - expo
-      - react-native
-      - supports-color
-      - web-streams-polyfill
-    dev: false
-
-  /@veramo/did-provider-pkh/5.1.2:
-    resolution: {integrity: sha512-JzT2eZKZXKo6vqjK31h0A0ye96BJLCXRKzU7L1IBzE1lcoGJRqrjENUuY1HTbdXeOXRFLGEGKW35WPzB1Rxz0A==}
-    dependencies:
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/signing-key': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      caip: 1.1.0
-      debug: 4.3.4
-      did-resolver: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@veramo/did-provider-web/5.1.2:
-    resolution: {integrity: sha512-5ZwgQgIfkQFJy6n4+o7nsPRvbWTP65O4ErxMZIQeGhYVcGr5Q6MJk9g+A4bGy/jdJEKzyzD7e1XWcjxJTPJT2w==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/did-manager': 5.1.2
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@veramo/did-resolver/5.1.2:
-    resolution: {integrity: sha512-edvF4E6X3XwVUH/eeIsZmYJGfHVL0fFPzdl9lf0jrCiticik76QYiUWLXj67q8E43Lv16mYOIe3S3qQ3/vmsKg==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/utils': 5.1.2
-      cross-fetch: 3.1.5
-      debug: 4.3.4
-      did-resolver: 4.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@veramo/key-manager/5.1.2:
-    resolution: {integrity: sha512-o7sNQfDjdJO0MkV+wwUL5wQwZXBG6hMXdbaTqwZgdA0btE9267anx9Cy7dpLnfsRWvHM3EsLFTuZdL9mytMIgQ==}
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@stablelib/ed25519': 1.0.3
-      '@veramo/core-types': 5.1.2
-      debug: 4.3.4
-      did-jwt: 6.11.0
-      uint8arrays: 3.1.1
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@veramo/kms-local/5.1.2:
-    resolution: {integrity: sha512-YJBh9n+cxVoa/bUfa/weV0nd0ik+GgRxaO4NZQS9rJF50vI8XHV1+FOZeKm38LKVbvB4/nupTSzkmQb4nFQNcg==}
-    dependencies:
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/random': 5.7.0
-      '@ethersproject/signing-key': 5.7.0
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@ethersproject/wallet': 5.7.0
-      '@stablelib/ed25519': 1.0.3
-      '@stablelib/nacl': 1.0.4
-      '@stablelib/random': 1.0.2
-      '@stablelib/x25519': 1.0.3
-      '@veramo/core-types': 5.1.2
-      '@veramo/key-manager': 5.1.2
-      base-58: 0.0.1
-      debug: 4.3.4
-      did-jwt: 6.11.0
-      elliptic: 6.5.4
-      uint8arrays: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@veramo/kms-web3/5.1.2:
-    resolution: {integrity: sha512-d97boXJZOPEXfUskxijEgI0Vccjte+ZgTPRnXQ4mI5chEubWVD0/kx3HRNzXYcL6iHWTm3/hvzL2iAK6vgVyXA==}
-    dependencies:
-      '@ethersproject/providers': 5.7.2
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@veramo/core-types': 5.1.2
-      '@veramo/key-manager': 5.1.2
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /@veramo/message-handler/5.1.2:
-    resolution: {integrity: sha512-fov1wFOe5f4YoNpmjlo8pRyG2GJI0qlSW0Zvo3umhbfMc/yohcx8zAi4ZaR3uqxPGfsdsbCO2zU8+VSfUqcH0Q==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@veramo/remote-client/5.1.2:
-    resolution: {integrity: sha512-+rjb9SDlLLo08oBYG4ovk4KbWXSNGBsKI/+SIqiqTf9/IGwsidsNxzQXtaSoIe1CVMIvlBGRUWJq6GxM13yAVw==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      cross-fetch: 3.1.5
-      debug: 4.3.4
-      openapi-types: 12.1.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@veramo/remote-server/5.1.2_express@4.18.2:
-    resolution: {integrity: sha512-ioTeLOLsmMoHeODedpy4l/7e2v263shIszYM6FrK0TmZZuxen6aqkjMrTRaB7Rxqxz3J2d0HJi2RDthw9LEh6w==}
-    peerDependencies:
-      express: ^4.18.2
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/remote-client': 5.1.2
-      debug: 4.3.4
-      did-resolver: 4.0.1
-      express: 4.18.2
-      passport: 0.6.0
-      passport-http-bearer: 1.0.1
-      url-parse: 1.5.10
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@veramo/selective-disclosure/5.1.2:
-    resolution: {integrity: sha512-XD4JvS0PtU6pFLA2ulbSHiT/VtJfkiJEyyDoKGIL6sxMorocfzMI9eg9wRpI8k3SHKiA+VrP5UeNKsNnlodHiQ==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/message-handler': 5.1.2
-      '@veramo/utils': 5.1.2
-      debug: 4.3.4
-      did-jwt: 6.11.0
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@veramo/url-handler/5.1.2:
-    resolution: {integrity: sha512-k8Ao++I6uFkdz2xOU5z0Fv6pXnyediyeywhfHprarwaFjpw7Gi00QEnU3+1gciCIxVDXTpc/a2uKJS0FkUIwJw==}
-    dependencies:
-      '@veramo/core-types': 5.1.2
-      '@veramo/message-handler': 5.1.2
-      cross-fetch: 3.1.5
-      debug: 4.3.4
-      url-parse: 1.5.10
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@veramo/utils/5.1.2:
-    resolution: {integrity: sha512-1hcQzoTQ8q5LWfT1GzCA7wDyX95Pmz2xSVmV5P5otbAtrWk9GXn01snbaDlW+vz/a/iWKKcLlZbkRf5uLpHdnQ==}
-    dependencies:
-      '@ethersproject/signing-key': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@stablelib/ed25519': 1.0.3
-      '@veramo/core-types': 5.1.2
-      blakejs: 1.2.1
-      credential-status: 2.0.5
-      cross-fetch: 3.1.5
-      debug: 4.3.4
-      did-jwt: 6.11.0
-      did-jwt-vc: 3.1.0
-      did-resolver: 4.0.1
-      elliptic: 6.5.4
-      multiformats: 9.9.0
-      uint8arrays: 3.1.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
 
   /@webassemblyjs/ast/1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
@@ -18862,7 +18405,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.3.1_@types+node@18.11.18
+      jest: 29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4
       jest-util: 29.3.1
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -19291,85 +18834,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /typeorm/0.3.12:
-    resolution: {integrity: sha512-sYSxBmCf1nJLLTcYtwqZ+lQIRtLPyUoO93rHTOKk9vJCyT4UfRtU7oRsJvfvKP3nnZTD1hzz2SEy2zwPEN6OyA==}
-    engines: {node: '>= 12.9.0'}
-    hasBin: true
-    peerDependencies:
-      '@google-cloud/spanner': ^5.18.0
-      '@sap/hana-client': ^2.12.25
-      better-sqlite3: ^7.1.2 || ^8.0.0
-      hdb-pool: ^0.1.6
-      ioredis: ^5.0.4
-      mongodb: ^3.6.0
-      mssql: ^7.3.0
-      mysql2: ^2.2.5 || ^3.0.1
-      oracledb: ^5.1.0
-      pg: ^8.5.1
-      pg-native: ^3.0.0
-      pg-query-stream: ^4.0.0
-      redis: ^3.1.1 || ^4.0.0
-      sql.js: ^1.4.0
-      sqlite3: ^5.0.3
-      ts-node: ^10.7.0
-      typeorm-aurora-data-api-driver: ^2.0.0
-    peerDependenciesMeta:
-      '@google-cloud/spanner':
-        optional: true
-      '@sap/hana-client':
-        optional: true
-      better-sqlite3:
-        optional: true
-      hdb-pool:
-        optional: true
-      ioredis:
-        optional: true
-      mongodb:
-        optional: true
-      mssql:
-        optional: true
-      mysql2:
-        optional: true
-      oracledb:
-        optional: true
-      pg:
-        optional: true
-      pg-native:
-        optional: true
-      pg-query-stream:
-        optional: true
-      redis:
-        optional: true
-      sql.js:
-        optional: true
-      sqlite3:
-        optional: true
-      ts-node:
-        optional: true
-      typeorm-aurora-data-api-driver:
-        optional: true
-    dependencies:
-      '@sqltools/formatter': 1.2.5
-      app-root-path: 3.1.0
-      buffer: 6.0.3
-      chalk: 4.1.2
-      cli-highlight: 2.1.11
-      date-fns: 2.29.3
-      debug: 4.3.4
-      dotenv: 16.0.3
-      glob: 8.1.0
-      js-yaml: 4.1.0
-      mkdirp: 2.1.3
-      reflect-metadata: 0.1.13
-      sha.js: 2.4.11
-      tslib: 2.5.0
-      uuid: 9.0.0
-      xml2js: 0.4.23
-      yargs: 17.6.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /typeorm/0.3.12_pg@8.8.0+sqlite3@5.1.4:
     resolution: {integrity: sha512-sYSxBmCf1nJLLTcYtwqZ+lQIRtLPyUoO93rHTOKk9vJCyT4UfRtU7oRsJvfvKP3nnZTD1hzz2SEy2zwPEN6OyA==}


### PR DESCRIPTION
## What issue is this PR fixing
`did:web` DID Documents hosted on Veramo web servers previously displayed Ed25519 Verification Keys in 2018 format, with outdated `publicKeyHex`. Moving to the 2020 version, with `publicKeyMultibase` should provide more interoperability


## What is being changed
* Add test to exercise Ed25519Signature2020 Suite
* Build DID Doc in `web-did-doc-router` with 2020 keys
* moved a helper function from `credential-ld/src/suites/Ed25519Signature2020.ts` to `utils/src/encodings.ts`
 
## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [ ] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [ ] I allow my PR to be updated by the reviewers (to speed up the review process).
* [X] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

## Details
If applicable, add screen captures, error messages or stack traces to help explain your problem.
