### PR TITLE
feat(did-comm) Support DIDComm Messaging attachments

### DIFF
--- a/packages/core/plugin.schema.json
+++ b/packages/core/plugin.schema.json
@@ -2032,6 +2032,13 @@
                 "$ref": "#/components/schemas/VerifiablePresentation"
               },
               "description": "Optional. Array of attached verifiable presentations"
+            },
+            "attachments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/IMessageAttachment"
+              },
+              "description": "Optional. Array of generic attachments"
             }
           },
           "required": [
@@ -2248,6 +2255,59 @@
         "CompactJWT": {
           "type": "string",
           "description": "Represents a Json Web Token in compact form. \"header.payload.signature\""
+        },
+        "IMessageAttachment": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "media_type": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "lastmod_time": {
+              "type": "string"
+            },
+            "byte_count": {
+              "type": "number"
+            },
+            "data": {
+              "$ref": "#/components/schemas/IMessageAttachmentData"
+            }
+          },
+          "required": [
+            "data"
+          ],
+          "description": "Message attachment"
+        },
+        "IMessageAttachmentData": {
+          "type": "object",
+          "properties": {
+            "jws": {},
+            "hash": {
+              "type": "string"
+            },
+            "links": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "base64": {
+              "type": "string"
+            },
+            "json": {}
+          },
+          "description": "The DIDComm message structure for data in an attachment. See https://identity.foundation/didcomm-messaging/spec/#attachments"
         },
         "IDataStoreGetVerifiableCredentialArgs": {
           "type": "object",
@@ -2822,6 +2882,13 @@
                 "$ref": "#/components/schemas/VerifiablePresentation"
               },
               "description": "Optional. Array of attached verifiable presentations"
+            },
+            "attachments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/IMessageAttachment"
+              },
+              "description": "Optional. Array of generic attachments"
             }
           },
           "required": [
@@ -3038,6 +3105,59 @@
         "CompactJWT": {
           "type": "string",
           "description": "Represents a Json Web Token in compact form. \"header.payload.signature\""
+        },
+        "IMessageAttachment": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "media_type": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "lastmod_time": {
+              "type": "string"
+            },
+            "byte_count": {
+              "type": "number"
+            },
+            "data": {
+              "$ref": "#/components/schemas/IMessageAttachmentData"
+            }
+          },
+          "required": [
+            "data"
+          ],
+          "description": "Message attachment"
+        },
+        "IMessageAttachmentData": {
+          "type": "object",
+          "properties": {
+            "jws": {},
+            "hash": {
+              "type": "string"
+            },
+            "links": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "base64": {
+              "type": "string"
+            },
+            "json": {}
+          },
+          "description": "The DIDComm message structure for data in an attachment. See https://identity.foundation/didcomm-messaging/spec/#attachments"
         },
         "FindCredentialsArgs": {
           "$ref": "#/components/schemas/FindArgs-TCredentialColumns",
@@ -3616,6 +3736,13 @@
                 "$ref": "#/components/schemas/VerifiablePresentation"
               },
               "description": "Optional. Array of attached verifiable presentations"
