### PR TITLE
add publicKeyJwk as valid verificationMethod

### DIFF
--- a/packages/utils/src/__tests__/did-utils.test.ts
+++ b/packages/utils/src/__tests__/did-utils.test.ts
@@ -38,4 +38,20 @@ describe('@veramo/utils did utils', () => {
 
     expect(getEthereumAddress(verificationMethod)).toEqual("0x1B54DaD834f2017ab66C1a1ffF74425889141e51".toLowerCase())
   })
+
+  it('should return blockchainAccountId for did:key', () => {
+    const verificationMethod = {
+        "id": "did:key:zQ3shdHG4u9wPDoEzSokyLm3readHkrpYaXFf9jbc8Eiz1UM5#zQ3shdHG4u9wPDoEzSokyLm3readHkrpYaXFf9jbc8Eiz1UM5",
+        "type": "EcdsaSecp256k1VerificationKey2019",
+        "controller": "did:key:zQ3shdHG4u9wPDoEzSokyLm3readHkrpYaXFf9jbc8Eiz1UM5",
+        "publicKeyJwk": {
+            "kty": "EC",
+            "crv": "secp256k1",
+            "x": "6805tExt2N3AcS9cxs_RJT_RtAkfK6rqIix5B4k0oEg",
+            "y": "qw0mojIWWljYFYHvsSkcBfaUVfeSf1YEbyFZmzAif2Q"
+        }
+    }
+
+    expect(getEthereumAddress(verificationMethod)).toEqual("0x923f7158062db4761a8917ad1628d11536c5f07b".toLowerCase())
+  })
 })

--- a/packages/utils/src/did-utils.ts
+++ b/packages/utils/src/did-utils.ts
@@ -119,7 +119,8 @@ export function getEthereumAddress(verificationMethod: VerificationMethod): stri
     } else if (
       verificationMethod.publicKeyHex ||
       verificationMethod.publicKeyBase58 ||
-      verificationMethod.publicKeyBase64
+      verificationMethod.publicKeyBase64 ||
+      verificationMethod.publicKeyJwk
     ) {
       const pbBytes = extractPublicKeyBytes(verificationMethod)
       const pbHex = computePublicKey(pbBytes, false)


### PR DESCRIPTION
Potential missing of `verificationMethod.publicKeyJwk` in `getEthereumAddress()` Otherwise without this the method doesn't call `extractPublicKeyBytes()` that is able to manage this type of `VerificationMethod`.

Linking to an issue provides some context and a reason for the PR to be reviewed, as well as simplifying the release
notes and changelogs that get generated automatically. If an issue is linked like this it will be automatically closed
when the PR is merged.

## What is being changed
A clear description of what this PR brings.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [x] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

## Details
If applicable, add screen captures, error messages or stack traces to help explain your problem.
