### PR TITLE
fix(did-provider-ethr): export KMSEthereumSigner for convenience

### DIFF
--- a/packages/did-provider-ethr/src/index.ts
+++ b/packages/did-provider-ethr/src/index.ts
@@ -5,3 +5,4 @@
  * @packageDocumentation
  */
 export { EthrDIDProvider } from './ethr-did-provider.js'
+export { KmsEthereumSigner } from './kms-eth-signer.js'

--- a/packages/did-provider-ethr/src/kms-eth-signer.ts
+++ b/packages/did-provider-ethr/src/kms-eth-signer.ts
@@ -10,6 +10,8 @@ import { IKey } from '@veramo/core-types'
 /**
  * Creates an `@ethersproject/abstract-signer` implementation by wrapping
  * a veramo agent with a key-manager that should be capable of `eth_signTransaction`
+ *
+ * @internal This is exported for convenience, not meant to be supported as part of the public API
  */
 export class KmsEthereumSigner extends Signer implements TypedDataSigner {
   private context: IRequiredContext


### PR DESCRIPTION
## What issue is this PR fixing

relates to #583

## What is being changed

The `KMSEthereumSigner` class is now exported, but only for convenience.
It is not (yet) meant to be part of the public API.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.