+            },
+            "attachments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/IMessageAttachment"
+              },
+              "description": "Optional. Array of generic attachments"
             }
           },
           "required": [
@@ -3815,6 +3942,59 @@
         "CompactJWT": {
           "type": "string",
           "description": "Represents a Json Web Token in compact form. \"header.payload.signature\""
+        },
+        "IMessageAttachment": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "media_type": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "lastmod_time": {
+              "type": "string"
+            },
+            "byte_count": {
+              "type": "number"
+            },
+            "data": {
+              "$ref": "#/components/schemas/IMessageAttachmentData"
+            }
+          },
+          "required": [
+            "data"
+          ],
+          "description": "Message attachment"
+        },
+        "IMessageAttachmentData": {
+          "type": "object",
+          "properties": {
+            "jws": {},
+            "hash": {
+              "type": "string"
+            },
+            "links": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "base64": {
+              "type": "string"
+            },
+            "json": {}
+          },
+          "description": "The DIDComm message structure for data in an attachment. See https://identity.foundation/didcomm-messaging/spec/#attachments"
         }
       },
       "methods": {

--- a/packages/core/src/types/IMessage.ts
+++ b/packages/core/src/types/IMessage.ts
@@ -17,6 +17,35 @@ export interface IMetaData {
 }
 
 /**
+ * Message attachment
+ * @public
+ */
+export interface IMessageAttachment {
+  id?: string
+  description?: string
+  filename?: string
+  media_type?: string
+  format?: string
+  lastmod_time?: string
+  byte_count?: number
+  data: IMessageAttachmentData
+}
+
+/**
+ * The DIDComm message structure for data in an attachment.
+ * See https://identity.foundation/didcomm-messaging/spec/#attachments
+ *
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
+export interface IMessageAttachmentData {
+  jws?: any
+  hash?: string
+  links?: string[]
+  base64?: string
+  json?: any
+}
+
+/**
  * Represents a DIDComm v1 message payload, with optionally decoded credentials and presentations.
  * @public
  */
@@ -90,4 +119,9 @@ export interface IMessage {
    * Optional. Array of attached verifiable presentations
    */
   presentations?: VerifiablePresentation[]
+
+  /**
+   * Optional. Array of generic attachments
+   */
+  attachments?: IMessageAttachment[]
 }

--- a/packages/did-comm/plugin.schema.json
+++ b/packages/did-comm/plugin.schema.json
@@ -78,7 +78,13 @@
             "from_prior": {
               "type": "string"
             },
-            "body": {}
+            "body": {},
+            "attachments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/IDIDCommMessageAttachment"
+              }
+            }
           },
           "required": [
             "type",
@@ -87,6 +93,59 @@
             "body"
           ],
           "description": "The DIDComm message structure. See https://identity.foundation/didcomm-messaging/spec/#plaintext-message-structure"
+        },
+        "IDIDCommMessageAttachment": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "media_type": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "lastmod_time": {
+              "type": "string"
+            },
+            "byte_count": {
+              "type": "number"
+            },
+            "data": {
+              "$ref": "#/components/schemas/IDIDCommMessageAttachmentData"
+            }
+          },
+          "required": [
+            "data"
+          ],
+          "description": "The DIDComm message structure for attachments. See https://identity.foundation/didcomm-messaging/spec/#attachments"
+        },
+        "IDIDCommMessageAttachmentData": {
+          "type": "object",
+          "properties": {
+            "jws": {},
+            "hash": {
+              "type": "string"
+            },
+            "links": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "base64": {
+              "type": "string"
+            },
+            "json": {}
+          },
+          "description": "The DIDComm message structure for data in an attachment. See https://identity.foundation/didcomm-messaging/spec/#attachments"
         },
         "DIDCommMessagePacking": {
           "type": "string",
@@ -274,6 +333,13 @@
                 "$ref": "#/components/schemas/VerifiablePresentation"
               },
               "description": "Optional. Array of attached verifiable presentations"
