### PR TITLE
feat(core-types): allow inline @context for Credentials and Presentations

### DIFF
--- a/packages/core-types/src/plugin.schema.json
+++ b/packages/core-types/src/plugin.schema.json
@@ -2107,17 +2107,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -2178,6 +2168,30 @@
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
         },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
+        },
         "CredentialStatusReference": {
           "type": "object",
           "properties": {
@@ -2223,17 +2237,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",
@@ -2970,17 +2974,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -3041,6 +3035,30 @@
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
         },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
+        },
         "CredentialStatusReference": {
           "type": "object",
           "properties": {
@@ -3086,17 +3104,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",
@@ -3811,17 +3819,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -3882,6 +3880,30 @@
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
         },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
+        },
         "CredentialStatusReference": {
           "type": "object",
           "properties": {
@@ -3927,17 +3949,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",
@@ -4101,10 +4113,7 @@
               }
             },
             "@context": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "$ref": "#/components/schemas/DateType"
@@ -4151,6 +4160,30 @@
             }
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
+        },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
         },
         "DateType": {
           "type": "string",
@@ -4207,17 +4240,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -4315,10 +4338,7 @@
               }
             },
             "@context": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",
@@ -4385,17 +4405,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",
@@ -4507,17 +4517,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -4577,6 +4577,30 @@
             }
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
+        },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
         },
         "CredentialStatusReference": {
           "type": "object",
@@ -4733,17 +4757,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",
@@ -4849,17 +4863,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -4919,6 +4923,30 @@
             }
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
+        },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
         },
         "CredentialStatusReference": {
           "type": "object",
@@ -5299,17 +5327,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -5369,6 +5387,30 @@
             }
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
+        },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
         }
       },
       "methods": {

--- a/packages/core-types/src/types/vc-data-model.ts
+++ b/packages/core-types/src/types/vc-data-model.ts
@@ -77,6 +77,13 @@ export interface ProofType {
 }
 
 /**
+ * The data type for `@context` properties of credentials, presentations, etc.
+ *
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
+export type ContextType = string | Record<string, any> | (string | Record<string, any>)[]
+
+/**
  * Represents an unsigned W3C Credential payload.
  * See {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model}
  *
@@ -86,7 +93,7 @@ export interface UnsignedCredential {
   issuer: IssuerType
   credentialSubject: CredentialSubject
   type?: string[] | string
-  '@context': string[] | string
+  '@context': ContextType
   issuanceDate: string
   expirationDate?: string
   credentialStatus?: CredentialStatusReference
@@ -121,7 +128,7 @@ export interface UnsignedPresentation {
   holder: string
   verifiableCredential?: W3CVerifiableCredential[]
   type?: string[] | string
-  '@context': string[] | string
+  '@context': ContextType
   verifier?: string[]
   issuanceDate?: string
   expirationDate?: string
@@ -162,7 +169,7 @@ export interface CredentialPayload {
   issuer: IssuerType
   credentialSubject?: CredentialSubject
   type?: string[]
-  '@context'?: string[]
+  '@context'?: ContextType
   issuanceDate?: DateType
   expirationDate?: DateType
   credentialStatus?: CredentialStatusReference
@@ -180,7 +187,7 @@ export interface PresentationPayload {
   holder: string
   verifiableCredential?: W3CVerifiableCredential[]
   type?: string[]
-  '@context'?: string[]
+  '@context'?: ContextType
   verifier?: string[]
   issuanceDate?: DateType
   expirationDate?: DateType

--- a/packages/credential-eip712/src/plugin.schema.json
+++ b/packages/credential-eip712/src/plugin.schema.json
@@ -35,10 +35,7 @@
               }
             },
             "@context": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "$ref": "#/components/schemas/DateType"
@@ -86,6 +83,30 @@
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
         },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
+        },
         "DateType": {
           "type": "string",
           "description": "Represents an issuance or expiration date for Credentials / Presentations. This is used as input when creating them."
@@ -132,17 +153,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -211,10 +222,7 @@
               }
             },
             "@context": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",
@@ -281,17 +289,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",

--- a/packages/credential-ld/src/__tests__/issue-verify-flow.test.ts
+++ b/packages/credential-ld/src/__tests__/issue-verify-flow.test.ts
@@ -80,6 +80,34 @@ describe('credential-LD full flow', () => {
     didEthrIdentifier = await agent.didManagerCreate({ provider: 'did:ethr:goerli' })
   })
 
+  it('create credential with inline context', async () => {
+    const credential: CredentialPayload = {
+      issuer: didKeyIdentifier.did,
+      '@context': [
+        {
+          '@context': {
+            nothing: 'custom:example.context#blank',
+          },
+        },
+      ],
+      credentialSubject: {
+        nothing: 'else matters',
+      },
+    }
+    const verifiableCredential = await agent.createVerifiableCredential({
+      credential,
+      proofFormat: 'lds',
+    })
+
+    expect(verifiableCredential).toBeDefined()
+
+    const result = await agent.verifyCredential({
+      credential: verifiableCredential,
+    })
+
+    expect(result.verified).toBe(true)
+  })
+
   it('works with Ed25519Signature2018 credential', async () => {
     const credential: CredentialPayload = {
       issuer: didKeyIdentifier.did,

--- a/packages/credential-ld/src/plugin.schema.json
+++ b/packages/credential-ld/src/plugin.schema.json
@@ -42,10 +42,7 @@
               }
             },
             "@context": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "$ref": "#/components/schemas/DateType"
@@ -93,6 +90,30 @@
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
         },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
+        },
         "DateType": {
           "type": "string",
           "description": "Represents an issuance or expiration date for Credentials / Presentations. This is used as input when creating them."
@@ -139,17 +160,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -233,10 +244,7 @@
               }
             },
             "@context": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",
@@ -303,17 +311,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",

--- a/packages/credential-ld/src/suites/JsonWebSignature2020.ts
+++ b/packages/credential-ld/src/suites/JsonWebSignature2020.ts
@@ -2,19 +2,19 @@ import { CredentialPayload, DIDDocument, IAgentContext, IKey, TKeyType } from "@
 import { RequiredAgentMethods, VeramoLdSignature } from "../ld-suites.js";
 import * as u8a from "uint8arrays";
 import { JsonWebKey, JsonWebSignature } from "@transmute/json-web-signature";
-import { encodeJoseBlob } from "@veramo/utils";
+import { asArray, encodeJoseBlob } from "@veramo/utils";
 
 
 /**
  * Veramo wrapper for the JsonWebSignature2020 suite by Transmute Industries
- * 
+ *
  * @alpha This API is experimental and is very likely to change or disappear in future releases without notice.
  */
 export class VeramoJsonWebSignature2020 extends VeramoLdSignature {
     getSupportedVerificationType(): 'JsonWebKey2020' {
         return 'JsonWebKey2020'
     }
-    
+
     getSupportedVeramoKeyType(): TKeyType {
         return 'Ed25519'
     }
@@ -68,6 +68,10 @@ export class VeramoJsonWebSignature2020 extends VeramoLdSignature {
             key: verificationKey,
         })
 
+        suite.ensureSuiteContext = ({ document }: { document: any, addSuiteContext: boolean }) => {
+            document['@context'] = [...asArray(document['@context'] || []), 'https://w3id.org/security/suites/jws-2020/v1']
+        }
+
         return suite
     }
 
