### PR TITLE
fix: fixes missing `.js` file extension

### DIFF
--- a/packages/did-provider-pkh/src/resolver.ts
+++ b/packages/did-provider-pkh/src/resolver.ts
@@ -6,7 +6,7 @@ import type {
   Resolvable,
   ResolverRegistry,
 } from 'did-resolver';
-import { isValidNamespace, SECPK1_NAMESPACES } from './pkh-did-provider';
+import { isValidNamespace, SECPK1_NAMESPACES } from './pkh-did-provider.js';
 import Debug from 'debug'
 
 const debug = Debug('veramo:pkh-did-resolver')


### PR DESCRIPTION
## What issue is this PR fixing

fixes #1122 

## What is being changed
Adds missing `.js` file extension for a relative path import.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

## Details
If applicable, add screen captures, error messages or stack traces to help explain your problem.
