### PR TITLE
fix: SES import method rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ key-store.json
 
 .vscode/
 node_modules
-temp
+temp/
+tmp/
 
 agent.yml
 data

--- a/packages/data-store-json/src/identifier/did-store.ts
+++ b/packages/data-store-json/src/identifier/did-store.ts
@@ -37,7 +37,7 @@ export class DIDStoreJson extends AbstractDIDStore {
     }
   }
 
-  async get({
+  async getDID({
               did,
               alias,
               provider,
@@ -70,7 +70,7 @@ export class DIDStoreJson extends AbstractDIDStore {
     return deserialize(serialize(identifier))
   }
 
-  async delete({ did }: { did: string }) {
+  async deleteDID({ did }: { did: string }) {
     if (this.cacheTree.dids[did]) {
       const oldTree = deserialize(serialize(this.cacheTree, { lossy: true }))
       delete this.cacheTree.dids[did]
@@ -81,7 +81,7 @@ export class DIDStoreJson extends AbstractDIDStore {
     return false
   }
 
-  async import(args: IIdentifier) {
+  async importDID(args: IIdentifier) {
     const oldTree = deserialize(serialize(this.cacheTree, { lossy: true }))
     this.cacheTree.dids[args.did] = args
     args.keys.forEach((key) => {
@@ -96,7 +96,7 @@ export class DIDStoreJson extends AbstractDIDStore {
     return true
   }
 
-  async list(args: { alias?: string; provider?: string }): Promise<IIdentifier[]> {
+  async listDIDs(args: { alias?: string; provider?: string }): Promise<IIdentifier[]> {
     const result = Object.values(this.cacheTree.dids).filter(
       (iid: IIdentifier) =>
         (!args.provider || (args.provider && iid.provider === args.provider)) &&

--- a/packages/data-store-json/src/identifier/key-store.ts
+++ b/packages/data-store-json/src/identifier/key-store.ts
@@ -40,7 +40,7 @@ export class KeyStoreJson extends AbstractKeyStore {
     }
   }
 
-  async get({ kid }: { kid: string }): Promise<IKey> {
+  async getKey({ kid }: { kid: string }): Promise<IKey> {
     if (this.cacheTree.keys[kid]) {
       return deserialize(serialize(this.cacheTree.keys[kid]))
     } else {
@@ -48,7 +48,7 @@ export class KeyStoreJson extends AbstractKeyStore {
     }
   }
 
-  async delete({ kid }: { kid: string }) {
+  async deleteKey({ kid }: { kid: string }) {
     if (this.cacheTree.keys[kid]) {
       const oldTree = deserialize(serialize(this.cacheTree, { lossy: true }))
       delete this.cacheTree.keys[kid]
@@ -59,14 +59,14 @@ export class KeyStoreJson extends AbstractKeyStore {
     }
   }
 
-  async import(args: IKey) {
+  async importKey(args: IKey) {
     const oldTree = deserialize(serialize(this.cacheTree, { lossy: true }))
     this.cacheTree.keys[args.kid] = args
     await this.notifyUpdate(oldTree, this.cacheTree)
     return true
   }
 
-  async list(args: {} = {}): Promise<ManagedKeyInfo[]> {
+  async listKeys(args: {} = {}): Promise<ManagedKeyInfo[]> {
     const keys = Object.values(this.cacheTree.keys).map((key: IKey) => {
       const { kid, publicKeyHex, type, meta, kms } = key
       return { kid, publicKeyHex, type, meta: deserialize(serialize(meta)), kms } as ManagedKeyInfo

--- a/packages/data-store-json/src/identifier/private-key-store.ts
+++ b/packages/data-store-json/src/identifier/private-key-store.ts
@@ -43,7 +43,7 @@ export class PrivateKeyStoreJson extends AbstractPrivateKeyStore {
     }
   }
 
-  async get({ alias }: { alias: string }): Promise<ManagedPrivateKey> {
+  async getKey({ alias }: { alias: string }): Promise<ManagedPrivateKey> {
     const key = deserialize(serialize(this.cacheTree.privateKeys[alias]))
     if (!key) throw Error('not_found: PrivateKey not found')
     if (this.secretBox && key.privateKeyHex) {
@@ -52,7 +52,7 @@ export class PrivateKeyStoreJson extends AbstractPrivateKeyStore {
     return key
   }
 
-  async delete({ alias }: { alias: string }) {
+  async deleteKey({ alias }: { alias: string }) {
     debug(`Deleting private key data for alias=${alias}`)
     const privateKeyEntry = this.cacheTree.privateKeys[alias]
     if (privateKeyEntry) {
@@ -63,7 +63,7 @@ export class PrivateKeyStoreJson extends AbstractPrivateKeyStore {
     return true
   }
 
-  async import(args: ImportablePrivateKey): Promise<ManagedPrivateKey> {
+  async importKey(args: ImportablePrivateKey): Promise<ManagedPrivateKey> {
     debug('Saving private key data', args.alias)
     const alias = args.alias || uuid4()
     const key: ManagedPrivateKey = deserialize(serialize({
@@ -88,7 +88,7 @@ export class PrivateKeyStoreJson extends AbstractPrivateKeyStore {
     return key
   }
 
-  async list(): Promise<Array<ManagedPrivateKey>> {
+  async listKeys(): Promise<Array<ManagedPrivateKey>> {
     return deserialize(serialize(Object.values(this.cacheTree.privateKeys)))
   }
 }

--- a/packages/data-store/src/identifier/did-store.ts
+++ b/packages/data-store/src/identifier/did-store.ts
@@ -30,7 +30,7 @@ export class DIDStore extends AbstractDIDStore {
     super()
   }
 
-  async get({
+  async getDID({
     did,
     alias,
     provider,
@@ -87,7 +87,7 @@ export class DIDStore extends AbstractDIDStore {
     return result
   }
 
-  async delete({ did }: { did: string }) {
+  async deleteDID({ did }: { did: string }) {
     const identifier = await (await getConnectedDb(this.dbConnection)).getRepository(Identifier).findOne({
       where: { did },
       relations: ['keys', 'services', 'issuedCredentials', 'issuedPresentations'],
@@ -123,7 +123,7 @@ export class DIDStore extends AbstractDIDStore {
     return true
   }
 
-  async import(args: IIdentifier) {
+  async importDID(args: IIdentifier) {
     const identifier = new Identifier()
     identifier.did = args.did
     if (args.controllerKeyId) {
@@ -160,7 +160,7 @@ export class DIDStore extends AbstractDIDStore {
     return true
   }
 
-  async list(args: { alias?: string; provider?: string }): Promise<IIdentifier[]> {
+  async listDIDs(args: { alias?: string; provider?: string }): Promise<IIdentifier[]> {
     const where: any = { provider: args?.provider || Not(IsNull()) }
     if (args?.alias) {
       where['alias'] = args.alias

--- a/packages/data-store/src/identifier/key-store.ts
+++ b/packages/data-store/src/identifier/key-store.ts
@@ -27,13 +27,13 @@ export class KeyStore extends AbstractKeyStore {
     super()
   }
 
-  async get({ kid }: { kid: string }): Promise<IKey> {
+  async getKey({ kid }: { kid: string }): Promise<IKey> {
     const key = await (await getConnectedDb(this.dbConnection)).getRepository(Key).findOneBy({ kid })
     if (!key) throw Error('Key not found')
     return key as IKey
   }
 
-  async delete({ kid }: { kid: string }) {
+  async deleteKey({ kid }: { kid: string }) {
     const key = await (await getConnectedDb(this.dbConnection)).getRepository(Key).findOneBy({ kid })
     if (!key) throw Error('Key not found')
     debug('Deleting key', kid)
@@ -41,7 +41,7 @@ export class KeyStore extends AbstractKeyStore {
     return true
   }
 
-  async import(args: IKey) {
+  async importKey(args: IKey) {
     const key = new Key()
     key.kid = args.kid
     key.publicKeyHex = args.publicKeyHex
@@ -53,7 +53,7 @@ export class KeyStore extends AbstractKeyStore {
     return true
   }
 
-  async list(args: {} = {}): Promise<ManagedKeyInfo[]> {
+  async listKeys(args: {} = {}): Promise<ManagedKeyInfo[]> {
     const keys = await (await getConnectedDb(this.dbConnection)).getRepository(Key).find()
     const managedKeys: ManagedKeyInfo[] = keys.map((key) => {
       const { kid, publicKeyHex, type, meta, kms } = key

--- a/packages/data-store/src/identifier/private-key-store.ts
+++ b/packages/data-store/src/identifier/private-key-store.ts
@@ -26,7 +26,7 @@ export class PrivateKeyStore extends AbstractPrivateKeyStore {
     }
   }
 
-  async get({ alias }: { alias: string }): Promise<ManagedPrivateKey> {
+  async getKey({ alias }: { alias: string }): Promise<ManagedPrivateKey> {
     const key = await (await getConnectedDb(this.dbConnection)).getRepository(PrivateKey).findOneBy({ alias })
     if (!key) throw Error('Key not found')
     if (this.secretBox && key.privateKeyHex) {
@@ -35,7 +35,7 @@ export class PrivateKeyStore extends AbstractPrivateKeyStore {
     return key as ManagedPrivateKey
   }
 
-  async delete({ alias }: { alias: string }) {
+  async deleteKey({ alias }: { alias: string }) {
     const key = await (await getConnectedDb(this.dbConnection)).getRepository(PrivateKey).findOneBy({ alias })
     if (!key) throw Error(`not_found: Private Key data not found for alias=${alias}`)
     debug('Deleting private key data', alias)
@@ -43,7 +43,7 @@ export class PrivateKeyStore extends AbstractPrivateKeyStore {
     return true
   }
 
-  async import(args: ImportablePrivateKey): Promise<ManagedPrivateKey> {
+  async importKey(args: ImportablePrivateKey): Promise<ManagedPrivateKey> {
     const key = new PrivateKey()
     key.alias = args.alias || uuid4()
     key.privateKeyHex = args.privateKeyHex
@@ -63,7 +63,7 @@ export class PrivateKeyStore extends AbstractPrivateKeyStore {
     return key
   }
 
-  async list(): Promise<Array<ManagedPrivateKey>> {
+  async listKeys(): Promise<Array<ManagedPrivateKey>> {
     const keys = await (await getConnectedDb(this.dbConnection)).getRepository(PrivateKey).find()
     return keys
   }

--- a/packages/did-manager/src/abstract-identifier-store.ts
+++ b/packages/did-manager/src/abstract-identifier-store.ts
@@ -5,9 +5,9 @@ import { IIdentifier } from '@veramo/core'
  * @public
  */
 export abstract class AbstractDIDStore {
-  abstract import(args: IIdentifier): Promise<boolean>
-  abstract get(args: { did: string }): Promise<IIdentifier>
-  abstract get(args: { alias: string; provider: string }): Promise<IIdentifier>
-  abstract delete(args: { did: string }): Promise<boolean>
-  abstract list(args: { alias?: string; provider?: string }): Promise<IIdentifier[]>
+  abstract importDID(args: IIdentifier): Promise<boolean>
+  abstract getDID(args: { did: string }): Promise<IIdentifier>
+  abstract getDID(args: { alias: string; provider: string }): Promise<IIdentifier>
+  abstract deleteDID(args: { did: string }): Promise<boolean>
+  abstract listDIDs(args: { alias?: string; provider?: string }): Promise<IIdentifier[]>
 }

--- a/packages/did-manager/src/id-manager.ts
+++ b/packages/did-manager/src/id-manager.ts
@@ -84,18 +84,18 @@ export class DIDManager implements IAgentPlugin {
 
   /** {@inheritDoc @veramo/core#IDIDManager.didManagerFind} */
   async didManagerFind(args: IDIDManagerFindArgs): Promise<IIdentifier[]> {
-    return this.store.list(args)
+    return this.store.listDIDs(args)
   }
 
   /** {@inheritDoc @veramo/core#IDIDManager.didManagerGet} */
   async didManagerGet({ did }: IDIDManagerGetArgs): Promise<IIdentifier> {
-    return this.store.get({ did })
+    return this.store.getDID({ did })
   }
 
   /** {@inheritDoc @veramo/core#IDIDManager.didManagerGetByAlias} */
   async didManagerGetByAlias({ alias, provider }: IDIDManagerGetByAliasArgs): Promise<IIdentifier> {
     const providerName = provider || this.defaultProvider
-    return this.store.get({ alias, provider: providerName })
+    return this.store.getDID({ alias, provider: providerName })
   }
 
   /** {@inheritDoc @veramo/core#IDIDManager.didManagerCreate} */
@@ -107,7 +107,7 @@ export class DIDManager implements IAgentPlugin {
     if (args?.alias !== undefined) {
       let existingIdentifier
       try {
-        existingIdentifier = await this.store.get({ alias: args.alias, provider: providerName })
+        existingIdentifier = await this.store.getDID({ alias: args.alias, provider: providerName })
       } catch (e) {}
       if (existingIdentifier) {
         throw Error(
@@ -124,7 +124,7 @@ export class DIDManager implements IAgentPlugin {
     if (args?.alias) {
       identifier.alias = args.alias
     }
-    await this.store.import(identifier)
+    await this.store.importDID(identifier)
     return identifier
   }
 
@@ -136,7 +136,7 @@ export class DIDManager implements IAgentPlugin {
     try {
       const providerName = provider || this.defaultProvider
       // @ts-ignore
-      const identifier = await this.store.get({ alias, provider: providerName })
+      const identifier = await this.store.getDID({ alias, provider: providerName })
       return identifier
     } catch {
       return this.didManagerCreate({ provider, alias, kms, options }, context)
@@ -157,7 +157,7 @@ export class DIDManager implements IAgentPlugin {
      * 6. Update the identifier in the store
      * 7. Return the identifier
      */
-      const identifier = await this.store.get({ did })
+      const identifier = await this.store.getDID({ did })
       const identifierProvider = this.getProvider(identifier.provider)
       if (typeof identifierProvider?.updateIdentifier !== 'function') {
         throw new Error(`not_supported: ${identifier?.provider} provider does not implement full document updates`)
@@ -166,7 +166,7 @@ export class DIDManager implements IAgentPlugin {
         { did, document, options },
         context,
       )
-      await this.store.import(updatedIdentifier)
+      await this.store.importDID(updatedIdentifier)
       return updatedIdentifier
   }
 
@@ -175,9 +175,9 @@ export class DIDManager implements IAgentPlugin {
     { did, alias }: IDIDManagerSetAliasArgs,
     context: IAgentContext<IKeyManager>,
   ): Promise<boolean> {
-    const identifier = await this.store.get({ did })
+    const identifier = await this.store.getDID({ did })
     identifier.alias = alias
-    return await this.store.import(identifier)
+    return await this.store.importDID(identifier)
   }
 
   /** {@inheritDoc @veramo/core#IDIDManager.didManagerImport} */
@@ -196,7 +196,7 @@ export class DIDManager implements IAgentPlugin {
       keys,
       services,
     }
-    await this.store.import(importedDID)
+    await this.store.importDID(importedDID)
     return importedDID
   }
 
@@ -205,10 +205,10 @@ export class DIDManager implements IAgentPlugin {
     { did }: IDIDManagerDeleteArgs,
     context: IAgentContext<IKeyManager>,
   ): Promise<boolean> {
-    const identifier = await this.store.get({ did })
+    const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
     await provider.deleteIdentifier(identifier, context)
-    return this.store.delete({ did })
+    return this.store.deleteDID({ did })
   }
 
   /** {@inheritDoc @veramo/core#IDIDManager.didManagerAddKey} */
@@ -216,11 +216,11 @@ export class DIDManager implements IAgentPlugin {
     { did, key, options }: IDIDManagerAddKeyArgs,
     context: IAgentContext<IKeyManager>,
   ): Promise<any> {
-    const identifier = await this.store.get({ did })
+    const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
     const result = await provider.addKey({ identifier, key, options }, context)
     identifier.keys.push(key)
-    await this.store.import(identifier)
+    await this.store.importDID(identifier)
     return result
   }
 
@@ -229,11 +229,11 @@ export class DIDManager implements IAgentPlugin {
     { did, kid, options }: IDIDManagerRemoveKeyArgs,
     context: IAgentContext<IKeyManager>,
   ): Promise<any> {
-    const identifier = await this.store.get({ did })
+    const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
     const result = await provider.removeKey({ identifier, kid, options }, context)
     identifier.keys = identifier.keys.filter((k) => k.kid !== kid)
-    await this.store.import(identifier)
+    await this.store.importDID(identifier)
     return result
   }
 
@@ -242,11 +242,11 @@ export class DIDManager implements IAgentPlugin {
     { did, service, options }: IDIDManagerAddServiceArgs,
     context: IAgentContext<IKeyManager>,
   ): Promise<any> {
-    const identifier = await this.store.get({ did })
+    const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
     const result = await provider.addService({ identifier, service, options }, context)
     identifier.services.push(service)
-    await this.store.import(identifier)
+    await this.store.importDID(identifier)
     return result
   }
 
@@ -255,11 +255,11 @@ export class DIDManager implements IAgentPlugin {
     { did, id, options }: IDIDManagerRemoveServiceArgs,
     context: IAgentContext<IKeyManager>,
   ): Promise<any> {
-    const identifier = await this.store.get({ did })
+    const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
     const result = await provider.removeService({ identifier, id, options }, context)
     identifier.services = identifier.services.filter((s) => s.id !== id)
-    await this.store.import(identifier)
+    await this.store.importDID(identifier)
     return result
   }
 }

--- a/packages/did-manager/src/memory-did-store.ts
+++ b/packages/did-manager/src/memory-did-store.ts
@@ -9,7 +9,7 @@ import { AbstractDIDStore } from './abstract-identifier-store.js'
 export class MemoryDIDStore extends AbstractDIDStore {
   private identifiers: Record<string, IIdentifier> = {}
 
-  async get({
+  async getDID({
     did,
     alias,
     provider,
@@ -33,12 +33,12 @@ export class MemoryDIDStore extends AbstractDIDStore {
     throw Error(`not_found: IIdentifier not found with alias=${alias} provider=${provider}`)
   }
 
-  async delete({ did }: { did: string }) {
+  async deleteDID({ did }: { did: string }) {
     delete this.identifiers[did]
     return true
   }
 
-  async import(args: IIdentifier) {
+  async importDID(args: IIdentifier) {
     const identifier = { ...args }
     for (const key of identifier.keys) {
       if (key.privateKeyHex) {
@@ -49,7 +49,7 @@ export class MemoryDIDStore extends AbstractDIDStore {
     return true
   }
 
-  async list(args: { alias?: string; provider?: string }): Promise<IIdentifier[]> {
+  async listDIDs(args: { alias?: string; provider?: string }): Promise<IIdentifier[]> {
     let result: IIdentifier[] = []
 
     for (const key of Object.keys(this.identifiers)) {

--- a/packages/key-manager/src/__tests__/abstract-key-store.test.ts
+++ b/packages/key-manager/src/__tests__/abstract-key-store.test.ts
@@ -2,7 +2,7 @@ import { AbstractKeyStore } from '../abstract-key-store'
 import { IKey, ManagedKeyInfo } from '@veramo/core'
 
 class MockKeyStore extends AbstractKeyStore {
-  async list(args: {}): Promise<ManagedKeyInfo[]> {
+  async listKeys(args: {}): Promise<ManagedKeyInfo[]> {
     return [
       {
         kid: '',
@@ -12,7 +12,7 @@ class MockKeyStore extends AbstractKeyStore {
       },
     ]
   }
-  async get({ kid }: { kid: string }): Promise<IKey> {
+  async getKey({ kid }: { kid: string }): Promise<IKey> {
     return {
       kid: '',
       kms: '',
@@ -21,11 +21,11 @@ class MockKeyStore extends AbstractKeyStore {
     }
   }
 
-  async delete({ kid }: { kid: string }) {
+  async deleteKey({ kid }: { kid: string }) {
     return true
   }
 
-  async import(args: IKey): Promise<boolean> {
+  async importKey(args: IKey): Promise<boolean> {
     return true
   }
 }

--- a/packages/key-manager/src/abstract-key-store.ts
+++ b/packages/key-manager/src/abstract-key-store.ts
@@ -10,11 +10,11 @@ import { IKey, ManagedKeyInfo } from '@veramo/core'
  * @public
  */
 export abstract class AbstractKeyStore {
-  abstract import(args: Partial<IKey>): Promise<boolean>
+  abstract importKey(args: Partial<IKey>): Promise<boolean>
 
-  abstract get(args: { kid: string }): Promise<IKey>
+  abstract getKey(args: { kid: string }): Promise<IKey>
 
-  abstract delete(args: { kid: string }): Promise<boolean>
+  abstract deleteKey(args: { kid: string }): Promise<boolean>
 
-  abstract list(args: {}): Promise<Array<ManagedKeyInfo>>
+  abstract listKeys(args: {}): Promise<Array<ManagedKeyInfo>>
 }

--- a/packages/key-manager/src/abstract-private-key-store.ts
+++ b/packages/key-manager/src/abstract-private-key-store.ts
@@ -34,11 +34,11 @@ export type ImportablePrivateKey = RequireOnly<ManagedPrivateKey, 'privateKeyHex
  * @public
  */
 export abstract class AbstractPrivateKeyStore {
-  abstract import(args: ImportablePrivateKey): Promise<ManagedPrivateKey>
+  abstract importKey(args: ImportablePrivateKey): Promise<ManagedPrivateKey>
 
-  abstract get(args: { alias: string }): Promise<ManagedPrivateKey>
+  abstract getKey(args: { alias: string }): Promise<ManagedPrivateKey>
 
-  abstract delete(args: { alias: string }): Promise<boolean>
+  abstract deleteKey(args: { alias: string }): Promise<boolean>
 
-  abstract list(args: {}): Promise<Array<ManagedPrivateKey>>
+  abstract listKeys(args: {}): Promise<Array<ManagedPrivateKey>>
 }

--- a/packages/key-manager/src/memory-key-store.ts
+++ b/packages/key-manager/src/memory-key-store.ts
@@ -18,23 +18,23 @@ import { v4 as uuidv4 } from 'uuid'
 export class MemoryKeyStore extends AbstractKeyStore {
   private keys: Record<string, IKey> = {}
 
-  async get({ kid }: { kid: string }): Promise<IKey> {
+  async getKey({ kid }: { kid: string }): Promise<IKey> {
     const key = this.keys[kid]
     if (!key) throw Error('Key not found')
     return key
   }
 
-  async delete({ kid }: { kid: string }) {
+  async deleteKey({ kid }: { kid: string }) {
     delete this.keys[kid]
     return true
   }
 
-  async import(args: IKey) {
+  async importKey(args: IKey) {
     this.keys[args.kid] = { ...args }
     return true
   }
 
-  async list(args: {}): Promise<Exclude<IKey, 'privateKeyHex'>[]> {
+  async listKeys(args: {}): Promise<Exclude<IKey, 'privateKeyHex'>[]> {
     const safeKeys = Object.values(this.keys).map((key) => {
       const { privateKeyHex, ...safeKey } = key
       return safeKey
@@ -53,18 +53,18 @@ export class MemoryKeyStore extends AbstractKeyStore {
 export class MemoryPrivateKeyStore extends AbstractPrivateKeyStore {
   private privateKeys: Record<string, ManagedPrivateKey> = {}
 
-  async get({ alias }: { alias: string }): Promise<ManagedPrivateKey> {
+  async getKey({ alias }: { alias: string }): Promise<ManagedPrivateKey> {
     const key = this.privateKeys[alias]
     if (!key) throw Error(`not_found: PrivateKey not found for alias=${alias}`)
     return key
   }
 
-  async delete({ alias }: { alias: string }) {
+  async deleteKey({ alias }: { alias: string }) {
     delete this.privateKeys[alias]
     return true
   }
 
-  async import(args: ImportablePrivateKey) {
+  async importKey(args: ImportablePrivateKey) {
     const alias = args.alias || uuidv4()
     const existingEntry = this.privateKeys[alias]
     if (existingEntry && existingEntry.privateKeyHex !== args.privateKeyHex) {
@@ -74,7 +74,7 @@ export class MemoryPrivateKeyStore extends AbstractPrivateKeyStore {
     return this.privateKeys[alias]
   }
 
-  async list(): Promise<Array<ManagedPrivateKey>> {
+  async listKeys(): Promise<Array<ManagedPrivateKey>> {
     return [...Object.values(this.privateKeys)]
   }
 }

--- a/packages/kms-local/src/key-management-system.ts
+++ b/packages/kms-local/src/key-management-system.ts
@@ -49,13 +49,13 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
       throw new Error('invalid_argument: type and privateKeyHex are required to import a key')
     }
     const managedKey = this.asManagedKeyInfo({ alias: args.kid, ...args })
-    await this.keyStore.import({ alias: managedKey.kid, ...args })
+    await this.keyStore.importKey({ alias: managedKey.kid, ...args })
     debug('imported key', managedKey.type, managedKey.publicKeyHex)
     return managedKey
   }
 
   async listKeys(): Promise<ManagedKeyInfo[]> {
-    const privateKeys = await this.keyStore.list({})
+    const privateKeys = await this.keyStore.listKeys({})
     const managedKeys = privateKeys.map((key) => this.asManagedKeyInfo(key))
     return managedKeys
   }
@@ -99,7 +99,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
   }
 
   async deleteKey(args: { kid: string }) {
-    return await this.keyStore.delete({ alias: args.kid })
+    return await this.keyStore.deleteKey({ alias: args.kid })
   }
 
   async sign({
@@ -113,7 +113,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
   }): Promise<string> {
     let managedKey: ManagedPrivateKey
     try {
-      managedKey = await this.keyStore.get({ alias: keyRef.kid })
+      managedKey = await this.keyStore.getKey({ alias: keyRef.kid })
     } catch (e) {
       throw new Error(`key_not_found: No key entry found for kid=${keyRef.kid}`)
     }
@@ -150,7 +150,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
   }): Promise<string> {
     let myKey: ManagedPrivateKey
     try {
-      myKey = await this.keyStore.get({ alias: args.myKeyRef.kid })
+      myKey = await this.keyStore.getKey({ alias: args.myKeyRef.kid })
     } catch (e) {
       throw new Error(`key_not_found: No key entry found for kid=${args.myKeyRef.kid}`)
     }


### PR DESCRIPTION
## What issue is this PR fixing

fixes #1090

## What is being changed

The `import` method name was causing issues on SES, so it was renamed in the DID/Key stores.
To keep the API consistent, I renamed all the other methods in the stores as well.

This is a BREAKING CHANGE, as the API of these interfaces is getting a rename.
Functionality remains the same.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because functionality does not change.