@@ -76,10 +80,11 @@ export class VeramoJsonWebSignature2020 extends VeramoLdSignature {
     }
 
     preSigningCredModification(credential: CredentialPayload): void {
-        credential['@context'] = [...credential['@context'] || [], 'https://w3id.org/security/suites/jws-2020/v1']
+        // nop
     }
 
     preDidResolutionModification(didUrl: string, didDoc: DIDDocument): void {
         // do nothing
     }
+
 }

--- a/packages/did-comm/src/plugin.schema.json
+++ b/packages/did-comm/src/plugin.schema.json
@@ -405,17 +405,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -476,6 +466,30 @@
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
         },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
+        },
         "CredentialStatusReference": {
           "type": "object",
           "properties": {
@@ -521,17 +535,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",

--- a/packages/selective-disclosure/src/plugin.schema.json
+++ b/packages/selective-disclosure/src/plugin.schema.json
@@ -70,17 +70,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "verifier": {
               "type": "array",
@@ -151,17 +141,7 @@
               ]
             },
             "@context": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/components/schemas/ContextType"
             },
             "issuanceDate": {
               "type": "string"
@@ -212,6 +192,30 @@
             }
           },
           "description": "The value of the credentialSubject property is defined as a set of objects that contain one or more properties that are each related to a subject of the verifiable credential. Each object MAY contain an id.\n\nSee  {@link  https://www.w3.org/TR/vc-data-model/#credential-subject | Credential Subject }"
+        },
+        "ContextType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              }
+            }
+          ],
+          "description": "The data type for `@context` properties of credentials, presentations, etc."
         },
         "CredentialStatusReference": {
           "type": "object",

--- a/packages/utils/src/credential-utils.ts
+++ b/packages/utils/src/credential-utils.ts
@@ -30,7 +30,7 @@ export const MANDATORY_CREDENTIAL_CONTEXT = 'https://www.w3.org/2018/credentials
  * @beta This API may change without a BREAKING CHANGE notice.
  */
 export function processEntryToArray(
-  inputEntryOrArray?: string | string[] | null,
+  inputEntryOrArray?: string | string[] | any,
   startWithEntry?: string,
 ): string[] {
   const result: string[] = asArray<string>(inputEntryOrArray) || [startWithEntry]

--- a/packages/utils/src/type-utils.ts
+++ b/packages/utils/src/type-utils.ts
@@ -20,7 +20,7 @@ export function isDefined<T>(arg: T): arg is Exclude<T, null | undefined> {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export function asArray<T>(arg?: T | T[] | null): T[] {
+export function asArray<T>(arg?: T | T[] | any): (T | any)[] {
   return isDefined(arg) ? (Array.isArray(arg) ? arg : [arg]) : []
 }
 

--- a/scripts/prepare-integration-tests.ts
+++ b/scripts/prepare-integration-tests.ts
@@ -86,8 +86,6 @@ for (const packageName of Object.keys(agentPlugins)) {
     console.log(packageName, pluginInterfaceName)
     const pluginInterface = entry.findMembersByName(pluginInterfaceName)[0]
 
-    console.log('extracting plugin interface members for ', pluginInterfaceName)
-
     // Collecting method information
     const methods: RestMethod[] = []
     for (const member of pluginInterface.members) {


### PR DESCRIPTION
## What issue is this PR fixing

fixes #1073

## What is being changed

This PR defines a data type for `@context` properties to include inline objects too, besides strings and string arrays.

## Quality
Check all that apply:
* [x] I want these changes to be integrated
* [x] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [x] I added unit tests.
* [ ] I added integration tests.
