### PR TITLE
fix(credential-ld): fix LDdefaultContexts file extensions

### DIFF
--- a/packages/credential-ld/src/ld-default-contexts.ts
+++ b/packages/credential-ld/src/ld-default-contexts.ts
@@ -9,9 +9,9 @@ import { ContextDoc } from './types'
  * @beta This API may change without a BREAKING CHANGE notice.
  */
 export const LdDefaultContexts = new Map([
-  ['https://www.w3.org/2018/credentials/v1', require('./contexts/www.w3.org_2018_credentials_v1')],
-  ['https://www.w3.org/ns/did/v1', require('./contexts/www.w3.org_ns_did_v1')],
-  ['https://w3id.org/security/v1', require('./contexts/w3id.org_security_v1')],
+  ['https://www.w3.org/2018/credentials/v1', require('./contexts/www.w3.org_2018_credentials_v1.json')],
+  ['https://www.w3.org/ns/did/v1', require('./contexts/www.w3.org_ns_did_v1.json')],
+  ['https://w3id.org/security/v1', require('./contexts/w3id.org_security_v1.json')],
   ['https://w3id.org/security/v2', require('./contexts/w3id.org_security_v2.json')],
   ['https://w3id.org/security/v3-unstable', require('./contexts/w3id.org_security_v3-unstable.json')],
   ['https://w3id.org/security/suites/ed25519-2018/v1', require('./contexts/w3id.org_security_suites_ed25519-2018_v1.json')],


### PR DESCRIPTION
## What issue is this PR fixing

Fixes issue where some files without `.json` suffix cannot be imported and throw `Can't resolve` error.


## What is being changed
Adds `.json` to filenames that are missing it in `ld-default-contexts.ts`

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.