+            },
+            "attachments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/IMessageAttachment"
+              },
+              "description": "Optional. Array of generic attachments"
             }
           },
           "required": [
@@ -490,6 +556,59 @@
         "CompactJWT": {
           "type": "string",
           "description": "Represents a Json Web Token in compact form. \"header.payload.signature\""
+        },
+        "IMessageAttachment": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "media_type": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "lastmod_time": {
+              "type": "string"
+            },
+            "byte_count": {
+              "type": "number"
+            },
+            "data": {
+              "$ref": "#/components/schemas/IMessageAttachmentData"
+            }
+          },
+          "required": [
+            "data"
+          ],
+          "description": "Message attachment"
+        },
+        "IMessageAttachmentData": {
+          "type": "object",
+          "properties": {
+            "jws": {},
+            "hash": {
+              "type": "string"
+            },
+            "links": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "base64": {
+              "type": "string"
+            },
+            "json": {}
+          },
+          "description": "The DIDComm message structure for data in an attachment. See https://identity.foundation/didcomm-messaging/spec/#attachments"
         },
         "IUnpackDIDCommMessageArgs": {
           "$ref": "#/components/schemas/IPackedDIDCommMessage",

--- a/packages/did-comm/src/__tests__/message-handler.test.ts
+++ b/packages/did-comm/src/__tests__/message-handler.test.ts
@@ -184,6 +184,7 @@ describe('did-comm-message-handler', () => {
             body: {
               hello: 'world'
             },
+            attachments: [{ data: { hash: 'some-hash', json: { some: 'attachment' } } }],
             from: sender.did,
             id: `${id}`,
             to: recipient.did,
@@ -198,7 +199,14 @@ describe('did-comm-message-handler', () => {
   }
 
   const getRegularMessage = () => {
-    return { id: v4(), type: 'fake', to: recipient.did, from: sender.did, body: { hello: 'world' }}
+    return {
+      id: v4(),
+      type: 'fake',
+      to: recipient.did,
+      from: sender.did,
+      body: { hello: 'world' },
+      attachments: [{ data: { hash: 'some-hash', json: { some: 'attachment' } } }],
+    }
   }
 
   it('should pack and unpack message with none packing', async () => {

--- a/packages/did-comm/src/message-handler.ts
+++ b/packages/did-comm/src/message-handler.ts
@@ -107,6 +107,7 @@ export class DIDCommMessageHandler extends AbstractMessageHandler {
             created_time: createdAt,
             expires_time: expiresAt,
             body: data,
+            attachments,
           } = unpackedMessage.message
 
           message.type = type
@@ -117,6 +118,7 @@ export class DIDCommMessageHandler extends AbstractMessageHandler {
           message.createdAt = createdAt
           message.expiresAt = expiresAt
           message.data = data
+          message.attachments = attachments
 
           message.addMetaData({ type: 'didCommMetaData', value: JSON.stringify(unpackedMessage.metaData) })
           context.agent.emit('DIDCommV2Message-received', unpackedMessage)

--- a/packages/did-comm/src/types/message-types.ts
+++ b/packages/did-comm/src/types/message-types.ts
@@ -16,6 +16,7 @@ export interface IDIDCommMessage {
   next?: string
   from_prior?: string
   body: any
+  attachments?: IDIDCommMessageAttachment[]
 }
 
 /**
@@ -100,4 +101,35 @@ export interface IUnpackedDIDCommMessage {
  */
 export interface IPackedDIDCommMessage {
   message: string
+}
+
+/**
+ * The DIDComm message structure for attachments.
+ * See https://identity.foundation/didcomm-messaging/spec/#attachments
+ *
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
+export interface IDIDCommMessageAttachment {
+  id?: string
+  description?: string
+  filename?: string
+  media_type?: string
+  format?: string
+  lastmod_time?: string
+  byte_count?: number
+  data: IDIDCommMessageAttachmentData
+}
+
+/**
+ * The DIDComm message structure for data in an attachment.
+ * See https://identity.foundation/didcomm-messaging/spec/#attachments
+ *
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
+export interface IDIDCommMessageAttachmentData {
+  jws?: any
+  hash?: string
+  links?: string[]
+  base64?: string
+  json?: any
 }

--- a/packages/message-handler/src/message.ts
+++ b/packages/message-handler/src/message.ts
@@ -1,4 +1,10 @@
-import { IMessage, IMetaData, VerifiableCredential, VerifiablePresentation } from '@veramo/core'
+import {
+  IMessage,
+  IMetaData,
+  IMessageAttachment,
+  VerifiableCredential,
+  VerifiablePresentation,
+} from '@veramo/core'
 
 /**
  * A class implementing {@link @veramo/core#IMessage | IMessage}.
@@ -45,6 +51,7 @@ export class Message implements IMessage {
 
   presentations?: VerifiablePresentation[]
   credentials?: VerifiableCredential[]
+  attachments?: IMessageAttachment[]
 
   addMetaData(meta: IMetaData) {
     if (this.metaData) {


### PR DESCRIPTION
## What issue is this PR fixing
closes #612

## What is being changed
This adds support for `attachments` in DIDComm messages. The `DIDCommMessageHandler` will pass along the attachments after unpacking.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [x] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [x] I allow my PR to be updated by the reviewers (to speed up the review process).
* [x] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.
