### PR TITLE
docs: link core-types package properly for documentation output

### DIFF
--- a/__tests__/shared/keyManager.ts
+++ b/__tests__/shared/keyManager.ts
@@ -83,7 +83,7 @@ export default (testContext: {
       await expect(
         agent.keyManagerCreate({
           kms: 'local',
-          //@ts-ignore
+          // @ts-ignore
           type: 'foobar',
         }),
       ).rejects.toThrow('Key type not supported: foobar')
@@ -505,7 +505,7 @@ export default (testContext: {
         },
       }
 
-      //@ts-ignore
+      // @ts-ignore
       const recovered = recoverTypedSignature({
         data: data as any,
         signature: signature,
@@ -604,7 +604,7 @@ export default (testContext: {
       }
 
       const args = { data, signature: signature, version: SignTypedDataVersion.V4 }
-      //@ts-ignore
+      // @ts-ignore
       const recovered = recoverTypedSignature(args)
       expect(address.toLowerCase()).toEqual(recovered)
     })

--- a/__tests__/shared/resolveDid.ts
+++ b/__tests__/shared/resolveDid.ts
@@ -127,19 +127,19 @@ export default (testContext: {
 
     it('should throw error when resolving garbage', async () => {
       expect.assertions(3)
-      //@ts-ignore
+      // @ts-ignore
       await expect(agent.resolveDid()).resolves.toEqual({
         didDocument: null,
         didDocumentMetadata: {},
         didResolutionMetadata: { error: 'invalidDid' },
       })
-      //@ts-ignore
+      // @ts-ignore
       await expect(agent.resolveDid({})).resolves.toEqual({
         didDocument: null,
         didDocumentMetadata: {},
         didResolutionMetadata: { error: 'invalidDid' },
       })
-      //@ts-ignore
+      // @ts-ignore
       await expect(agent.resolveDid({ didUrl: 'garbage' })).resolves.toEqual({
         didDocument: null,
         didDocumentMetadata: {},
@@ -160,11 +160,11 @@ export default (testContext: {
 
     it('should throw validation error', async () => {
       expect.assertions(3)
-      //@ts-ignore
+      // @ts-ignore
       await expect(agent.resolveDid()).rejects.toHaveProperty('name', 'ValidationError')
-      //@ts-ignore
+      // @ts-ignore
       await expect(agent.resolveDid({})).rejects.toHaveProperty('name', 'ValidationError')
-      //@ts-ignore
+      // @ts-ignore
       await expect(agent.resolveDid({ didUrl: 1 })).rejects.toHaveProperty('name', 'ValidationError')
     })
   })

--- a/__tests__/utils/ethers-provider.ts
+++ b/__tests__/utils/ethers-provider.ts
@@ -18,11 +18,11 @@ class MockWeb3Provider implements ExternalProvider {
     
     switch(request.method) {
       case 'personal_sign':
-        //@ts-ignore
+        // @ts-ignore
         return this.wallet.signMessage(request.params[1])
         break
         case 'eth_signTypedData_v4':
-        //@ts-ignore
+        // @ts-ignore
         const {domain, types, message} = JSON.parse(request.params[1])
         delete(types.EIP712Domain)
         return this.wallet._signTypedData(domain, types, message)

--- a/docsconfig.json
+++ b/docsconfig.json
@@ -1,6 +1,7 @@
 {
     "documentPackages": [
         "core",
+        "core-types",
         "credential-ld",
         "credential-status",
         "credential-w3c",

--- a/packages/cli/src/dev.ts
+++ b/packages/cli/src/dev.ts
@@ -77,7 +77,7 @@ function getReference(response: string): OpenAPIV3.ReferenceObject | OpenAPIV3.S
   }
 
   if (['string', 'number', 'boolean', 'object', 'integer'].includes(response)) {
-    //@ts-ignore
+    // @ts-ignore
     return { type: response }
   } else {
     return { $ref: '#/components/schemas/' + response }
@@ -152,28 +152,28 @@ dev
         const methodSignature = member as ApiMethodSignature
         method.description = methodSignature.tsdocComment?.summarySection
           ?.getChildNodes()[0]
-          //@ts-ignore
+          // @ts-ignore
           ?.getChildNodes()[0]?.text
 
         method.description = method.description || ''
 
         if (method.parameters) {
-          //@ts-ignore
+          // @ts-ignore
           api.components.schemas = {
-            //@ts-ignore
+            // @ts-ignore
             ...api.components.schemas,
             ...createSchema(generator, method.parameters).components.schemas,
           }
         }
 
-        //@ts-ignore
+        // @ts-ignore
         api.components.schemas = {
-          //@ts-ignore
+          // @ts-ignore
           ...api.components.schemas,
           ...createSchema(generator, method.response).components.schemas,
         }
 
-        //@ts-ignore
+        // @ts-ignore
         api.components.methods[method.operationId] = {
           description: method.description,
           arguments: getReference(method.parameters),

--- a/packages/cli/src/execute.ts
+++ b/packages/cli/src/execute.ts
@@ -24,7 +24,7 @@ program
 
       if (!method) {
         const answers = await inquirer.prompt({
-          //@ts-ignore
+          // @ts-ignore
           type: 'autocomplete',
           name: 'method',
           pageSize: 15,

--- a/packages/cli/src/lib/agentCreator.ts
+++ b/packages/cli/src/lib/agentCreator.ts
@@ -2,7 +2,7 @@ import { TAgent, IPluginMethodMap } from '@veramo/core-types'
 import { createObjects } from './objectCreator.js'
 
 export async function createAgentFromConfig<T extends IPluginMethodMap>(config: object): Promise<TAgent<T>> {
-  //@ts-ignore
+  // @ts-ignore
   const { agent } = await createObjects(config, { agent: '/agent' })
   return agent
 }

--- a/packages/cli/src/sdr.ts
+++ b/packages/cli/src/sdr.ts
@@ -278,7 +278,7 @@ sdr
         ' ' +
         shortDid(message.from) +
         ' asking to share: ' +
-        //@ts-ignore
+        // @ts-ignore
         message.data?.claims?.map((claim) => claim.claimType).join(','),
       value: message,
     }))

--- a/packages/core-types/src/index.ts
+++ b/packages/core-types/src/index.ts
@@ -1,5 +1,7 @@
 /**
- * Provides {@link @veramo/core#Agent} implementation and defines {@link @veramo/core#IResolver}, {@link @veramo/core#IDIDManager}, {@link @veramo/core#IKeyManager}, {@link @veramo/core#IDataStore}, {@link @veramo/core#IMessageHandler} plugin interfaces
+ * Provides {@link @veramo/core#Agent} implementation and defines {@link @veramo/core-types#IResolver},
+ * {@link @veramo/core-types#IDIDManager}, {@link @veramo/core-types#IKeyManager}, {@link
+ * @veramo/core-types#IDataStore}, {@link @veramo/core-types#IMessageHandler} plugin interfaces
  *
  * @packageDocumentation
  */
@@ -23,4 +25,3 @@ export * from './types/IResolver.js'
 export * from './types/IError.js'
 export * from './types/IVerifyResult.js'
 export * from './types/vc-data-model.js'
-

--- a/packages/core-types/src/plugin.schema.json
+++ b/packages/core-types/src/plugin.schema.json
@@ -3656,8 +3656,8 @@
             },
             "save": {
               "type": "boolean",
-              "description": "Optional. If set to `true`, the message will be saved using\n {@link  @veramo/core#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage } \n<p/><p/>",
-              "deprecated": "Please call {@link @veramo/core#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} after\nhandling the message and determining that it must be saved."
+              "description": "Optional. If set to `true`, the message will be saved using\n {@link  @veramo/core-types#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage } \n<p/><p/>",
+              "deprecated": "Please call {@link @veramo/core-types#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} after\nhandling the message and determining that it must be saved."
             }
           },
           "required": [
@@ -4056,8 +4056,8 @@
             },
             "save": {
               "type": "boolean",
-              "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core#IDataStore | storage plugin }  to be saved.",
-              "deprecated": "Please call\n{@link @veramo/core#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to save\nthe credential after creating it."
+              "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core-types#IDataStore | storage plugin }  to be saved.",
+              "deprecated": "Please call\n{@link @veramo/core-types#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to save\nthe credential after creating it."
             },
             "proofFormat": {
               "$ref": "#/components/schemas/ProofFormat",
@@ -4259,8 +4259,8 @@
             },
             "save": {
               "type": "boolean",
-              "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core#IDataStore | storage plugin }  to be saved. <p/><p/>",
-              "deprecated": "Please call\n{@link @veramo/core#IDataStore.dataStoreSaveVerifiablePresentation | dataStoreSaveVerifiablePresentation()} to\nsave the credential after creating it."
+              "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core-types#IDataStore | storage plugin }  to be saved. <p/><p/>",
+              "deprecated": "Please call\n{@link @veramo/core-types#IDataStore.dataStoreSaveVerifiablePresentation | dataStoreSaveVerifiablePresentation()} to\nsave the credential after creating it."
             },
             "challenge": {
               "type": "string",

--- a/packages/core-types/src/types/IAgent.ts
+++ b/packages/core-types/src/types/IAgent.ts
@@ -55,7 +55,7 @@ export interface IEventListener {
   readonly eventTypes?: string[]
   /**
    * Processes an event emitted by the agent.
-   * @param context - Execution context. Requires agent with {@link @veramo/core#IDataStore} methods
+   * @param context - Execution context. Requires agent with {@link @veramo/core-types#IDataStore} methods
    * @public
    */
   onEvent?(event: { type: string; data: any }, context: IAgentContext<{}>): Promise<void>

--- a/packages/core-types/src/types/ICredentialIssuer.ts
+++ b/packages/core-types/src/types/ICredentialIssuer.ts
@@ -39,10 +39,10 @@ export interface ICreateVerifiablePresentationArgs {
 
   /**
    * If this parameter is true, the resulting VerifiablePresentation is sent to the
-   * {@link @veramo/core#IDataStore | storage plugin} to be saved.
+   * {@link @veramo/core-types#IDataStore | storage plugin} to be saved.
    * <p/><p/>
    * @deprecated Please call
-   *   {@link @veramo/core#IDataStore.dataStoreSaveVerifiablePresentation | dataStoreSaveVerifiablePresentation()} to
+   *   {@link @veramo/core-types#IDataStore.dataStoreSaveVerifiablePresentation | dataStoreSaveVerifiablePresentation()} to
    *   save the credential after creating it.
    */
   save?: boolean
@@ -110,10 +110,10 @@ export interface ICreateVerifiableCredentialArgs {
 
   /**
    * If this parameter is true, the resulting VerifiablePresentation is sent to the
-   * {@link @veramo/core#IDataStore | storage plugin} to be saved.
+   * {@link @veramo/core-types#IDataStore | storage plugin} to be saved.
    *
    * @deprecated Please call
-   *   {@link @veramo/core#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to save
+   *   {@link @veramo/core-types#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to save
    *   the credential after creating it.
    */
   save?: boolean
@@ -173,7 +173,7 @@ export interface ICredentialIssuer extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Presentation.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core#VerifiablePresentation} that was requested or
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiablePresentation} that was requested or
    *   rejects with an error if there was a problem with the input or while getting the key to sign
    *
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Presentation data model
@@ -191,7 +191,7 @@ export interface ICredentialIssuer extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Presentation.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core#VerifiableCredential} that was requested or rejects
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or rejects
    *   with an error if there was a problem with the input or while getting the key to sign
    *
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#credentials | Verifiable Credential data model}

--- a/packages/core-types/src/types/ICredentialStatusVerifier.ts
+++ b/packages/core-types/src/types/ICredentialStatusVerifier.ts
@@ -1,7 +1,7 @@
 import { DIDDocument } from 'did-resolver'
 import { IAgentContext, IPluginMethodMap } from './IAgent.js'
 import { VerifiableCredential, CredentialStatus } from './vc-data-model.js'
-import { IResolver } from "./IResolver.js";
+import { IResolver } from './IResolver.js'
 
 /**
  * Arguments for calling {@link ICredentialStatusVerifier.checkCredentialStatus | checkCredentialStatus}.
@@ -27,7 +27,7 @@ export interface ICheckCredentialStatusArgs {
 
 /**
  * This interface defines a plugin that can check the {@link https://www.w3.org/TR/vc-data-model/#status | status} of a
- * {@link @veramo/core#VerifiableCredential | Verifiable Credential}.
+ * {@link @veramo/core-types#VerifiableCredential | Verifiable Credential}.
  *
  * This is used for the discovery of information about the current status of a verifiable credential, such as whether
  * it is suspended or revoked. The precise contents of the credential status information is determined by the specific
@@ -44,7 +44,7 @@ export interface ICheckCredentialStatusArgs {
  */
 export interface ICredentialStatusVerifier extends IPluginMethodMap {
   /**
-   * Checks the status of a {@link @veramo/core#VerifiableCredential | Verifiable Credential}.
+   * Checks the status of a {@link @veramo/core-types#VerifiableCredential | Verifiable Credential}.
    *
    * @param args - The credential to be checked, along with the DID document of the issuer.
    * @param context - *RESERVED* This is filled by the framework when the method is called.

--- a/packages/core-types/src/types/IDIDManager.ts
+++ b/packages/core-types/src/types/IDIDManager.ts
@@ -291,7 +291,7 @@ export interface IDIDManager extends IPluginMethodMap {
    * @param args - Required. Arguments to create the identifier
    * @param context - *RESERVED* This is filled by the framework when the method is called. This method's
    *    <a href="/docs/agent/plugins#executing-plugin-methods">execution context</a> requires an `agent` that has
-   *   {@link @veramo/core#IKeyManager} methods.
+   *   {@link @veramo/core-types#IKeyManager} methods.
    *
    * @example
    * ```typescript
@@ -309,7 +309,7 @@ export interface IDIDManager extends IPluginMethodMap {
    *
    * @param args - Required. Arguments to set identifier alias
    * @param context - <a href="/docs/agent/plugins#executing-plugin-methods">Execution context</a>. Requires `agent`
-   *   that has {@link @veramo/core#IKeyManager} methods
+   *   that has {@link @veramo/core-types#IKeyManager} methods
    *
    * @example
    * ```typescript
@@ -328,7 +328,7 @@ export interface IDIDManager extends IPluginMethodMap {
    *   found.
    * @param context - *RESERVED* This is filled by the framework when the method is called. This method's
    *    <a href="/docs/agent/plugins#executing-plugin-methods">execution context</a> requires an `agent` that has
-   *   {@link @veramo/core#IKeyManager} methods.
+   *   {@link @veramo/core-types#IKeyManager} methods.
    */
   didManagerGetOrCreate(
     args: IDIDManagerGetOrCreateArgs,
@@ -336,11 +336,11 @@ export interface IDIDManager extends IPluginMethodMap {
   ): Promise<IIdentifier>
 
   /**
-   * Updates the DID document of a managed {@link @veramo/core#IIdentifier | DID}.
+   * Updates the DID document of a managed {@link @veramo/core-types#IIdentifier | DID}.
    * @param args - the arguments necessary for the update. The options are specific for each DID provider.
    * @param context - *RESERVED* This is filled by the framework when the method is called. This method's
    *   <a href="/docs/agent/plugins#executing-plugin-methods">execution context</a> requires an `agent` that has
-   *   {@link @veramo/core#IKeyManager} methods.
+   *   {@link @veramo/core-types#IKeyManager} methods.
    */
   didManagerUpdate(args: IDIDManagerUpdateArgs, context: IAgentContext<IKeyManager>): Promise<IIdentifier>
 

--- a/packages/core-types/src/types/IMessageHandler.ts
+++ b/packages/core-types/src/types/IMessageHandler.ts
@@ -19,9 +19,9 @@ export interface IHandleMessageArgs {
 
   /**
    * Optional. If set to `true`, the message will be saved using
-   * {@link @veramo/core#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage}
+   * {@link @veramo/core-types#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage}
    * <p/><p/>
-   * @deprecated Please call {@link @veramo/core#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} after
+   * @deprecated Please call {@link @veramo/core-types#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} after
    *   handling the message and determining that it must be saved.
    */
   save?: boolean
@@ -36,10 +36,10 @@ export interface IMessageHandler extends IPluginMethodMap {
    * Parses a raw message.
    *
    * After the message is parsed, you can decide if it should be saved, and pass the result to
-   * {@link @veramo/core#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} to save it.
+   * {@link @veramo/core-types#IDataStore.dataStoreSaveMessage | dataStoreSaveMessage()} to save it.
    *
    * @param args - The `raw` message to be handled along with optional `metadata` about the origin.
-   * @param context - Execution context. Requires agent with {@link @veramo/core#IDataStore} methods
+   * @param context - Execution context. Requires agent with {@link @veramo/core-types#IDataStore} methods
    */
   handleMessage(args: IHandleMessageArgs, context: IAgentContext<IDataStore>): Promise<IMessage>
 }

--- a/packages/core/src/__tests__/agent.subscriber.test.ts
+++ b/packages/core/src/__tests__/agent.subscriber.test.ts
@@ -1,6 +1,5 @@
 import { Agent } from '../agent.js'
-import { CoreEvents } from '@veramo/core-types'
-import { IEventListener } from '@veramo/core-types'
+import { CoreEvents, IEventListener } from '../../../core-types/src'
 import { jest } from '@jest/globals'
 
 function sleep(ms: number) {

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -1,5 +1,5 @@
 import { Agent, createAgent } from '../agent.js'
-import { IAgentPlugin, IResolver } from '@veramo/core-types'
+import { IAgentPlugin, IResolver } from '../../../core-types/src'
 import { jest } from '@jest/globals'
 
 describe('core agent', () => {
@@ -13,7 +13,7 @@ describe('core agent', () => {
       plugins: [plugin],
     })
 
-    //@ts-ignore
+    // @ts-ignore
     await agent.doSomething({ foo: 'baz' })
     expect(plugin.methods?.doSomething).toBeCalledWith({ foo: 'baz' }, { agent })
     await agent.execute('doSomething', { foo: 'bar' })
@@ -35,7 +35,7 @@ describe('core agent', () => {
       },
     })
 
-    //@ts-ignore
+    // @ts-ignore
     await agent.doSomething({ foo: 'baz' })
     expect(doSomething).toBeCalledWith({ foo: 'baz' }, { agent })
     await agent.execute('doSomething', { foo: 'bar' })
@@ -62,13 +62,13 @@ describe('core agent', () => {
       },
     })
 
-    //@ts-ignore
+    // @ts-ignore
     expect(agent.doSomething).toEqual(undefined)
     expect(agent.execute('doSomething', { foo: 'bar' })).rejects.toEqual(
       Error('Method not available: doSomething'),
     )
 
-    //@ts-ignore
+    // @ts-ignore
     await agent.bar({ foo: 'baz' })
     expect(plugin.methods?.bar).toBeCalledWith({ foo: 'baz' }, { agent })
     await agent.execute('baz', { foo: 'bar' })
@@ -90,7 +90,7 @@ describe('core agent', () => {
       plugins: [plugin],
     })
 
-    //@ts-ignore
+    // @ts-ignore
     await agent.doSomething({ foo: 'baz' })
     expect(plugin.methods?.doSomething).toBeCalledWith(
       { foo: 'baz' },

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -122,7 +122,7 @@ export class Agent implements IAgent {
 
     for (const method of Object.keys(this.methods)) {
       if (!this.protectedMethods.includes(method)) {
-        //@ts-ignore
+        // @ts-ignore
         this[method] = async (args: any) => this.execute(method, args)
       }
     }
@@ -235,7 +235,7 @@ export class Agent implements IAgent {
  * Helper function to create a new instance of the {@link Agent} class with correct type
  *
  * @remarks
- * Use {@link TAgent} to configure agent type (list of available methods) for autocomplete in IDE
+ * Use {@link @veramo/core-types#TAgent} to configure agent type (list of available methods) for autocomplete in IDE
  *
  * @example
  * ```typescript
@@ -262,6 +262,6 @@ export class Agent implements IAgent {
 export function createAgent<T extends IPluginMethodMap, C = Record<string, any>>(
   options: IAgentOptions & { context?: C },
 ): TAgent<T> & { context?: C } {
-  //@ts-ignore
+  // @ts-ignore
   return new Agent(options) as TAgent<T>
 }

--- a/packages/credential-eip712/src/types/ICredentialEIP712.ts
+++ b/packages/credential-eip712/src/types/ICredentialEIP712.ts
@@ -27,7 +27,7 @@ export interface ICredentialIssuerEIP712 extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Credential.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core#VerifiableCredential} that was requested or rejects with an error
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or rejects with an error
    * if there was a problem with the input or while getting the key to sign
    *
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#credentials | Verifiable Credential data model}
@@ -51,10 +51,7 @@ export interface ICredentialIssuerEIP712 extends IPluginMethodMap {
    *
    * @beta This API may change without a BREAKING CHANGE notice.
    */
-  verifyCredentialEIP712(
-    args: IVerifyCredentialEIP712Args,
-    context: IRequiredContext
-  ): Promise<boolean>
+  verifyCredentialEIP712(args: IVerifyCredentialEIP712Args, context: IRequiredContext): Promise<boolean>
 
   /**
    * Creates a Verifiable Presentation.
@@ -63,7 +60,7 @@ export interface ICredentialIssuerEIP712 extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Presentation.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core#VerifiablePresentation} that was requested or rejects with an error
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiablePresentation} that was requested or rejects with an error
    * if there was a problem with the input or while getting the key to sign
    *
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Presentation data model }
@@ -83,10 +80,7 @@ export interface ICredentialIssuerEIP712 extends IPluginMethodMap {
    *
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Credential data model}
    */
-  verifyPresentationEIP712(
-    args: IVerifyPresentationEIP712Args,
-    context: IRequiredContext
-  ): Promise<boolean>  
+  verifyPresentationEIP712(args: IVerifyPresentationEIP712Args, context: IRequiredContext): Promise<boolean>
 }
 
 /**
@@ -137,7 +131,7 @@ export interface ICreateVerifiablePresentationEIP712Args {
    * [Optional] The ID of the key that should sign this presentation.
    * If this is not specified, the first matching key will be used.
    */
-  keyRef?: string  
+  keyRef?: string
 }
 
 /**
@@ -146,7 +140,7 @@ export interface ICreateVerifiablePresentationEIP712Args {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
- export interface IVerifyCredentialEIP712Args {
+export interface IVerifyCredentialEIP712Args {
   /**
    * The json payload of the Credential according to the
    * {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model}
@@ -156,7 +150,6 @@ export interface ICreateVerifiablePresentationEIP712Args {
    *
    */
   credential: VerifiableCredential
-
 }
 
 /**
@@ -165,7 +158,7 @@ export interface ICreateVerifiablePresentationEIP712Args {
  *
  * @public
  */
- export interface IVerifyPresentationEIP712Args {
+export interface IVerifyPresentationEIP712Args {
   /**
    * The Verifiable Presentation object according to the
    * {@link https://www.w3.org/TR/vc-data-model/#presentations | canonical model} or the JWT representation.
@@ -175,7 +168,6 @@ export interface ICreateVerifiablePresentationEIP712Args {
    *
    */
   presentation: VerifiablePresentation
-
 }
 
 /**
@@ -186,6 +178,4 @@ export interface ICreateVerifiablePresentationEIP712Args {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export type IRequiredContext = IAgentContext<
-  IResolver & IKeyManager & IDIDManager
->
+export type IRequiredContext = IAgentContext<IResolver & IKeyManager & IDIDManager>

--- a/packages/credential-ld/src/__tests__/issue-verify-flow.test.ts
+++ b/packages/credential-ld/src/__tests__/issue-verify-flow.test.ts
@@ -7,9 +7,7 @@ import {
   IResolver,
   TAgent,
 } from '../../../core-types/src'
-import {
-  createAgent
-} from '../../../core/src'
+import { createAgent } from '../../../core/src'
 import { CredentialPlugin } from '../../../credential-w3c/src'
 import { DIDManager, MemoryDIDStore } from '../../../did-manager/src'
 import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-manager/src'
@@ -27,6 +25,7 @@ import { VeramoEcdsaSecp256k1RecoverySignature2020 } from '../suites/EcdsaSecp25
 import { jest } from '@jest/globals'
 
 import 'cross-fetch/polyfill'
+
 jest.setTimeout(300000)
 
 const customContext: Record<string, ContextDoc> = {

--- a/packages/credential-ld/src/plugin.schema.json
+++ b/packages/credential-ld/src/plugin.schema.json
@@ -11,7 +11,7 @@
             },
             "keyRef": {
               "type": "string",
-              "description": "Optional. The key handle ( {@link  @veramo/core#IKey.kid | IKey.kid } ) from the internal database."
+              "description": "Optional. The key handle ( {@link  @veramo/core-types#IKey.kid | IKey.kid } ) from the internal database."
             },
             "fetchRemoteContexts": {
               "type": "boolean",
@@ -199,7 +199,7 @@
             },
             "keyRef": {
               "type": "string",
-              "description": "Optional. The key handle ( {@link  @veramo/core#IKey.kid | IKey.kid } ) from the internal database."
+              "description": "Optional. The key handle ( {@link  @veramo/core-types#IKey.kid | IKey.kid } ) from the internal database."
             },
             "fetchRemoteContexts": {
               "type": "boolean",

--- a/packages/credential-ld/src/types.ts
+++ b/packages/credential-ld/src/types.ts
@@ -27,7 +27,7 @@ export interface ICredentialIssuerLD extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Presentation.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core#VerifiablePresentation} that was requested or rejects with an error
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiablePresentation} that was requested or rejects with an error
    * if there was a problem with the input or while getting the key to sign
    *
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Presentation data model }
@@ -46,7 +46,7 @@ export interface ICredentialIssuerLD extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Presentation.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core#VerifiableCredential} that was requested or rejects with an error
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or rejects with an error
    * if there was a problem with the input or while getting the key to sign
    *
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#credentials | Verifiable Credential data model}
@@ -116,7 +116,7 @@ export interface ICreateVerifiablePresentationLDArgs {
   domain?: string
 
   /**
-   * Optional. The key handle ({@link @veramo/core#IKey.kid | IKey.kid}) from the internal database.
+   * Optional. The key handle ({@link @veramo/core-types#IKey.kid | IKey.kid}) from the internal database.
    */
   keyRef?: string
 
@@ -130,7 +130,7 @@ export interface ICreateVerifiablePresentationLDArgs {
   /**
    * Any other options that can be forwarded to the lower level libraries
    */
-  [x:string]: any
+  [x: string]: any
 }
 
 /**
@@ -152,9 +152,9 @@ export interface ICreateVerifiableCredentialLDArgs {
   credential: CredentialPayload
 
   /**
-   * Optional. The key handle ({@link @veramo/core#IKey.kid | IKey.kid}) from the internal database.
+   * Optional. The key handle ({@link @veramo/core-types#IKey.kid | IKey.kid}) from the internal database.
    */
-  keyRef?: string,
+  keyRef?: string
 
   /**
    * Set this to true if you want the `@context` URLs to be fetched in case they are not preloaded.
@@ -166,7 +166,7 @@ export interface ICreateVerifiableCredentialLDArgs {
   /**
    * Any other options that can be forwarded to the lower level libraries
    */
-  [x:string]: any
+  [x: string]: any
 }
 
 /**
@@ -196,7 +196,7 @@ export interface IVerifyCredentialLDArgs {
   /**
    * Any other options that can be forwarded to the lower level libraries
    */
-  [x:string]: any
+  [x: string]: any
 }
 
 /**
@@ -236,7 +236,7 @@ export interface IVerifyPresentationLDArgs {
   /**
    * Any other options that can be forwarded to the lower level libraries
    */
-  [x:string]: any
+  [x: string]: any
 }
 
 /**

--- a/packages/credential-status/src/__tests__/credential-status.test.ts
+++ b/packages/credential-status/src/__tests__/credential-status.test.ts
@@ -3,7 +3,7 @@ import { createAgent } from '../../../core/src'
 import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { CredentialStatusPlugin } from '../credential-status.js'
 import { DIDDocument, DIDResolutionOptions, DIDResolutionResult, Resolvable } from 'did-resolver'
-import { StatusMethod } from "credential-status";
+import { StatusMethod } from 'credential-status'
 import { jest } from '@jest/globals'
 
 describe('@veramo/credential-status', () => {

--- a/packages/credential-status/src/credential-status.ts
+++ b/packages/credential-status/src/credential-status.ts
@@ -10,7 +10,7 @@ import { extractIssuer, isDefined, resolveDidOrThrow } from '@veramo/utils'
 import { Status, StatusMethod } from 'credential-status'
 
 /**
- * This plugin implements the {@link @veramo/core#ICredentialStatusVerifier | ICredentialStatusVerifier}
+ * This plugin implements the {@link @veramo/core-types#ICredentialStatusVerifier | ICredentialStatusVerifier}
  * interface.
  *
  * This aggregates some {@link credential-status#StatusMethod | credential status implementations} to provide a second

--- a/packages/credential-w3c/src/__tests__/credentialStatus.test.ts
+++ b/packages/credential-w3c/src/__tests__/credentialStatus.test.ts
@@ -1,4 +1,4 @@
-describe('did-comm', () => {
+describe('dummy', () => {
   const a = 100
   it('should run a dummy test', () => {
     expect(a).toEqual(100)

--- a/packages/credential-w3c/src/__tests__/issue-verify-flow.test.ts
+++ b/packages/credential-w3c/src/__tests__/issue-verify-flow.test.ts
@@ -6,10 +6,9 @@ import {
   IKeyManager,
   IResolver,
   TAgent,
+  VerifiableCredential,
 } from '../../../core-types/src'
-import {
-  createAgent
-} from '../../../core/src'
+import { createAgent } from '../../../core/src'
 import { CredentialIssuer } from '../../../credential-w3c/src'
 import { DIDManager, MemoryDIDStore } from '../../../did-manager/src'
 import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-manager/src'
@@ -17,14 +16,15 @@ import { KeyManagementSystem } from '../../../kms-local/src'
 import { getDidKeyResolver, KeyDIDProvider } from '../../../did-provider-key/src'
 import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { EthrDIDProvider } from '../../../did-provider-ethr/src'
-import { ContextDoc } from '../../../credential-ld/src/types'
+import {
+  ContextDoc,
+  CredentialIssuerLD,
+  LdDefaultContexts,
+  VeramoEcdsaSecp256k1RecoverySignature2020,
+  VeramoEd25519Signature2018,
+} from '../../../credential-ld/src'
 import { Resolver } from 'did-resolver'
 import { getResolver as ethrDidResolver } from 'ethr-did-resolver'
-import { CredentialIssuerLD } from '../../../credential-ld/src/action-handler'
-import { LdDefaultContexts } from '../../../credential-ld/src/ld-default-contexts'
-import { VeramoEd25519Signature2018 } from '../../../credential-ld/src/suites/Ed25519Signature2018'
-import { VeramoEcdsaSecp256k1RecoverySignature2020 } from '../../../credential-ld/src/suites/EcdsaSecp256k1RecoverySignature2020'
-import { VerifiableCredential } from '../../../core-types/src'
 import { jest } from '@jest/globals'
 
 jest.setTimeout(300000)

--- a/packages/credential-w3c/src/__tests__/message-handler.test.ts
+++ b/packages/credential-w3c/src/__tests__/message-handler.test.ts
@@ -1,7 +1,7 @@
 import { DIDResolutionResult, IAgentContext, ICredentialPlugin, IResolver } from '../../../core-types/src'
 import { Message } from '../../../message-handler/src'
-import { W3cMessageHandler, MessageTypes } from '../index'
-import { IContext } from '../message-handler'
+import { IContext, MessageTypes, W3cMessageHandler } from '../message-handler.js'
+// @ts-ignore
 import pkg from 'blakejs'
 const { blake2bHex } = pkg
 import { jest } from '@jest/globals'

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -19,7 +19,7 @@ import {
   W3CVerifiablePresentation,
 } from '@veramo/core-types'
 
-import schema from "@veramo/core-types/build/plugin.schema.json" assert { type: 'json' }
+import schema from '@veramo/core-types/build/plugin.schema.json' assert { type: 'json' }
 
 import {
   createVerifiableCredentialJwt,
@@ -53,13 +53,13 @@ const enum DocumentFormat {
 const debug = Debug('veramo:w3c:action-handler')
 
 /**
- * A Veramo plugin that implements the {@link @veramo/core#ICredentialPlugin | ICredentialPlugin} methods.
+ * A Veramo plugin that implements the {@link @veramo/core-types#ICredentialPlugin | ICredentialPlugin} methods.
  *
  * @public
  */
 export class CredentialPlugin implements IAgentPlugin {
   readonly methods: ICredentialPlugin
-  readonly schema = { 
+  readonly schema = {
     components: {
       schemas: {
         ...schema.ICredentialIssuer.components.schemas,
@@ -67,9 +67,9 @@ export class CredentialPlugin implements IAgentPlugin {
       },
       methods: {
         ...schema.ICredentialIssuer.components.methods,
-        ...schema.ICredentialVerifier.components.methods
-      }
-    }
+        ...schema.ICredentialVerifier.components.methods,
+      },
+    },
   }
 
   constructor() {
@@ -81,7 +81,7 @@ export class CredentialPlugin implements IAgentPlugin {
     }
   }
 
-  /** {@inheritdoc @veramo/core#ICredentialIssuer.createVerifiablePresentation} */
+  /** {@inheritdoc @veramo/core-types#ICredentialIssuer.createVerifiablePresentation} */
   async createVerifiablePresentation(
     args: ICreateVerifiablePresentationArgs,
     context: IssuerAgentContext,
@@ -183,7 +183,7 @@ export class CredentialPlugin implements IAgentPlugin {
     return verifiablePresentation
   }
 
-  /** {@inheritdoc @veramo/core#ICredentialIssuer.createVerifiableCredential} */
+  /** {@inheritdoc @veramo/core-types#ICredentialIssuer.createVerifiableCredential} */
   async createVerifiableCredential(
     args: ICreateVerifiableCredentialArgs,
     context: IssuerAgentContext,
@@ -265,7 +265,7 @@ export class CredentialPlugin implements IAgentPlugin {
     }
   }
 
-  /** {@inheritdoc @veramo/core#ICredentialVerifier.verifyCredential} */
+  /** {@inheritdoc @veramo/core-types#ICredentialVerifier.verifyCredential} */
   async verifyCredential(args: IVerifyCredentialArgs, context: VerifierAgentContext): Promise<IVerifyResult> {
     let { credential, policies, ...otherOptions } = args
     let verifiedCredential: VerifiableCredential
@@ -298,7 +298,7 @@ export class CredentialPlugin implements IAgentPlugin {
           const verifiedCopy = JSON.parse(JSON.stringify(verifiedCredential))
           delete verifiedCopy.proof.jwt
 
-          if(canonicalize(credentialCopy) !== canonicalize(verifiedCopy)) {
+          if (canonicalize(credentialCopy) !== canonicalize(verifiedCopy)) {
             verificationResult.verified = false
             verificationResult.error = new Error('Credential does not match JWT')
           }
@@ -372,7 +372,7 @@ export class CredentialPlugin implements IAgentPlugin {
     return verificationResult
   }
 
-  /** {@inheritdoc @veramo/core#ICredentialVerifier.verifyPresentation} */
+  /** {@inheritdoc @veramo/core-types#ICredentialVerifier.verifyPresentation} */
   async verifyPresentation(
     args: IVerifyPresentationArgs,
     context: VerifierAgentContext,

--- a/packages/credential-w3c/src/index.ts
+++ b/packages/credential-w3c/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Provides a {@link @veramo/credential-w3c#CredentialPlugin | plugin} for the {@link @veramo/core#Agent} that
  * implements
- * {@link @veramo/core#ICredentialIssuer} interface.
+ * {@link @veramo/core-types#ICredentialIssuer} interface.
  *
  * Provides a {@link @veramo/credential-w3c#W3cMessageHandler | plugin} for the
  * {@link @veramo/message-handler#MessageHandler} that verifies Credentials and Presentations in a message.

--- a/packages/credential-w3c/src/message-handler.ts
+++ b/packages/credential-w3c/src/message-handler.ts
@@ -46,7 +46,7 @@ export type IContext = IAgentContext<IResolver & ICredentialVerifier>
  *
  * The current version can only handle `JWT` encoded
  *
- * @remarks {@link @veramo/core#IDataStore | IDataStore }
+ * @remarks {@link @veramo/core-types#IDataStore | IDataStore }
  *
  * @public
  */

--- a/packages/data-store-json/src/__tests__/data-store-orm-json.test.ts
+++ b/packages/data-store-json/src/__tests__/data-store-orm-json.test.ts
@@ -12,11 +12,9 @@ import {
   VerifiableCredential,
   VerifiablePresentation,
 } from '../../../core-types/src'
-import {
-  Agent
-} from '../../../core/src'
-import { DataStoreJson } from '../data-store-json'
-import { VeramoJsonStore } from '../types'
+import { Agent } from '../../../core/src'
+import { DataStoreJson } from '../data-store-json.js'
+import { VeramoJsonStore } from '../types.js'
 
 const did1 = 'did:test:111'
 const did2 = 'did:test:222'
@@ -117,7 +115,7 @@ let dataStore: VeramoJsonStore
 
 describe('@veramo/data-store queries', () => {
   function makeAgent(context?: Record<string, any>): TAgent<IDataStore & IDataStoreORM> {
-    //@ts-ignore
+    // @ts-ignore
     return new Agent({
       context,
       plugins: [new DataStoreJson(dataStore)],

--- a/packages/data-store-json/src/data-store-json.ts
+++ b/packages/data-store-json/src/data-store-json.ts
@@ -37,11 +37,13 @@ import {
 } from './types.js'
 import { normalizeCredential } from 'did-jwt-vc'
 
-type LocalRecords = Required<Pick<VeramoJsonCache, 'dids' | 'credentials' | 'presentations' | 'claims' | 'messages'>>
+type LocalRecords = Required<
+  Pick<VeramoJsonCache, 'dids' | 'credentials' | 'presentations' | 'claims' | 'messages'>
+>
 
 /**
- * A Veramo agent storage plugin that implements the {@link @veramo/core#IDataStore | IDataStore} and
- * {@link @veramo/core#IDataStoreORM | IDataStoreORM} methods using one big JSON object as a backend.
+ * A Veramo agent storage plugin that implements the {@link @veramo/core-types#IDataStore | IDataStore} and
+ * {@link @veramo/core-types#IDataStoreORM | IDataStoreORM} methods using one big JSON object as a backend.
  *
  * Each update operation triggers a callback that can be used to either save the latest state of the agent data or
  * compute a diff and log only the changes.

--- a/packages/data-store-json/src/index.ts
+++ b/packages/data-store-json/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * {@link @veramo/core#Agent} {@link @veramo/data-store-json#DataStoreJson | plugin} that implements
- * {@link @veramo/core#IDataStore } and
- * {@link @veramo/core#IDataStoreORM }interfaces and uses a JSON tree as a backend.
+ * {@link @veramo/core-types#IDataStore } and
+ * {@link @veramo/core-types#IDataStoreORM }interfaces and uses a JSON tree as a backend.
  *
  * The JSON tree backend can be persisted to any JSON compatible media using a callback that gets called when the agent
  * data is updated.

--- a/packages/data-store-json/src/types.ts
+++ b/packages/data-store-json/src/types.ts
@@ -11,7 +11,7 @@ import { ManagedPrivateKey } from '@veramo/key-manager'
 
 /**
  * This is used internally by {@link @veramo/data-store-json#DataStoreJson | DataStoreJson} to represent a Verifiable
- * Credential in a way that facilitates querying using the {@link @veramo/core#IDataStoreORM} interface.
+ * Credential in a way that facilitates querying using the {@link @veramo/core-types#IDataStoreORM} interface.
  *
  * @beta This API may change in future versions without a BREAKING CHANGE notice.
  */
@@ -30,7 +30,7 @@ export interface CredentialTableEntry {
 
 /**
  * This is used internally by {@link @veramo/data-store-json#DataStoreJson | DataStoreJson} to represent the claims
- * contained in a Verifiable Credential in a way that facilitates querying using the {@link @veramo/core#IDataStoreORM}
+ * contained in a Verifiable Credential in a way that facilitates querying using the {@link @veramo/core-types#IDataStoreORM}
  * interface.
  *
  * @beta This API may change in future versions without a BREAKING CHANGE notice.
@@ -50,7 +50,7 @@ export interface ClaimTableEntry {
 
 /**
  * This is used internally by {@link @veramo/data-store-json#DataStoreJson | DataStoreJson} to represent a Verifiable
- * Presentation in a way that facilitates querying using the {@link @veramo/core#IDataStoreORM} interface.
+ * Presentation in a way that facilitates querying using the {@link @veramo/core-types#IDataStoreORM} interface.
  *
  * @beta This API may change in future versions without a BREAKING CHANGE notice.
  */

--- a/packages/data-store/src/__tests__/data-store-orm.test.ts
+++ b/packages/data-store/src/__tests__/data-store-orm.test.ts
@@ -14,9 +14,9 @@ import {
 } from '../../../core-types/src'
 import { Agent } from '../../../core/src'
 import { DataSource } from 'typeorm'
-import { DataStoreORM } from '../data-store-orm'
-import { DataStore } from '../data-store'
-import { Entities } from '../index'
+import { DataStoreORM } from '../data-store-orm.js'
+import { DataStore } from '../data-store.js'
+import { Entities } from '../index.js'
 import * as fs from 'fs'
 
 const did1 = 'did:test:111'
@@ -119,7 +119,7 @@ describe('@veramo/data-store queries', () => {
   const databaseFile = './tmp/test-db2.sqlite'
 
   function makeAgent(context?: Record<string, any>): TAgent<IDataStore & IDataStoreORM> {
-    //@ts-ignore
+    // @ts-ignore
     return new Agent({
       context,
       plugins: [new DataStore(dbConnection), new DataStoreORM(dbConnection)],

--- a/packages/data-store/src/__tests__/entities.test.ts
+++ b/packages/data-store/src/__tests__/entities.test.ts
@@ -1,11 +1,12 @@
-import { Credential, createCredentialEntity } from '../entities/credential'
-import { createPresentationEntity } from '../entities/presentation'
+import { createCredentialEntity, Credential } from '../entities/credential.js'
+import { createPresentationEntity } from '../entities/presentation.js'
+import { Claim, Entities, Identifier, Message } from '../index.js'
 import { DataSource, In } from 'typeorm'
-import { Identifier, Message, Claim } from '../index'
-import { Entities } from '../index'
+// @ts-ignore
 import pkg from 'blakejs'
-const { blake2bHex } = pkg
 import * as fs from 'fs'
+
+const { blake2bHex } = pkg
 
 describe('DB entities test', () => {
   let connection: DataSource

--- a/packages/data-store/src/data-store-orm.ts
+++ b/packages/data-store/src/data-store-orm.ts
@@ -37,11 +37,11 @@ import {
   Not,
   SelectQueryBuilder,
 } from 'typeorm'
-import { getConnectedDb } from "./utils.js";
-import { OrPromise } from "@veramo/utils";
+import { getConnectedDb } from './utils.js'
+import { OrPromise } from '@veramo/utils'
 
 /**
- * This class implements the {@link @veramo/core#IDataStoreORM} query interface using a TypeORM compatible database.
+ * This class implements the {@link @veramo/core-types#IDataStoreORM} query interface using a TypeORM compatible database.
  *
  * This allows you to filter Verifiable Credentials, Presentations and Messages by some common properties that are
  * parsed and stored in database tables.
@@ -50,8 +50,8 @@ import { OrPromise } from "@veramo/utils";
  * database with Credentials, Presentations and Messages in such a way that they can be queried by this class.
  * These two classes MUST also share the same database connection.
  *
- * @see {@link @veramo/core#IDataStoreORM}
- * @see {@link @veramo/core#IDataStore}
+ * @see {@link @veramo/core-types#IDataStoreORM}
+ * @see {@link @veramo/core-types#IDataStore}
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
@@ -348,7 +348,9 @@ function addVerifierQuery(input: FindArgs<any>, qb: SelectQueryBuilder<any>): Se
 }
 
 function createWhereObject(
-  input: FindArgs<TMessageColumns | TClaimsColumns | TCredentialColumns | TPresentationColumns | TIdentifiersColumns>,
+  input: FindArgs<
+    TMessageColumns | TClaimsColumns | TCredentialColumns | TPresentationColumns | TIdentifiersColumns
+  >,
 ): any {
   const where: Record<string, any> = {}
   if (input?.where) {

--- a/packages/data-store/src/data-store.ts
+++ b/packages/data-store/src/data-store.ts
@@ -23,15 +23,15 @@ import { getConnectedDb } from './utils.js'
 import { OrPromise } from '@veramo/utils'
 
 /**
- * This class implements the {@link @veramo/core#IDataStore} interface using a TypeORM compatible database.
+ * This class implements the {@link @veramo/core-types#IDataStore} interface using a TypeORM compatible database.
  *
  * This allows you to store and retrieve Verifiable Credentials, Presentations and Messages by their IDs.
  *
  * For more complex queries you should use {@link @veramo/data-store#DataStoreORM} which is the default way to query
  * the stored data by some common properties. These two classes MUST also share the same database connection.
  *
- * @see {@link @veramo/core#IDataStoreORM}
- * @see {@link @veramo/core#IDataStore}
+ * @see {@link @veramo/core-types#IDataStoreORM}
+ * @see {@link @veramo/core-types#IDataStore}
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */

--- a/packages/data-store/src/did-discovery-provider.ts
+++ b/packages/data-store/src/did-discovery-provider.ts
@@ -9,7 +9,7 @@ import {
 /**
  * This implementation of {@link @veramo/did-discovery#AbstractDidDiscoveryProvider | AbstractDidDiscoveryProvider}
  * helps you discover DIDs based on data that is stored by a local plugin that implements
- * {@link @veramo/core#IDataStoreORM | IDataStoreORM}.
+ * {@link @veramo/core-types#IDataStoreORM | IDataStoreORM}.
  *
  * DIDs can be discovered by partial matches of `name` from `Profile` credentials, by partial matches of `alias` of
  * managed DIDs as well as partial matches of DIDs that are issuer or subject of credentials.
@@ -60,32 +60,28 @@ export class DataStoreDiscoveryProvider implements AbstractDidDiscoveryProvider 
     })
 
     const identifiersByDID = await context.agent.dataStoreORMGetIdentifiers({
-      where: [
-        { column: 'did', value: [`%${args.query}%`], op: 'Like' }
-      ]
+      where: [{ column: 'did', value: [`%${args.query}%`], op: 'Like' }],
     })
 
     identifiersByDID.forEach((identifier) => {
       matches.push({
         did: identifier.did as string,
         metaData: {
-          alias: identifier.alias
-        }
+          alias: identifier.alias,
+        },
       })
     })
 
     const identifiersByAlias = await context.agent.dataStoreORMGetIdentifiers({
-      where: [
-        { column: 'alias', value: [`%${args.query}%`], op: 'Like' }
-      ]
+      where: [{ column: 'alias', value: [`%${args.query}%`], op: 'Like' }],
     })
 
     identifiersByAlias.forEach((identifier) => {
       matches.push({
         did: identifier.did as string,
         metaData: {
-          alias: identifier.alias
-        }
+          alias: identifier.alias,
+        },
       })
     })
 

--- a/packages/data-store/src/entities/PreMigrationEntities.ts
+++ b/packages/data-store/src/entities/PreMigrationEntities.ts
@@ -11,11 +11,11 @@ import { KeyType } from "./key.js";
 @Entity('key')
 export class PreMigrationKey extends BaseEntity {
   @PrimaryColumn()
-    //@ts-ignore
+    // @ts-ignore
   kid: string
 
   @Column()
-    //@ts-ignore
+    // @ts-ignore
   type: KeyType
 
   @Column({ nullable: true })

--- a/packages/data-store/src/entities/claim.ts
+++ b/packages/data-store/src/entities/claim.ts
@@ -6,7 +6,7 @@ import { Credential } from './credential.js'
  * Represents the properties of a claim extracted from a Verifiable Credential `credentialSubject`, and stored in a
  * TypeORM database for querying.
  *
- * @see {@link @veramo/core#IDataStoreORM} for the interface defining how this can be queried.
+ * @see {@link @veramo/core-types#IDataStoreORM} for the interface defining how this can be queried.
  * @see {@link @veramo/data-store#DataStoreORM} for the implementation of the query interface.
  *
  * @beta This API may change without a BREAKING CHANGE notice.
@@ -14,14 +14,14 @@ import { Credential } from './credential.js'
 @Entity('claim')
 export class Claim extends BaseEntity {
   @PrimaryColumn()
-    //@ts-ignore
+  // @ts-ignore
   hash: string
 
   @ManyToOne((type) => Identifier, (identifier) => identifier.issuedClaims, {
     eager: true,
     onDelete: 'CASCADE',
   })
-    //@ts-ignore
+  // @ts-ignore
   issuer: Relation<Identifier>
 
   @ManyToOne((type) => Identifier, (identifier) => identifier.receivedClaims, {
@@ -33,33 +33,33 @@ export class Claim extends BaseEntity {
   @ManyToOne((type) => Credential, (credential) => credential.claims, {
     onDelete: 'CASCADE',
   })
-    //@ts-ignore
+  // @ts-ignore
   credential: Relation<Credential>
 
   @Column()
-    //@ts-ignore
+  // @ts-ignore
   issuanceDate: Date
 
   @Column({ nullable: true })
   expirationDate?: Date
 
   @Column('simple-array')
-    //@ts-ignore
+  // @ts-ignore
   context: string[]
 
   @Column('simple-array')
-    //@ts-ignore
+  // @ts-ignore
   credentialType: string[]
 
   @Column()
-    //@ts-ignore
+  // @ts-ignore
   type: string
 
   @Column('text', { nullable: true })
-    //@ts-ignore
+  // @ts-ignore
   value: string | null
 
   @Column()
-    //@ts-ignore
+  // @ts-ignore
   isObj: boolean
 }

--- a/packages/data-store/src/entities/credential.ts
+++ b/packages/data-store/src/entities/credential.ts
@@ -1,5 +1,14 @@
 import { VerifiableCredential } from '@veramo/core-types'
-import { BaseEntity, Column, Entity, ManyToMany, ManyToOne, OneToMany, PrimaryColumn, Relation } from 'typeorm'
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  PrimaryColumn,
+  Relation,
+} from 'typeorm'
 import { Identifier } from './identifier.js'
 import { Message } from './message.js'
 import { Presentation } from './presentation.js'
@@ -9,22 +18,22 @@ import { asArray, computeEntryHash, extractIssuer } from '@veramo/utils'
 /**
  * Represents some common properties of a Verifiable Credential that are stored in a TypeORM database for querying.
  *
- * @see {@link @veramo/core#IDataStoreORM.dataStoreORMGetVerifiableCredentials | dataStoreORMGetVerifiableCredentials}
+ * @see {@link @veramo/core-types#IDataStoreORM.dataStoreORMGetVerifiableCredentials | dataStoreORMGetVerifiableCredentials}
  *   for the interface defining how this can be queried.
  *
  * @see {@link @veramo/data-store#DataStoreORM | DataStoreORM} for the implementation of the query interface.
  *
- * @see {@link @veramo/core#IDataStoreORM.dataStoreORMGetVerifiableCredentialsByClaims | dataStoreORMGetVerifiableCredentialsByClaims} for the interface defining how to query credentials by the claims they contain.
+ * @see {@link @veramo/core-types#IDataStoreORM.dataStoreORMGetVerifiableCredentialsByClaims | dataStoreORMGetVerifiableCredentialsByClaims} for the interface defining how to query credentials by the claims they contain.
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
 @Entity('credential')
 export class Credential extends BaseEntity {
   @PrimaryColumn()
-    //@ts-ignore
+  // @ts-ignore
   hash: string
 
-  //@ts-ignore
+  // @ts-ignore
   private _raw: VerifiableCredential
 
   set raw(raw: VerifiableCredential) {
@@ -42,7 +51,7 @@ export class Credential extends BaseEntity {
     eager: true,
     onDelete: 'CASCADE',
   })
-    //@ts-ignore
+  // @ts-ignore
   issuer: Relation<Identifier>
 
   // Subject can be null https://w3c.github.io/vc-data-model/#credential-uniquely-identifies-a-subject
@@ -57,32 +66,32 @@ export class Credential extends BaseEntity {
   id?: string
 
   @Column()
-    //@ts-ignore
+  // @ts-ignore
   issuanceDate: Date
 
   @Column({ nullable: true })
   expirationDate?: Date
 
   @Column('simple-array')
-    //@ts-ignore
+  // @ts-ignore
   context: string[]
 
   @Column('simple-array')
-    //@ts-ignore
+  // @ts-ignore
   type: string[]
 
   @OneToMany((type) => Claim, (claim) => claim.credential, {
     cascade: ['insert'],
   })
-    //@ts-ignore
+  // @ts-ignore
   claims: Relation<Claim[]>
 
   @ManyToMany((type) => Presentation, (presentation) => presentation.credentials)
-    //@ts-ignore
+  // @ts-ignore
   presentations: Relation<Presentation[]>
 
   @ManyToMany((type) => Message, (message) => message.credentials)
-    //@ts-ignore
+  // @ts-ignore
   messages: Relation<Message[]>
 }
 

--- a/packages/data-store/src/entities/identifier.ts
+++ b/packages/data-store/src/entities/identifier.ts
@@ -18,7 +18,7 @@ import { Credential } from './credential.js'
 import { Claim } from './claim.js'
 
 /**
- * Represents some properties and relationships of an {@link @veramo/core#IIdentifier} that are stored in a TypeORM
+ * Represents some properties and relationships of an {@link @veramo/core-types#IIdentifier} that are stored in a TypeORM
  * database for the purpose of keeping track of keys and services associated with a DID managed by a Veramo agent.
  *
  * @see {@link @veramo/data-store#DIDStore | DIDStore} for the implementation used by the
@@ -31,15 +31,15 @@ import { Claim } from './claim.js'
 @Index(['alias', 'provider'], { unique: true })
 export class Identifier extends BaseEntity {
   @PrimaryColumn()
-    //@ts-ignore
+  // @ts-ignore
   did: string
 
   @Column({ nullable: true })
-    //@ts-ignore
+  // @ts-ignore
   provider?: string
 
   @Column({ nullable: true })
-    //@ts-ignore
+  // @ts-ignore
   alias?: string
 
   @BeforeInsert()
@@ -54,57 +54,57 @@ export class Identifier extends BaseEntity {
   }
 
   @Column({ select: false })
-    //@ts-ignore
+  // @ts-ignore
   saveDate: Date
 
   @Column({ select: false })
-    //@ts-ignore
+  // @ts-ignore
   updateDate: Date
 
   @Column({ nullable: true })
-    //@ts-ignore
+  // @ts-ignore
   controllerKeyId?: string
 
   @OneToMany((type) => Key, (key) => key.identifier)
-    //@ts-ignore
+  // @ts-ignore
   keys: Key[]
 
   @OneToMany((type) => Service, (service) => service.identifier, {
     cascade: true,
   })
-    //@ts-ignore
+  // @ts-ignore
   services: Service[]
 
   @OneToMany((type) => Message, (message) => message.from)
-    //@ts-ignore
+  // @ts-ignore
   sentMessages: Message[]
 
   @OneToMany((type) => Message, (message) => message.to)
-    //@ts-ignore
+  // @ts-ignore
   receivedMessages: Message[]
 
   @OneToMany((type) => Presentation, (presentation) => presentation.holder)
-    //@ts-ignore
+  // @ts-ignore
   issuedPresentations: Presentation[]
 
   @ManyToMany((type) => Presentation, (presentation) => presentation.verifier)
-    //@ts-ignore
+  // @ts-ignore
   receivedPresentations: Presentation[]
 
   @OneToMany((type) => Credential, (credential) => credential.issuer)
-    //@ts-ignore
+  // @ts-ignore
   issuedCredentials: Credential[]
 
   @OneToMany((type) => Credential, (credential) => credential.subject)
-    //@ts-ignore
+  // @ts-ignore
   receivedCredentials: Credential[]
 
   @OneToMany((type) => Claim, (claim) => claim.issuer)
-    //@ts-ignore
+  // @ts-ignore
   issuedClaims: Claim[]
 
   @OneToMany((type) => Claim, (claim) => claim.subject)
-    //@ts-ignore
+  // @ts-ignore
   receivedClaims: Claim[]
 
   /**

--- a/packages/data-store/src/entities/key.ts
+++ b/packages/data-store/src/entities/key.ts
@@ -3,14 +3,14 @@ import { Entity, Column, PrimaryColumn, BaseEntity, ManyToOne, Relation } from '
 import { Identifier } from './identifier.js'
 
 /**
- * Mirrors {@link @veramo/core#TKeyType | TKeyType}
+ * Mirrors {@link @veramo/core-types#TKeyType | TKeyType}
  *
  * @beta - This API may change without a BREAKING CHANGE notice.
  */
 export type KeyType = TKeyType
 
 /**
- * Represents some properties of a {@link @veramo/core#IKey | IKey} that are stored in a TypeORM
+ * Represents some properties of a {@link @veramo/core-types#IKey | IKey} that are stored in a TypeORM
  * database for the purpose of keeping track of the {@link @veramo/key-manager#AbstractKeyManagementSystem}
  * implementations and the keys they are able to use.
  *
@@ -22,19 +22,19 @@ export type KeyType = TKeyType
 @Entity('key')
 export class Key extends BaseEntity {
   @PrimaryColumn()
-    //@ts-ignore
+  // @ts-ignore
   kid: string
 
   @Column()
-    //@ts-ignore
+  // @ts-ignore
   kms: string
 
   @Column()
-    //@ts-ignore
+  // @ts-ignore
   type: KeyType
 
   @Column()
-    //@ts-ignore
+  // @ts-ignore
   publicKeyHex: string
 
   @Column({

--- a/packages/data-store/src/entities/message.ts
+++ b/packages/data-store/src/entities/message.ts
@@ -21,7 +21,7 @@ import { v4 as uuidv4 } from 'uuid'
  * Represents message metadata as it is stored by {@link @veramo/data-store#DataStore | DataStore}.
  *
  * This metadata is most often used by {@link @veramo/message-handler#MessageHandler | MessageHandler} and
- * {@link @veramo/core#IMessageHandler | IMessageHandler} implementations to decorate messages that are interpreted and
+ * {@link @veramo/core-types#IMessageHandler | IMessageHandler} implementations to decorate messages that are interpreted and
  * decoded, but not returned as final, as they pass through the message handler chain.
  *
  * @beta - This API may change without a BREAKING CHANGE notice.
@@ -32,10 +32,10 @@ export interface MetaData {
 }
 
 /**
- * Represents some common properties of an {@link @veramo/core#IMessage} that are stored in a TypeORM database for
+ * Represents some common properties of an {@link @veramo/core-types#IMessage} that are stored in a TypeORM database for
  * querying.
  *
- * @see {@link @veramo/core#IDataStoreORM.dataStoreORMGetMessages | dataStoreORMGetMessages}
+ * @see {@link @veramo/core-types#IDataStoreORM.dataStoreORMGetMessages | dataStoreORMGetMessages}
  *   for the interface defining how this can be queried
  *
  * @see {@link @veramo/data-store#DataStoreORM | DataStoreORM} for the implementation of the query interface.
@@ -52,7 +52,7 @@ export class Message extends BaseEntity {
   }
 
   @PrimaryColumn()
-    //@ts-ignore
+  // @ts-ignore
   id: string
 
   @BeforeInsert()
@@ -67,11 +67,11 @@ export class Message extends BaseEntity {
   }
 
   @Column({ select: false })
-    //@ts-ignore
+  // @ts-ignore
   saveDate: Date
 
   @Column({ select: false })
-    //@ts-ignore
+  // @ts-ignore
   updateDate: Date
 
   @Column({ nullable: true })
@@ -84,7 +84,7 @@ export class Message extends BaseEntity {
   threadId?: string
 
   @Column()
-    //@ts-ignore
+  // @ts-ignore
   type: string
 
   @Column({ nullable: true })
@@ -124,12 +124,12 @@ export class Message extends BaseEntity {
     cascade: true,
   })
   @JoinTable()
-    //@ts-ignore
+  // @ts-ignore
   presentations: Relation<Presentation[]>
 
   @ManyToMany((type) => Credential, (credential) => credential.messages, { cascade: true })
   @JoinTable()
-    //@ts-ignore
+  // @ts-ignore
   credentials: Relation<Credential[]>
 }
 

--- a/packages/data-store/src/entities/presentation.ts
+++ b/packages/data-store/src/entities/presentation.ts
@@ -1,6 +1,15 @@
 import { VerifiableCredential, VerifiablePresentation } from '@veramo/core-types'
 
-import { BaseEntity, Column, Entity, JoinTable, ManyToMany, ManyToOne, PrimaryColumn, Relation } from 'typeorm'
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+  PrimaryColumn,
+  Relation,
+} from 'typeorm'
 import { Identifier } from './identifier.js'
 import { Message } from './message.js'
 import { createCredentialEntity, Credential } from './credential.js'
@@ -10,7 +19,7 @@ import { normalizeCredential } from 'did-jwt-vc'
 /**
  * Represents some common properties of a Verifiable Presentation that are stored in a TypeORM database for querying.
  *
- * @see {@link @veramo/core#IDataStoreORM.dataStoreORMGetVerifiablePresentations | dataStoreORMGetVerifiablePresentations} for the interface defining how this can be queried.
+ * @see {@link @veramo/core-types#IDataStoreORM.dataStoreORMGetVerifiablePresentations | dataStoreORMGetVerifiablePresentations} for the interface defining how this can be queried.
  *
  * @see {@link @veramo/data-store#DataStoreORM | DataStoreORM} for the implementation of the query interface.
  *
@@ -19,10 +28,10 @@ import { normalizeCredential } from 'did-jwt-vc'
 @Entity('presentation')
 export class Presentation extends BaseEntity {
   @PrimaryColumn()
-    //@ts-ignore
+  // @ts-ignore
   hash: string
 
-  //@ts-ignore
+  // @ts-ignore
   private _raw: IVerifiablePresentation
 
   set raw(raw: VerifiablePresentation) {
@@ -40,7 +49,7 @@ export class Presentation extends BaseEntity {
     eager: true,
     onDelete: 'CASCADE',
   })
-    //@ts-ignore
+  // @ts-ignore
   holder: Relation<Identifier>
 
   @ManyToMany((type) => Identifier, (identifier) => identifier?.receivedPresentations, {
@@ -49,36 +58,36 @@ export class Presentation extends BaseEntity {
     nullable: true,
   })
   @JoinTable()
-    //@ts-ignore
+  // @ts-ignore
   verifier?: Relation<Identifier[]>
 
   @Column({ nullable: true })
   id?: String
 
   @Column()
-    //@ts-ignore
+  // @ts-ignore
   issuanceDate: Date
 
   @Column({ nullable: true })
   expirationDate?: Date
 
   @Column('simple-array')
-    //@ts-ignore
+  // @ts-ignore
   context: string[]
 
   @Column('simple-array')
-    //@ts-ignore
+  // @ts-ignore
   type: string[]
 
   @ManyToMany((type) => Credential, (credential) => credential.presentations, {
     cascade: true,
   })
   @JoinTable()
-    //@ts-ignore
+  // @ts-ignore
   credentials: Relation<Credential[]>
 
   @ManyToMany((type) => Message, (message) => message.presentations)
-    //@ts-ignore
+  // @ts-ignore
   messages: Relation<Message[]>
 }
 

--- a/packages/data-store/src/entities/private-key.ts
+++ b/packages/data-store/src/entities/private-key.ts
@@ -14,14 +14,14 @@ import { Entity, Column, PrimaryColumn, BaseEntity } from 'typeorm'
 @Entity('private-key')
 export class PrivateKey extends BaseEntity {
   @PrimaryColumn()
-    //@ts-ignore
+    // @ts-ignore
   alias: string
 
   @Column()
-    //@ts-ignore
+    // @ts-ignore
   type: KeyType
 
   @Column()
-    //@ts-ignore
+    // @ts-ignore
   privateKeyHex: string
 }

--- a/packages/data-store/src/entities/service.ts
+++ b/packages/data-store/src/entities/service.ts
@@ -12,21 +12,21 @@ import { Identifier } from './identifier.js'
 @Entity('service')
 export class Service extends BaseEntity {
   @PrimaryColumn()
-    //@ts-ignore
+    // @ts-ignore
   id: string
 
   @Column()
-    //@ts-ignore
+    // @ts-ignore
   type: string
 
   @Column()
-    //@ts-ignore
+    // @ts-ignore
   serviceEndpoint: string
 
   @Column({ nullable: true })
   description?: string
 
   @ManyToOne((type) => Identifier, (identifier) => identifier?.services, { onDelete: 'CASCADE' })
-    //@ts-ignore
+    // @ts-ignore
   identifier?: Relation<Identifier>
 }

--- a/packages/data-store/src/identifier/private-key-store.ts
+++ b/packages/data-store/src/identifier/private-key-store.ts
@@ -4,13 +4,13 @@ import { ImportablePrivateKey, ManagedPrivateKey } from '@veramo/key-manager'
 import { PrivateKey } from '../entities/private-key.js'
 import { v4 as uuid4 } from 'uuid'
 import Debug from 'debug'
-import { OrPromise } from "@veramo/utils";
-import { getConnectedDb } from "../utils.js";
+import { OrPromise } from '@veramo/utils'
+import { getConnectedDb } from '../utils.js'
 
 const debug = Debug('veramo:typeorm:key-store')
 
 /**
- * An implementation of {@link @veramo/key-manager#abstractPrivateKeyStore | AbstractPrivateKeyStore} that uses a
+ * An implementation of {@link @veramo/key-manager#AbstractPrivateKeyStore | AbstractPrivateKeyStore} that uses a
  * TypeORM database connection to store private key material.
  *
  * The keys can be encrypted while at rest if this class is initialized with an

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * {@link https://typeorm.io/ | TypeORM } backed plugins. {@link @veramo/core#Agent}
- * {@link @veramo/data-store#DataStore | plugin} that implements {@link @veramo/core#IDataStore } interface.
+ * {@link @veramo/data-store#DataStore | plugin} that implements {@link @veramo/core-types#IDataStore } interface.
  * {@link @veramo/core#Agent} {@link @veramo/data-store#DataStoreORM | plugin} that implements
- * {@link @veramo/core#IDataStoreORM} interface. Provides {@link @veramo/data-store#KeyStore} for
+ * {@link @veramo/core-types#IDataStoreORM} interface. Provides {@link @veramo/data-store#KeyStore} for
  * {@link @veramo/key-manager#KeyManager} and {@link @veramo/data-store#DIDStore} for
  * {@link @veramo/did-manager#DIDManager}
  *

--- a/packages/did-comm/src/__tests__/coordinate-mediation-message-handler.test.ts
+++ b/packages/did-comm/src/__tests__/coordinate-mediation-message-handler.test.ts
@@ -1,4 +1,4 @@
-import { DIDComm } from '../didcomm'
+import { DIDComm } from '../didcomm.js'
 import {
   createAgent,
   IDIDManager,
@@ -14,25 +14,28 @@ import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-
 import { KeyManagementSystem } from '../../../kms-local/src'
 import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { Resolver } from 'did-resolver'
-import { DIDCommHttpTransport } from '../transports/transports'
-import { IDIDComm } from '../types/IDIDComm'
+import { DIDCommHttpTransport } from '../transports/transports.js'
+import { IDIDComm } from '../types/IDIDComm.js'
 import { MessageHandler } from '../../../message-handler/src'
 import {
   CoordinateMediationMediatorMessageHandler,
   CoordinateMediationRecipientMessageHandler,
   createMediateRequestMessage,
   createMediateGrantMessage,
-} from '../protocols/coordinate-mediation-message-handler'
+} from '../protocols/coordinate-mediation-message-handler.js'
 import { FakeDidProvider, FakeDidResolver } from '../../../test-utils/src'
 import { MessagingRouter, RequestWithAgentRouter } from '../../../remote-server/src'
 import { Entities, IDataStore, migrations } from '../../../data-store/src'
+// @ts-ignore
 import express from 'express'
 import { Server } from 'http'
-import { DIDCommMessageHandler } from '../message-handler'
+import { DIDCommMessageHandler } from '../message-handler.js'
 import { DataStore, DataStoreORM } from '../../../data-store/src'
 import { DataSource } from 'typeorm'
 import { v4 } from 'uuid'
+
 import { jest } from '@jest/globals'
+import 'cross-fetch/polyfill'
 
 const DIDCommEventSniffer: IEventListener = {
   eventTypes: ['DIDCommV2Message-sent', 'DIDCommV2Message-received'],

--- a/packages/did-comm/src/__tests__/message-handler.test.ts
+++ b/packages/did-comm/src/__tests__/message-handler.test.ts
@@ -1,4 +1,4 @@
-import { DIDComm } from '../didcomm'
+import { DIDComm } from '../didcomm.js'
 import {
   IDIDManager,
   IEventListener,
@@ -16,15 +16,16 @@ import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-
 import { KeyManagementSystem } from '../../../kms-local/src'
 import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { Resolver } from 'did-resolver'
-import { DIDCommHttpTransport } from '../transports/transports'
-import { IDIDComm } from '../types/IDIDComm'
+import { DIDCommHttpTransport } from '../transports/transports.js'
+import { IDIDComm } from '../types/IDIDComm.js'
 import { MessageHandler } from '../../../message-handler/src'
 import { FakeDidProvider, FakeDidResolver } from '../../../test-utils/src'
 import { MessagingRouter, RequestWithAgentRouter } from '../../../remote-server/src'
 import { Entities, IDataStore, migrations } from '../../../data-store/src'
+// @ts-ignore
 import express from 'express'
 import { Server } from 'http'
-import { DIDCommMessageHandler } from '../message-handler'
+import { DIDCommMessageHandler } from '../message-handler.js'
 import { DataStore, DataStoreORM } from '../../../data-store/src'
 import { DataSource } from 'typeorm'
 import { v4 } from 'uuid'

--- a/packages/did-comm/src/__tests__/messagepickup-message-handler.test.ts
+++ b/packages/did-comm/src/__tests__/messagepickup-message-handler.test.ts
@@ -1,4 +1,4 @@
-import { DIDComm } from '../didcomm'
+import { DIDComm } from '../didcomm.js'
 import {
   createAgent,
   IDIDManager,
@@ -14,11 +14,11 @@ import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-
 import { KeyManagementSystem } from '../../../kms-local/src'
 import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { Resolver } from 'did-resolver'
-import { DIDCommHttpTransport } from '../transports/transports'
-import { IDIDComm } from '../types/IDIDComm'
+import { DIDCommHttpTransport } from '../transports/transports.js'
+import { IDIDComm } from '../types/IDIDComm.js'
 import { MessageHandler } from '../../../message-handler/src'
-import { IDIDCommMessage, DIDCommMessageMediaType, IPackedDIDCommMessage } from '../types/message-types'
-import { QUEUE_MESSAGE_TYPE } from '../protocols/routing-message-handler'
+import { IDIDCommMessage, DIDCommMessageMediaType, IPackedDIDCommMessage } from '../types/message-types.js'
+import { QUEUE_MESSAGE_TYPE } from '../protocols/routing-message-handler.js'
 import {
   PickupMediatorMessageHandler,
   PickupRecipientMessageHandler,
@@ -27,18 +27,21 @@ import {
   DELIVERY_MESSAGE_TYPE,
   DELIVERY_REQUEST_MESSAGE_TYPE,
   MESSAGES_RECEIVED_MESSAGE_TYPE,
-} from '../protocols/messagepickup-message-handler'
+} from '../protocols/messagepickup-message-handler.js'
 import { FakeDidProvider, FakeDidResolver } from '../../../test-utils/src'
 import { MessagingRouter, RequestWithAgentRouter } from '../../../remote-server/src'
 import { Entities, IDataStore, migrations } from '../../../data-store/src'
+// @ts-ignore
 import express from 'express'
 import { Server } from 'http'
-import { DIDCommMessageHandler } from '../message-handler'
+import { DIDCommMessageHandler } from '../message-handler.js'
 import { DataStore, DataStoreORM } from '../../../data-store/src'
 import { DataSource } from 'typeorm'
 import { v4 } from 'uuid'
 import { Message } from '@veramo/message-handler'
+
 import { jest } from '@jest/globals'
+import 'cross-fetch/polyfill'
 
 const DIDCommEventSniffer: IEventListener = {
   eventTypes: [

--- a/packages/did-comm/src/__tests__/packing.test.ts
+++ b/packages/did-comm/src/__tests__/packing.test.ts
@@ -1,4 +1,4 @@
-import { DIDComm } from "../didcomm"
+import { DIDComm } from "../didcomm.js"
 import {
   IDIDManager,
   IIdentifier,

--- a/packages/did-comm/src/__tests__/routing-message-handler.test.ts
+++ b/packages/did-comm/src/__tests__/routing-message-handler.test.ts
@@ -1,4 +1,4 @@
-import { DIDComm } from '../didcomm'
+import { DIDComm } from '../didcomm.js'
 import {
   createAgent,
   IDIDManager,
@@ -14,31 +14,34 @@ import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-
 import { KeyManagementSystem } from '../../../kms-local/src'
 import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { Resolver } from 'did-resolver'
-import { DIDCommHttpTransport } from '../transports/transports'
-import { IDIDComm } from '../types/IDIDComm'
+import { DIDCommHttpTransport } from '../transports/transports.js'
+import { IDIDComm } from '../types/IDIDComm.js'
 import { MessageHandler } from '../../../message-handler/src'
 import {
   CoordinateMediationMediatorMessageHandler,
   CoordinateMediationRecipientMessageHandler,
   createMediateRequestMessage,
   MEDIATE_DENY_MESSAGE_TYPE,
-} from '../protocols/coordinate-mediation-message-handler'
-import { DIDCommMessageMediaType } from '../types/message-types'
+} from '../protocols/coordinate-mediation-message-handler.js'
+import { DIDCommMessageMediaType } from '../types/message-types.js'
 import {
   RoutingMessageHandler,
   FORWARD_MESSAGE_TYPE,
   QUEUE_MESSAGE_TYPE,
-} from '../protocols/routing-message-handler'
+} from '../protocols/routing-message-handler.js'
 import { FakeDidProvider, FakeDidResolver } from '../../../test-utils/src'
 import { MessagingRouter, RequestWithAgentRouter } from '../../../remote-server/src'
 import { Entities, IDataStore, migrations } from '../../../data-store/src'
+// @ts-ignore
 import express from 'express'
 import { Server } from 'http'
-import { DIDCommMessageHandler } from '../message-handler'
+import { DIDCommMessageHandler } from '../message-handler.js'
 import { DataStore, DataStoreORM } from '../../../data-store/src'
 import { DataSource } from 'typeorm'
 import { v4 } from 'uuid'
+
 import { jest } from '@jest/globals'
+import 'cross-fetch/polyfill'
 
 const DIDCommEventSniffer: IEventListener = {
   eventTypes: ['DIDCommV2Message-sent', 'DIDCommV2Message-received', 'DIDCommV2Message-forwardMessageQueued'],
@@ -216,7 +219,9 @@ describe('routing-message-handler', () => {
         body: {
           next: recipient.did,
         },
-        attachments: [{ media_type: DIDCommMessageMediaType.ENCRYPTED, data: { json: JSON.parse(innerMessage.message) } }],
+        attachments: [
+          { media_type: DIDCommMessageMediaType.ENCRYPTED, data: { json: JSON.parse(innerMessage.message) } },
+        ],
       },
     })
     await agent.sendDIDCommMessage({
@@ -233,7 +238,12 @@ describe('routing-message-handler', () => {
             id: msgId,
             to: mediator.did,
             type: FORWARD_MESSAGE_TYPE,
-            attachments: [{ media_type: DIDCommMessageMediaType.ENCRYPTED, data: { json: JSON.parse(innerMessage.message) } }],
+            attachments: [
+              {
+                media_type: DIDCommMessageMediaType.ENCRYPTED,
+                data: { json: JSON.parse(innerMessage.message) },
+              },
+            ],
           },
           metaData: { packing: 'anoncrypt' },
         },
@@ -246,7 +256,7 @@ describe('routing-message-handler', () => {
       {
         data: {
           id: expect.anything(),
-		  to: `${recipient.did}#${recipient.keys[0].kid}`,
+          to: `${recipient.did}#${recipient.keys[0].kid}`,
           type: QUEUE_MESSAGE_TYPE,
           raw: innerMessage.message,
           createdAt: expect.anything(),
@@ -313,7 +323,9 @@ describe('routing-message-handler', () => {
         body: {
           next: recipient.did,
         },
-        attachments: [{ media_type: DIDCommMessageMediaType.ENCRYPTED, data: { json: JSON.parse(innerMessage.message) } }],
+        attachments: [
+          { media_type: DIDCommMessageMediaType.ENCRYPTED, data: { json: JSON.parse(innerMessage.message) } },
+        ],
       },
     })
     await agent.sendDIDCommMessage({
@@ -326,7 +338,7 @@ describe('routing-message-handler', () => {
       {
         data: {
           id: expect.anything(),
-		  to: `${recipient.did}#${recipient.keys[0].kid}`,
+          to: `${recipient.did}#${recipient.keys[0].kid}`,
           type: QUEUE_MESSAGE_TYPE,
           raw: innerMessage.message,
           createdAt: expect.anything(),
@@ -386,7 +398,9 @@ describe('routing-message-handler', () => {
         body: {
           next: recipient.did,
         },
-        attachments: [{ media_type: DIDCommMessageMediaType.ENCRYPTED, data: { json: JSON.parse(innerMessage.message) } }],
+        attachments: [
+          { media_type: DIDCommMessageMediaType.ENCRYPTED, data: { json: JSON.parse(innerMessage.message) } },
+        ],
       },
     })
     await agent.sendDIDCommMessage({

--- a/packages/did-comm/src/__tests__/trust-ping-message-handler.test.ts
+++ b/packages/did-comm/src/__tests__/trust-ping-message-handler.test.ts
@@ -1,4 +1,4 @@
-import { DIDComm } from '../didcomm'
+import { DIDComm } from '../didcomm.js'
 import {
   IDIDManager,
   IEventListener,
@@ -8,27 +8,28 @@ import {
   IResolver,
   TAgent,
 } from '../../../core-types/src'
-import {
-  createAgent
-} from '../../../core/src'
+import { createAgent } from '../../../core/src'
 import { DIDManager, MemoryDIDStore } from '../../../did-manager/src'
 import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-manager/src'
 import { KeyManagementSystem } from '../../../kms-local/src'
 import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { Resolver } from 'did-resolver'
-import { DIDCommHttpTransport } from '../transports/transports'
-import { IDIDComm } from '../types/IDIDComm'
+import { DIDCommHttpTransport } from '../transports/transports.js'
+import { IDIDComm } from '../types/IDIDComm.js'
 import { MessageHandler } from '../../../message-handler/src'
-import { createTrustPingMessage, TrustPingMessageHandler } from '../protocols/trust-ping-message-handler'
+import { createTrustPingMessage, TrustPingMessageHandler } from '../protocols/trust-ping-message-handler.js'
 import { FakeDidProvider, FakeDidResolver } from '../../../test-utils/src'
 import { MessagingRouter, RequestWithAgentRouter } from '../../../remote-server/src'
 import { Entities, IDataStore, MetaData, migrations } from '../../../data-store/src'
+// @ts-ignore
 import express from 'express'
 import { Server } from 'http'
-import { DIDCommMessageHandler } from '../message-handler'
+import { DIDCommMessageHandler } from '../message-handler.js'
 import { DataStore, DataStoreORM } from '../../../data-store/src'
 import { DataSource } from 'typeorm'
+
 import { jest } from '@jest/globals'
+import 'cross-fetch/polyfill'
 
 const DIDCommEventSniffer: IEventListener = {
   eventTypes: ['DIDCommV2Message-sent', 'DIDCommV2Message-received'],

--- a/packages/did-comm/src/types/IDIDComm.ts
+++ b/packages/did-comm/src/types/IDIDComm.ts
@@ -44,11 +44,11 @@ export interface IDIDComm extends IPluginMethodMap {
    *   * args.message - {@link IDIDCommMessage} - the message to be packed
    *   * args.packing - {@link DIDCommMessagePacking} - the packing method
    *   * args.keyRef - Optional - string - either an `id` of a {@link did-resolver#VerificationMethod}
-   *     `kid` of a {@link @veramo/core#IKey} that will be used when `packing` is `jws` or `authcrypt`.
+   *     `kid` of a {@link @veramo/core-types#IKey} that will be used when `packing` is `jws` or `authcrypt`.
    *   * args.options - {@link IDIDCommOptions} - optional options
    *
-   * @param context - This method requires an agent that also has {@link @veramo/core#IDIDManager},
-   *   {@link @veramo/core#IKeyManager} and {@link @veramo/core#IResolver} plugins in use.
+   * @param context - This method requires an agent that also has {@link @veramo/core-types#IDIDManager},
+   *   {@link @veramo/core-types#IKeyManager} and {@link @veramo/core-types#IResolver} plugins in use.
    *   When calling this method, the `context` is supplied automatically by the framework.
    *
    * @returns a Promise that resolves to an object containing the serialized packed `message` string
@@ -65,8 +65,8 @@ export interface IDIDComm extends IPluginMethodMap {
    * {@link DIDCommMessagePacking} used to pack it.
    *
    * @param args - an object containing the serialized message to be unpacked
-   * @param context - This method requires an agent that also has {@link @veramo/core#IDIDManager},
-   *   {@link @veramo/core#IKeyManager} and {@link @veramo/core#IResolver} plugins in use.
+   * @param context - This method requires an agent that also has {@link @veramo/core-types#IDIDManager},
+   *   {@link @veramo/core-types#IKeyManager} and {@link @veramo/core-types#IResolver} plugins in use.
    *   When calling this method, the `context` is supplied automatically by the framework.
    *
    * @returns a Promise that resolves to an object containing
@@ -89,7 +89,7 @@ export interface IDIDComm extends IPluginMethodMap {
    *
    * @param args - An object containing the message, recipient information and optional
    * information about the transport that should be used.
-   * @param context - This method requires an agent that also has {@link @veramo/core#IResolver}
+   * @param context - This method requires an agent that also has {@link @veramo/core-types#IResolver}
    * plugins in use. When calling this method, the `context` is supplied automatically by the framework.
    *
    * @returns The transport id that was used to send the message. It throws an error in case something

--- a/packages/did-manager/src/id-manager.ts
+++ b/packages/did-manager/src/id-manager.ts
@@ -25,7 +25,7 @@ import schema from '@veramo/core-types/build/plugin.schema.json' assert { type: 
 import { AbstractDIDStore } from './abstract-identifier-store.js'
 
 /**
- * Agent plugin that implements {@link @veramo/core#IDIDManager} interface
+ * Agent plugin that implements {@link @veramo/core-types#IDIDManager} interface
  * @public
  */
 export class DIDManager implements IAgentPlugin {
@@ -77,28 +77,28 @@ export class DIDManager implements IAgentPlugin {
     return provider
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerGetProviders} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerGetProviders} */
   async didManagerGetProviders(): Promise<string[]> {
     return Object.keys(this.providers)
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerFind} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerFind} */
   async didManagerFind(args: IDIDManagerFindArgs): Promise<IIdentifier[]> {
     return this.store.listDIDs(args)
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerGet} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerGet} */
   async didManagerGet({ did }: IDIDManagerGetArgs): Promise<IIdentifier> {
     return this.store.getDID({ did })
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerGetByAlias} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerGetByAlias} */
   async didManagerGetByAlias({ alias, provider }: IDIDManagerGetByAliasArgs): Promise<IIdentifier> {
     const providerName = provider || this.defaultProvider
     return this.store.getDID({ alias, provider: providerName })
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerCreate} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerCreate} */
   async didManagerCreate(
     args: IDIDManagerCreateArgs,
     context: IAgentContext<IKeyManager>,
@@ -128,7 +128,7 @@ export class DIDManager implements IAgentPlugin {
     return identifier
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerGetOrCreate} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerGetOrCreate} */
   async didManagerGetOrCreate(
     { provider, alias, kms, options }: IDIDManagerGetOrCreateArgs,
     context: IAgentContext<IKeyManager>,
@@ -143,7 +143,7 @@ export class DIDManager implements IAgentPlugin {
     }
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerUpdate} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerUpdate} */
   async didManagerUpdate(
     { did, document, options }: IDIDManagerUpdateArgs,
     context: IAgentContext<IKeyManager>,
@@ -157,20 +157,19 @@ export class DIDManager implements IAgentPlugin {
      * 6. Update the identifier in the store
      * 7. Return the identifier
      */
-      const identifier = await this.store.getDID({ did })
-      const identifierProvider = this.getProvider(identifier.provider)
-      if (typeof identifierProvider?.updateIdentifier !== 'function') {
-        throw new Error(`not_supported: ${identifier?.provider} provider does not implement full document updates`)
-      }
-      const updatedIdentifier = await identifierProvider.updateIdentifier(
-        { did, document, options },
-        context,
+    const identifier = await this.store.getDID({ did })
+    const identifierProvider = this.getProvider(identifier.provider)
+    if (typeof identifierProvider?.updateIdentifier !== 'function') {
+      throw new Error(
+        `not_supported: ${identifier?.provider} provider does not implement full document updates`,
       )
-      await this.store.importDID(updatedIdentifier)
-      return updatedIdentifier
+    }
+    const updatedIdentifier = await identifierProvider.updateIdentifier({ did, document, options }, context)
+    await this.store.importDID(updatedIdentifier)
+    return updatedIdentifier
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerSetAlias} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerSetAlias} */
   async didManagerSetAlias(
     { did, alias }: IDIDManagerSetAliasArgs,
     context: IAgentContext<IKeyManager>,
@@ -180,7 +179,7 @@ export class DIDManager implements IAgentPlugin {
     return await this.store.importDID(identifier)
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerImport} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerImport} */
   async didManagerImport(
     identifier: MinimalImportableIdentifier,
     context: IAgentContext<IKeyManager>,
@@ -200,7 +199,7 @@ export class DIDManager implements IAgentPlugin {
     return importedDID
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerDelete} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerDelete} */
   async didManagerDelete(
     { did }: IDIDManagerDeleteArgs,
     context: IAgentContext<IKeyManager>,
@@ -211,7 +210,7 @@ export class DIDManager implements IAgentPlugin {
     return this.store.deleteDID({ did })
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerAddKey} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerAddKey} */
   async didManagerAddKey(
     { did, key, options }: IDIDManagerAddKeyArgs,
     context: IAgentContext<IKeyManager>,
@@ -224,7 +223,7 @@ export class DIDManager implements IAgentPlugin {
     return result
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerRemoveKey} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerRemoveKey} */
   async didManagerRemoveKey(
     { did, kid, options }: IDIDManagerRemoveKeyArgs,
     context: IAgentContext<IKeyManager>,
@@ -237,7 +236,7 @@ export class DIDManager implements IAgentPlugin {
     return result
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerAddService} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerAddService} */
   async didManagerAddService(
     { did, service, options }: IDIDManagerAddServiceArgs,
     context: IAgentContext<IKeyManager>,
@@ -250,7 +249,7 @@ export class DIDManager implements IAgentPlugin {
     return result
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerRemoveService} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerRemoveService} */
   async didManagerRemoveService(
     { did, id, options }: IDIDManagerRemoveServiceArgs,
     context: IAgentContext<IKeyManager>,

--- a/packages/did-manager/src/index.ts
+++ b/packages/did-manager/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * Provides a {@link @veramo/did-manager#DIDManager | plugin} for the
- * {@link @veramo/core#Agent} that implements {@link @veramo/core#IDIDManager} interface.
+ * {@link @veramo/core#Agent} that implements {@link @veramo/core-types#IDIDManager} interface.
  *
  * @packageDocumentation
  */

--- a/packages/did-provider-ion/__tests__/canonicalizer.test.ts
+++ b/packages/did-provider-ion/__tests__/canonicalizer.test.ts
@@ -1,4 +1,4 @@
-import { JsonCanonicalizer } from '../src/json-canonicalizer'
+import { JsonCanonicalizer } from '../src/json-canonicalizer.js'
 
 describe('canonicalizer result should be', () => {
   it('throwing an error on null input', () => {

--- a/packages/did-provider-ion/__tests__/functions.test.ts
+++ b/packages/did-provider-ion/__tests__/functions.test.ts
@@ -1,6 +1,6 @@
 import { ManagedKeyInfo } from '../../core-types/src'
-import { generatePrivateKeyHex, tempMemoryKey, toIonPrivateKeyJwk } from '../src/functions'
-import { KeyIdentifierRelation, KeyType } from '../src/types/ion-provider-types'
+import { generatePrivateKeyHex, tempMemoryKey, toIonPrivateKeyJwk } from '../src/functions.js'
+import { KeyIdentifierRelation, KeyType } from '../src/types/ion-provider-types.js'
 
 const PRIVATE_RECOVERY_KEY_HEX = '7c90c0575643d09a370c35021c91e9d8af2c968c5f3a4bf73802693511a55b9f'
 const PRIVATE_UPDATE_KEY_HEX = '7288a92f6219c873446abd1f8d26fcbbe1caa5274b47f6f086ef3e7e75dcad8b'

--- a/packages/did-provider-ion/__tests__/ion-did-provider.test.ts
+++ b/packages/did-provider-ion/__tests__/ion-did-provider.test.ts
@@ -4,8 +4,8 @@ import { DIDManager, MemoryDIDStore } from '../../did-manager/src'
 import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../key-manager/src'
 import { IonPublicKeyPurpose } from '@decentralized-identity/ion-sdk'
 import { KeyManagementSystem } from '../../kms-local/src'
-import { IonDIDProvider } from '../src'
-import { ICreateIdentifierOpts } from '../src/types/ion-provider-types'
+import { IonDIDProvider } from '../src/ion-did-provider.js'
+import { ICreateIdentifierOpts } from '../src/types/ion-provider-types.js'
 
 import { jest } from '@jest/globals'
 

--- a/packages/did-provider-ion/src/ion-did-provider.ts
+++ b/packages/did-provider-ion/src/ion-did-provider.ts
@@ -1,4 +1,12 @@
-import { DIDResolutionResult, IAgentContext, IIdentifier, IKey, IKeyManager, IService, ManagedKeyInfo } from '@veramo/core-types'
+import {
+  DIDResolutionResult,
+  IAgentContext,
+  IIdentifier,
+  IKey,
+  IKeyManager,
+  IService,
+  ManagedKeyInfo,
+} from '@veramo/core-types'
 import { AbstractIdentifierProvider } from '@veramo/did-manager'
 
 import Debug from 'debug'
@@ -47,19 +55,24 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
   private readonly defaultKms: string
   private readonly ionPoW: IonPoW
 
-  constructor(options: { defaultKms: string, challengeEnabled?: boolean, challengeEndpoint?: string, solutionEndpoint?: string}) {
+  constructor(options: {
+    defaultKms: string
+    challengeEnabled?: boolean
+    challengeEndpoint?: string
+    solutionEndpoint?: string
+  }) {
     super()
     this.defaultKms = options.defaultKms
-    const challengeEnabled = options?.challengeEnabled === undefined ? true : options.challengeEnabled;
+    const challengeEnabled = options?.challengeEnabled === undefined ? true : options.challengeEnabled
     const challengeEndpoint = options?.challengeEndpoint
     const solutionEndpoint = options?.solutionEndpoint
     this.ionPoW = new IonPoW({ challengeEnabled, challengeEndpoint, solutionEndpoint })
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerCreate} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerCreate} */
   async createIdentifier(
     { kms, options, alias }: { kms?: string; alias?: string; options?: ICreateIdentifierOpts },
-    context: IAgentContext<IKeyManager>
+    context: IAgentContext<IKeyManager>,
   ): Promise<Omit<IIdentifier, 'provider'>> {
     const actionTimestamp = getActionTimestamp(options?.actionTimestamp)
 
@@ -70,7 +83,7 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
         relation: KeyIdentifierRelation.RECOVERY,
         options: options?.recoveryKey,
       },
-      context
+      context,
     )
     const updateKey = await this.importProvidedOrGeneratedKey(
       {
@@ -79,7 +92,7 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
         relation: KeyIdentifierRelation.UPDATE,
         options: options?.updateKey,
       },
-      context
+      context,
     )
 
     // No options or no verification method options, results in us generating a single key as the only authentication verification method in the DID
@@ -102,7 +115,7 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
           relation: KeyIdentifierRelation.DID,
           options: verificationMethod,
         },
-        context
+        context,
       )
       veramoKeys.push(key)
       ionPublicKeys.push(toIonPublicKey(key, verificationMethod.purposes))
@@ -136,14 +149,20 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
     return identifier
   }
 
-  async updateIdentifier(args: { did: string; kms?: string | undefined; alias?: string | undefined; options?: any }, context: IAgentContext<IKeyManager>): Promise<IIdentifier> {
+  async updateIdentifier(
+    args: { did: string; kms?: string | undefined; alias?: string | undefined; options?: any },
+    context: IAgentContext<IKeyManager>,
+  ): Promise<IIdentifier> {
     throw new Error('IonDIDProvider updateIdentifier not supported yet.')
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerDelete} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerDelete} */
   async deleteIdentifier(identifier: IIdentifier, context: IContext): Promise<boolean> {
     const didResolution = await this.getAssertedDidDocument(identifier, IonDidForm.LONG)
-    const recoveryKey = getVeramoRecoveryKey(identifier.keys, didResolution.didDocumentMetadata.method.recoveryCommitment)
+    const recoveryKey = getVeramoRecoveryKey(
+      identifier.keys,
+      didResolution.didDocumentMetadata.method.recoveryCommitment,
+    )
     const request = await IonRequest.createDeactivateRequest({
       didSuffix: ionDidSuffixFromLong(identifier.did),
       recoveryPublicKey: toJwkEs256k(toIonPublicKeyJwk(recoveryKey.publicKeyHex)),
@@ -155,8 +174,11 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
     return true
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerAddKey} */
-  async addKey({ identifier, key, options }: { identifier: IIdentifier; key: IKey; options?: IAddKeyOpts }, context: IContext): Promise<any> {
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerAddKey} */
+  async addKey(
+    { identifier, key, options }: { identifier: IIdentifier; key: IKey; options?: IAddKeyOpts },
+    context: IContext,
+  ): Promise<any> {
     if (!options) {
       throw Error('Add key needs options, since we need to know the purpose(s) of the key')
     }
@@ -184,10 +206,10 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
     }
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerAddService} */
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerAddService} */
   async addService(
     { identifier, service, options }: { identifier: IIdentifier; service: IService; options?: IUpdateOpts },
-    context: IContext
+    context: IContext,
   ): Promise<any> {
     const rotation = await this.rotateVeramoKey({ identifier, options, context })
 
@@ -213,8 +235,11 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
     }
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerRemoveKey} */
-  async removeKey({ identifier, kid, options }: { identifier: IIdentifier; kid: string; options?: IUpdateOpts }, context: IContext): Promise<any> {
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerRemoveKey} */
+  async removeKey(
+    { identifier, kid, options }: { identifier: IIdentifier; kid: string; options?: IUpdateOpts },
+    context: IContext,
+  ): Promise<any> {
     const rotation = await this.rotateVeramoKey({ identifier, options, context })
 
     const request = await IonRequest.createUpdateRequest({
@@ -235,8 +260,11 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
     }
   }
 
-  /** {@inheritDoc @veramo/core#IDIDManager.didManagerRemoveService} */
-  async removeService({ identifier, id, options }: { identifier: IIdentifier; id: string; options?: IUpdateOpts }, context: IContext): Promise<any> {
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerRemoveService} */
+  async removeService(
+    { identifier, id, options }: { identifier: IIdentifier; id: string; options?: IUpdateOpts },
+    context: IContext,
+  ): Promise<any> {
     const rotation = await this.rotateVeramoKey({ identifier, options, context })
 
     const request = await IonRequest.createUpdateRequest({
@@ -264,7 +292,10 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
    * @param didForm - Use short or long form (the default) for resolution
    * @returns - A DID Document promise
    */
-  private async getAssertedDidDocument(identifier: IIdentifier, didForm: IonDidForm = IonDidForm.LONG): Promise<DIDResolutionResult> {
+  private async getAssertedDidDocument(
+    identifier: IIdentifier,
+    didForm: IonDidForm = IonDidForm.LONG,
+  ): Promise<DIDResolutionResult> {
     const didDocument = await resolveDidIonFromIdentifier(identifier, didForm)
     if (!didDocument) {
       return Promise.reject(Error(`Could not resolve existing DID document for did ${identifier.did}`))
@@ -301,7 +332,7 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
       alias?: string
       options?: KeyOpts
     },
-    context: IAgentContext<IKeyManager>
+    context: IAgentContext<IKeyManager>,
   ): Promise<IKeyRotation> {
     const currentVeramoKey =
       relation == KeyIdentifierRelation.UPDATE
@@ -317,7 +348,7 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
         relation,
         options,
       },
-      context
+      context,
     )
     const nextIonKey = toIonPublicKey(nextVeramoKey)
     const nextJwk = toIonPublicKeyJwk(nextVeramoKey.publicKeyHex)
@@ -345,7 +376,10 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
     context: IContext
   }) {
     const didResolution = await this.getAssertedDidDocument(identifier, IonDidForm.LONG)
-    const currentUpdateKey = getVeramoUpdateKey(identifier.keys, didResolution.didDocumentMetadata.method.updateCommitment)
+    const currentUpdateKey = getVeramoUpdateKey(
+      identifier.keys,
+      didResolution.didDocumentMetadata.method.updateCommitment,
+    )
     const commitment = computeCommitmentFromIonPublicKey(toIonPublicKey(currentUpdateKey))
     const actionId = getActionTimestamp(options?.actionTimestamp)
 
@@ -358,7 +392,7 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
         kms: kms ? kms : this.defaultKms,
         options: {},
       },
-      context
+      context,
     )
     return rotation
   }
@@ -380,8 +414,13 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
       actionTimestamp,
       relation,
       options,
-    }: { kms?: string; actionTimestamp: number; relation: KeyIdentifierRelation; options?: KeyOpts | VerificationMethod },
-    context: IAgentContext<IKeyManager>
+    }: {
+      kms?: string
+      actionTimestamp: number
+      relation: KeyIdentifierRelation
+      options?: KeyOpts | VerificationMethod
+    },
+    context: IAgentContext<IKeyManager>,
   ): Promise<IKey> {
     const kid = options?.kid ? options.kid : options?.key?.kid
     const type = options?.type
@@ -401,7 +440,9 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
     let privateKeyHex: string
     if (options?.key) {
       if (!options.key.privateKeyHex) {
-        throw new Error(`We need to have a private key when importing a recovery or update key. Key ${kid} did not have one`)
+        throw new Error(
+          `We need to have a private key when importing a recovery or update key. Key ${kid} did not have one`,
+        )
       }
       privateKeyHex = options.key.privateKeyHex
     } else {

--- a/packages/did-resolver/src/__tests__/integration.test.ts
+++ b/packages/did-resolver/src/__tests__/integration.test.ts
@@ -1,8 +1,8 @@
-import { DIDResolverPlugin } from '../resolver'
+import { DIDResolverPlugin } from '../resolver.js'
 import { Resolver } from 'did-resolver'
 import { getResolver as getEthrResolver } from 'ethr-did-resolver'
 import { getResolver as getWebDidResolver } from 'web-did-resolver'
-import { getUniversalResolverFor } from '../universal-resolver'
+import { getUniversalResolverFor } from '../universal-resolver.js'
 import { jest } from '@jest/globals'
 
 jest.setTimeout(60000)

--- a/packages/did-resolver/src/__tests__/resolver.test.ts
+++ b/packages/did-resolver/src/__tests__/resolver.test.ts
@@ -1,11 +1,11 @@
-import { DIDResolverPlugin } from '../resolver'
+import { DIDResolverPlugin } from '../resolver.js'
 import { Resolver } from 'did-resolver'
 
 describe('@veramo/did-resolver', () => {
   it('should throw error when misconfigured', () => {
     expect(() => {
       new DIDResolverPlugin({
-        //@ts-ignore
+        // @ts-ignore
         resolver: undefined,
       })
     }).toThrow()

--- a/packages/did-resolver/src/index.ts
+++ b/packages/did-resolver/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * Provides a {@link @veramo/did-resolver#DIDResolverPlugin | plugin} for the {@link @veramo/core#Agent}
- * that implements {@link @veramo/core#IResolver } interface.
+ * that implements {@link @veramo/core-types#IResolver } interface.
  *
  * @packageDocumentation
  */

--- a/packages/did-resolver/src/resolver.ts
+++ b/packages/did-resolver/src/resolver.ts
@@ -47,7 +47,7 @@ export class DIDResolverPlugin implements IAgentPlugin {
     }
   }
 
-  /** {@inheritDoc @veramo/core#IResolver.resolveDid} */
+  /** {@inheritDoc @veramo/core-types#IResolver.resolveDid} */
   async resolveDid({
     didUrl,
     options,
@@ -76,7 +76,7 @@ export class DIDResolverPlugin implements IAgentPlugin {
     }
   }
 
-  /** {@inheritDoc @veramo/core#IResolver.getDIDComponentById} */
+  /** {@inheritDoc @veramo/core-types#IResolver.getDIDComponentById} */
   async getDIDComponentById({
     didDocument,
     didUrl,

--- a/packages/key-manager/src/__tests__/abstract-key-store.test.ts
+++ b/packages/key-manager/src/__tests__/abstract-key-store.test.ts
@@ -1,4 +1,4 @@
-import { AbstractKeyStore } from '../abstract-key-store'
+import { AbstractKeyStore } from '../abstract-key-store.js'
 import { IKey, ManagedKeyInfo } from '@veramo/core-types'
 
 class MockKeyStore extends AbstractKeyStore {

--- a/packages/key-manager/src/index.ts
+++ b/packages/key-manager/src/index.ts
@@ -1,13 +1,17 @@
 /**
  * Provides a {@link @veramo/key-manager#KeyManager | plugin} for the {@link @veramo/core#Agent}
- * that implements {@link @veramo/core#IKeyManager} interface
+ * that implements {@link @veramo/core-types#IKeyManager} interface
  *
  * @packageDocumentation
  */
 export { KeyManager } from './key-manager.js'
 export { AbstractKeyManagementSystem } from './abstract-key-management-system.js'
 export { AbstractKeyStore } from './abstract-key-store.js'
-export { AbstractPrivateKeyStore, ImportablePrivateKey, ManagedPrivateKey } from './abstract-private-key-store.js'
+export {
+  AbstractPrivateKeyStore,
+  ImportablePrivateKey,
+  ManagedPrivateKey,
+} from './abstract-private-key-store.js'
 export { AbstractSecretBox } from './abstract-secret-box.js'
 export { MemoryKeyStore, MemoryPrivateKeyStore } from './memory-key-store.js'
 export * from './types.js'

--- a/packages/key-manager/src/key-manager.ts
+++ b/packages/key-manager/src/key-manager.ts
@@ -29,7 +29,7 @@ import Debug from 'debug'
 const debug = Debug('veramo:key-manager')
 
 /**
- * Agent plugin that implements {@link @veramo/core#IKeyManager} methods.
+ * Agent plugin that implements {@link @veramo/core-types#IKeyManager} methods.
  *
  * This plugin orchestrates various implementations of {@link AbstractKeyManagementSystem}, using a KeyStore to
  * remember the link between a key reference, its metadata, and the respective key management system that provides the
@@ -80,12 +80,12 @@ export class KeyManager implements IAgentPlugin {
     return kms
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerGetKeyManagementSystems} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerGetKeyManagementSystems} */
   async keyManagerGetKeyManagementSystems(): Promise<Array<string>> {
     return Object.keys(this.kms)
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerCreate} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerCreate} */
   async keyManagerCreate(args: IKeyManagerCreateArgs): Promise<ManagedKeyInfo> {
     const kms = this.getKms(args.kms)
     const partialKey = await kms.createKey({ type: args.type, meta: args.meta })
@@ -100,12 +100,12 @@ export class KeyManager implements IAgentPlugin {
     return key
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerGet} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerGet} */
   async keyManagerGet({ kid }: IKeyManagerGetArgs): Promise<IKey> {
     return this.store.getKey({ kid })
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerDelete} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerDelete} */
   async keyManagerDelete({ kid }: IKeyManagerDeleteArgs): Promise<boolean> {
     const key = await this.store.getKey({ kid })
     const kms = this.getKms(key.kms)
@@ -113,7 +113,7 @@ export class KeyManager implements IAgentPlugin {
     return this.store.deleteKey({ kid })
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerImport} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerImport} */
   async keyManagerImport(key: MinimalImportableKey): Promise<ManagedKeyInfo> {
     const kms = this.getKms(key.kms)
     const managedKey = await kms.importKey(key)
@@ -123,7 +123,7 @@ export class KeyManager implements IAgentPlugin {
     return importedKey
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerEncryptJWE} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerEncryptJWE} */
   async keyManagerEncryptJWE({ kid, to, data }: IKeyManagerEncryptJWEArgs): Promise<string> {
     // TODO: if a sender `key` is provided, then it should be used to create an authenticated encrypter
     // const key = await this.store.get({ kid })
@@ -145,7 +145,7 @@ export class KeyManager implements IAgentPlugin {
     return JSON.stringify(result)
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerDecryptJWE} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerDecryptJWE} */
   async keyManagerDecryptJWE({ kid, data }: IKeyManagerDecryptJWEArgs): Promise<string> {
     const jwe: JWE = JSON.parse(data)
     const ecdh = this.createX25519ECDH(kid)
@@ -158,7 +158,7 @@ export class KeyManager implements IAgentPlugin {
     return result
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerSignJWT} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerSignJWT} */
   async keyManagerSignJWT({ kid, data }: IKeyManagerSignJWTArgs): Promise<string> {
     if (typeof data === 'string') {
       return this.keyManagerSign({ keyRef: kid, data, encoding: 'utf-8' })
@@ -168,7 +168,7 @@ export class KeyManager implements IAgentPlugin {
     }
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerSign} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerSign} */
   async keyManagerSign(args: IKeyManagerSignArgs): Promise<string> {
     const { keyRef, data, algorithm, encoding, ...extras } = { encoding: 'utf-8', ...args }
     const keyInfo: ManagedKeyInfo = await this.store.getKey({ kid: keyRef })
@@ -187,7 +187,7 @@ export class KeyManager implements IAgentPlugin {
     return kms.sign({ keyRef: keyInfo, algorithm, data: dataBytes, ...extras })
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerSignEthTX} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerSignEthTX} */
   async keyManagerSignEthTX({ kid, transaction }: IKeyManagerSignEthTXArgs): Promise<string> {
     const { v, r, s, from, ...tx } = <any>transaction
     if (typeof from === 'string') {
@@ -208,7 +208,7 @@ export class KeyManager implements IAgentPlugin {
     return this.keyManagerSign({ keyRef: kid, data, algorithm, encoding: 'base16' })
   }
 
-  /** {@inheritDoc @veramo/core#IKeyManager.keyManagerSharedSecret} */
+  /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerSharedSecret} */
   async keyManagerSharedSecret(args: IKeyManagerSharedSecretArgs): Promise<string> {
     const { secretKeyRef, publicKey } = args
     const myKeyRef = await this.store.getKey({ kid: secretKeyRef })

--- a/packages/kms-local/src/__tests__/kms-local.test.ts
+++ b/packages/kms-local/src/__tests__/kms-local.test.ts
@@ -1,4 +1,4 @@
-import { KeyManagementSystem } from '../key-management-system'
+import { KeyManagementSystem } from '../key-management-system.js'
 import { TKeyType } from '../../../core-types/src'
 import { MemoryPrivateKeyStore } from '../../../key-manager/src'
 import * as u8a from 'uint8arrays'

--- a/packages/kms-local/src/__tests__/secret-box.test.ts
+++ b/packages/kms-local/src/__tests__/secret-box.test.ts
@@ -1,4 +1,4 @@
-import { SecretBox } from '../secret-box'
+import { SecretBox } from '../secret-box.js'
 // import * as elliptic from 'elliptic'
 // import * as hash from 'hash.js'
 
@@ -13,7 +13,7 @@ describe('@veramo/kms-local', () => {
     expect(decrypted).toEqual(message)
   })
   //
-  // //@ts-ignore
+  // // @ts-ignore
   // const curves = elliptic.default.curves
   //
   // function createCurve(options: any) {

--- a/packages/kms-local/src/key-management-system.ts
+++ b/packages/kms-local/src/key-management-system.ts
@@ -103,10 +103,10 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
   }
 
   async sign({
-               keyRef,
-               algorithm,
-               data,
-             }: {
+    keyRef,
+    algorithm,
+    data,
+  }: {
     keyRef: Pick<IKey, 'kid'>
     algorithm?: string
     data: Uint8Array
@@ -133,10 +133,11 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
       } else if (['eth_signTypedData', 'EthereumEip712Signature2021'].includes(algorithm)) {
         return await this.eth_signTypedData(managedKey.privateKeyHex, data)
       } else if (['eth_rawSign'].includes(algorithm)) {
-        return this.eth_rawSign(managedKey.privateKeyHex, data);
+        return this.eth_rawSign(managedKey.privateKeyHex, data)
       }
-    } else if (managedKey.type === 'Secp256r1' &&
-       (typeof algorithm === 'undefined' || algorithm === 'ES256')
+    } else if (
+      managedKey.type === 'Secp256r1' &&
+      (typeof algorithm === 'undefined' || algorithm === 'ES256')
     ) {
       return await this.signES256(managedKey.privateKeyHex, data)
     }
@@ -206,7 +207,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
         `invalid_arguments: Cannot sign typed data. 'domain', 'types', and 'message' must be provided`,
       )
     }
-    delete(msgTypes.EIP712Domain)
+    delete msgTypes.EIP712Domain
     const wallet = new Wallet(privateKeyHex)
 
     const signature = await wallet._signTypedData(msgDomain, msgTypes, msg)
@@ -248,7 +249,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
    * @returns a `0x` prefixed hex string representing the signed digest in compact format
    */
   private eth_rawSign(managedKey: string, data: Uint8Array) {
-    return new SigningKey("0x" + managedKey).signDigest(data).compact
+    return new SigningKey('0x' + managedKey).signDigest(data).compact
   }
 
   /**
@@ -278,10 +279,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
   /**
    * @returns a base64url encoded signature for the `ES256` alg
    */
-  private async signES256(
-    privateKeyHex: string,
-    data: Uint8Array,
-  ): Promise<string> {
+  private async signES256(privateKeyHex: string, data: Uint8Array): Promise<string> {
     const signer = ES256Signer(arrayify(privateKeyHex, { allowMissingPrefix: true }))
     const signature = await signer(data)
     // base64url encoded string
@@ -289,7 +287,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
   }
 
   /**
-   * Converts a {@link @veramo/key-manager#ManagedPrivateKey | ManagedPrivateKey} to {@link @veramo/core#ManagedKeyInfo}
+   * Converts a {@link @veramo/key-manager#ManagedPrivateKey | ManagedPrivateKey} to {@link @veramo/core-types#ManagedKeyInfo}
    */
   private asManagedKeyInfo(args: RequireOnly<ManagedPrivateKey, 'privateKeyHex' | 'type'>): ManagedKeyInfo {
     let key: Partial<ManagedKeyInfo>
@@ -316,7 +314,14 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
           kid: args.alias || publicKeyHex,
           publicKeyHex,
           meta: {
-            algorithms: ['ES256K', 'ES256K-R', 'eth_signTransaction', 'eth_signTypedData', 'eth_signMessage', 'eth_rawSign'],
+            algorithms: [
+              'ES256K',
+              'ES256K-R',
+              'eth_signTransaction',
+              'eth_signTypedData',
+              'eth_signMessage',
+              'eth_rawSign',
+            ],
           },
         }
         break

--- a/packages/message-handler/src/__tests__/default.test.ts
+++ b/packages/message-handler/src/__tests__/default.test.ts
@@ -1,8 +1,9 @@
 import { IAgentContext, IMessageHandler } from '../../../core-types/src'
 import { createAgent } from '../../../core/src'
-import { MessageHandler } from '..'
-import { AbstractMessageHandler, Message } from '../../build'
+import { MessageHandler } from '../message-handler.js'
 import { jest } from '@jest/globals'
+import { AbstractMessageHandler } from "../abstract-message-handler.js";
+import { Message } from "../message.js";
 
 jest.setTimeout(60000)
 

--- a/packages/message-handler/src/index.ts
+++ b/packages/message-handler/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * Provides a {@link @veramo/message-handler#MessageHandler | plugin} for the
- * {@link @veramo/core#Agent} that implements {@link @veramo/core#IMessageHandler} interface.
+ * {@link @veramo/core#Agent} that implements {@link @veramo/core-types#IMessageHandler} interface.
  *
  * @packageDocumentation
  */

--- a/packages/message-handler/src/message-handler.ts
+++ b/packages/message-handler/src/message-handler.ts
@@ -22,15 +22,15 @@ export const EventTypes = {
 }
 
 /**
- * A Veramo agent plugin that implements {@link @veramo/core#IMessageHandler | IMessageHandler} methods.
+ * A Veramo agent plugin that implements {@link @veramo/core-types#IMessageHandler | IMessageHandler} methods.
  *
- * This plugin is meant to chain together multiple other {@link @veramo/core#IMessageHandler | IMessageHandler}
+ * This plugin is meant to chain together multiple other {@link @veramo/core-types#IMessageHandler | IMessageHandler}
  * implementations.
  *
  * When handling a message, the message is passed from one handler to the next, and each handler in
  * the chain can decide if it is able to interpret the message.
  *
- * If the message can be processed by a handler it is returned as an {@link @veramo/core#IMessage | IMessage}.
+ * If the message can be processed by a handler it is returned as an {@link @veramo/core-types#IMessage | IMessage}.
  * If the message cannot be processed by any of the handlers, an error is thrown.
  *
  * @public
@@ -63,7 +63,7 @@ export class MessageHandler implements IAgentPlugin {
     }
   }
 
-  /** {@inheritDoc @veramo/core#IMessageHandler.handleMessage} */
+  /** {@inheritDoc @veramo/core-types#IMessageHandler.handleMessage} */
   public async handleMessage(
     args: IHandleMessageArgs,
     context: IAgentContext<IDataStore>,

--- a/packages/message-handler/src/message.ts
+++ b/packages/message-handler/src/message.ts
@@ -7,7 +7,7 @@ import {
 } from '@veramo/core-types'
 
 /**
- * A class implementing {@link @veramo/core#IMessage | IMessage}.
+ * A class implementing {@link @veramo/core-types#IMessage | IMessage}.
  *
  * This is used by {@link @veramo/message-handler#MessageHandler | MessageHandler}.
  *
@@ -23,7 +23,7 @@ export class Message implements IMessage {
     }
   }
 
-  //@ts-ignore
+  // @ts-ignore
   id: string
 
   createdAt?: string
@@ -32,7 +32,7 @@ export class Message implements IMessage {
 
   threadId?: string
 
-  //@ts-ignore
+  // @ts-ignore
   type: string
 
   raw?: string
@@ -46,7 +46,7 @@ export class Message implements IMessage {
   from?: string
 
   to?: string
-  
+
   returnRoute?: string
 
   metaData?: IMetaData[]

--- a/packages/selective-disclosure/src/__tests__/validate-presentation.test.ts
+++ b/packages/selective-disclosure/src/__tests__/validate-presentation.test.ts
@@ -1,6 +1,6 @@
 import { IAgentContext, VerifiableCredential, VerifiablePresentation } from '../../../core-types/src'
-import { ISelectiveDisclosureRequest } from '../types'
-import { SelectiveDisclosure } from '../action-handler'
+import { ISelectiveDisclosureRequest } from '../types.js'
+import { SelectiveDisclosure } from '../action-handler.js'
 import { jest } from '@jest/globals'
 
 const actionHandler = new SelectiveDisclosure()

--- a/packages/selective-disclosure/src/action-handler.ts
+++ b/packages/selective-disclosure/src/action-handler.ts
@@ -20,7 +20,7 @@ import {
   ISelectiveDisclosureRequest,
   IValidatePresentationAgainstSdrArgs,
 } from './types.js'
-import schema from './plugin.schema.json' assert { type: 'json'}
+import schema from './plugin.schema.json' assert { type: 'json' }
 import { createJWT } from 'did-jwt'
 import Debug from 'debug'
 import {
@@ -108,7 +108,7 @@ export class SelectiveDisclosure implements IAgentPlugin {
 
   /**
    * Gathers the required credentials necessary to fulfill a Selective Disclosure Request.
-   * It uses a {@link @veramo/core#IDataStoreORM} plugin implementation to query the local database for
+   * It uses a {@link @veramo/core-types#IDataStoreORM} plugin implementation to query the local database for
    * the required credentials.
    *
    * @param args - Contains the Request to be fulfilled and the DID of the subject

--- a/packages/selective-disclosure/src/message-handler.ts
+++ b/packages/selective-disclosure/src/message-handler.ts
@@ -7,7 +7,7 @@ import { asArray, computeEntryHash } from '@veramo/utils'
 const debug = Debug('veramo:selective-disclosure:message-handler')
 
 /**
- * Identifies a {@link @veramo/core#IMessage} that represents a Selective Disclosure Request
+ * Identifies a {@link @veramo/core-types#IMessage} that represents a Selective Disclosure Request
  *
  * @remarks See {@link https://github.com/uport-project/specs/blob/develop/messages/sharereq.md | Selective Disclosure Request}
  * @beta This API may change without a BREAKING CHANGE notice.

--- a/packages/url-handler/src/__tests__/message-handler.test.ts
+++ b/packages/url-handler/src/__tests__/message-handler.test.ts
@@ -1,5 +1,5 @@
 import { Message } from '../../../message-handler/src'
-import { UrlMessageHandler } from '../index'
+import { UrlMessageHandler } from '../message-handler.js'
 import fetchMock, { MockParams } from 'jest-fetch-mock'
 
 fetchMock.enableMocks()

--- a/packages/utils/src/__tests__/credential-utils.test.ts
+++ b/packages/utils/src/__tests__/credential-utils.test.ts
@@ -4,7 +4,7 @@ import {
   decodePresentationToObject,
   extractIssuer,
   processEntryToArray,
-} from '../credential-utils'
+} from '../credential-utils.js'
 
 describe('@veramo/utils credential utils', () => {
   it('processEntryToArray', () => {

--- a/packages/utils/src/__tests__/did-utils.test.ts
+++ b/packages/utils/src/__tests__/did-utils.test.ts
@@ -1,4 +1,4 @@
-import { getChainIdForDidEthr, getEthereumAddress } from '../did-utils'
+import { getChainIdForDidEthr, getEthereumAddress } from '../did-utils.js'
 
 describe('@veramo/utils did utils', () => {
   it(`should return correct chainId for did:ethr`, () => {

--- a/packages/utils/src/__tests__/encodings.test.ts
+++ b/packages/utils/src/__tests__/encodings.test.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, hexToBytes } from '../encodings'
+import { bytesToHex, hexToBytes } from '../encodings.js'
 
 describe('@veramo/utils encoding utils', () => {
   describe('hexToBytes', () => {

--- a/packages/utils/src/__tests__/utils.test.ts
+++ b/packages/utils/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { asArray, isDefined } from '../type-utils'
+import { asArray, isDefined } from '../type-utils.js'
 
 describe('@veramo/utils type utils', () => {
   it('isDefined should return correct results', () => {

--- a/packages/utils/src/credential-utils.ts
+++ b/packages/utils/src/credential-utils.ts
@@ -41,8 +41,8 @@ export function processEntryToArray(
 }
 
 /**
- * Parses a {@link @veramo/core#W3CVerifiableCredential | W3CVerifiableCredential} and converts it to a
- * {@link @veramo/core#VerifiableCredential | VerifiableCredential} so it is easier to use programmatically.
+ * Parses a {@link @veramo/core-types#W3CVerifiableCredential | W3CVerifiableCredential} and converts it to a
+ * {@link @veramo/core-types#VerifiableCredential | VerifiableCredential} so it is easier to use programmatically.
  *
  * @param input - the raw credential to be transformed
  * @beta This API may change without a BREAKING CHANGE notice.
@@ -52,8 +52,8 @@ export function decodeCredentialToObject(input: W3CVerifiableCredential): Verifi
 }
 
 /**
- * Parses a {@link @veramo/core#W3CVerifiablePresentation | W3CVerifiablePresentation} and converts it to a
- * {@link @veramo/core#VerifiablePresentation | VerifiablePresentation} so it is easier to use programmatically.
+ * Parses a {@link @veramo/core-types#W3CVerifiablePresentation | W3CVerifiablePresentation} and converts it to a
+ * {@link @veramo/core-types#VerifiablePresentation | VerifiablePresentation} so it is easier to use programmatically.
  *
  * @param input - the raw presentation to be transformed.
  *

--- a/packages/utils/src/did-utils.ts
+++ b/packages/utils/src/did-utils.ts
@@ -18,7 +18,7 @@ import { hexToBytes, bytesToHex, base64ToBytes, base58ToBytes } from './encoding
 const debug = Debug('veramo:utils')
 
 /**
- * Converts any Ed25519 keys of an {@link @veramo/core#IIdentifier | IIdentifier} to X25519 to be usable for encryption.
+ * Converts any Ed25519 keys of an {@link @veramo/core-types#IIdentifier | IIdentifier} to X25519 to be usable for encryption.
  *
  * @param identifier - the identifier with keys
  *
@@ -47,7 +47,7 @@ export function convertIdentifierEncryptionKeys(identifier: IIdentifier): IKey[]
 }
 
 /**
- * Converts any Secp256k1 public keys of an {@link @veramo/core#IIdentifier | IIdentifier} to their compressed form.
+ * Converts any Secp256k1 public keys of an {@link @veramo/core-types#IIdentifier | IIdentifier} to their compressed form.
  *
  * @param identifier - the identifier with keys
  *
@@ -188,14 +188,14 @@ export function getChainIdForDidEthr(verificationMethod: _NormalizedVerification
 }
 
 /**
- * Maps the keys of a locally managed {@link @veramo/core#IIdentifier | IIdentifier} to the corresponding
+ * Maps the keys of a locally managed {@link @veramo/core-types#IIdentifier | IIdentifier} to the corresponding
  * {@link did-resolver#VerificationMethod | VerificationMethod} entries from the DID document.
  *
  * @param identifier - the identifier to be mapped
  * @param section - the section of the DID document to be mapped (see
  *   {@link https://www.w3.org/TR/did-core/#verification-relationships | verification relationships}), but can also be
  *   `verificationMethod` to map all the keys.
- * @param context - the veramo agent context, which must contain a {@link @veramo/core#IResolver | IResolver}
+ * @param context - the veramo agent context, which must contain a {@link @veramo/core-types#IResolver | IResolver}
  *   implementation that can resolve the DID document of the identifier.
  *
  * @returns an array of mapped keys. The corresponding verification method is added to the `meta.verificationMethod`
@@ -246,7 +246,7 @@ export async function mapIdentifierKeysToDoc(
  * Resolve a DID document or throw an error if the resolution fails.
  *
  * @param didUrl - the DID to be resolved
- * @param context - the veramo agent context, which must contain a {@link @veramo/core#IResolver | IResolver}
+ * @param context - the veramo agent context, which must contain a {@link @veramo/core-types#IResolver | IResolver}
  *   implementation that can resolve the DID document of the `didUrl`.
  *
  * @returns a {@link did-resolver#DIDDocument | DIDDocument} if resolution is successful
@@ -310,7 +310,14 @@ export async function dereferenceDidKeys(
     .filter(isDefined)
     .map((key) => {
       const hexKey = extractPublicKeyHex(key, convert)
-      const { publicKeyHex, publicKeyBase58, publicKeyMultibase, publicKeyBase64, publicKeyJwk, ...keyProps } = key
+      const {
+        publicKeyHex,
+        publicKeyBase58,
+        publicKeyMultibase,
+        publicKeyBase64,
+        publicKeyJwk,
+        ...keyProps
+      } = key
       const newKey = { ...keyProps, publicKeyHex: hexKey }
 
       // With a JWK `key`, `newKey` does not have information about crv (Ed25519 vs X25519)
@@ -337,9 +344,15 @@ export async function dereferenceDidKeys(
 export function extractPublicKeyHex(pk: _ExtendedVerificationMethod, convert: boolean = false): string {
   let keyBytes = extractPublicKeyBytes(pk)
   if (convert) {
-    if (['Ed25519', 'Ed25519VerificationKey2018', 'Ed25519VerificationKey2020'].includes(pk.type) || (pk.type === 'JsonWebKey2020' && pk.publicKeyJwk?.crv === 'Ed25519')) {
+    if (
+      ['Ed25519', 'Ed25519VerificationKey2018', 'Ed25519VerificationKey2020'].includes(pk.type) ||
+      (pk.type === 'JsonWebKey2020' && pk.publicKeyJwk?.crv === 'Ed25519')
+    ) {
       keyBytes = convertPublicKeyToX25519(keyBytes)
-    } else if (!['X25519', 'X25519KeyAgreementKey2019', 'X25519KeyAgreementKey2020'].includes(pk.type) && !(pk.type === 'JsonWebKey2020' && pk.publicKeyJwk?.crv === 'X25519')) {
+    } else if (
+      !['X25519', 'X25519KeyAgreementKey2019', 'X25519KeyAgreementKey2020'].includes(pk.type) &&
+      !(pk.type === 'JsonWebKey2020' && pk.publicKeyJwk?.crv === 'X25519')
+    ) {
       return ''
     }
   }

--- a/packages/utils/src/types/utility-types.ts
+++ b/packages/utils/src/types/utility-types.ts
@@ -8,7 +8,7 @@ import { VerificationMethod } from 'did-resolver'
 export type _ExtendedVerificationMethod = VerificationMethod & { publicKeyBase64?: string }
 
 /**
- * Represents an {@link @veramo/core#IKey} that has been augmented with its corresponding
+ * Represents an {@link @veramo/core-types#IKey} that has been augmented with its corresponding
  * entry from a DID document.
  * `key.meta.verificationMethod` will contain the {@link did-resolver#VerificationMethod}
  * object from the {@link did-resolver#DIDDocument}

--- a/scripts/prepare-integration-tests.ts
+++ b/scripts/prepare-integration-tests.ts
@@ -104,7 +104,7 @@ for (const packageName of Object.keys(agentPlugins)) {
       const methodSignature = member as ApiMethodSignature
       method.description = methodSignature.tsdocComment?.summarySection
         ?.getChildNodes()[0]
-        //@ts-ignore
+        // @ts-ignore
         ?.getChildNodes()[0]?.text
 
       method.example =


### PR DESCRIPTION
## What is being changed

I was seeing some test failures locally caused by a reference error to `fetch`.

* Imports in tests now use the ESM format (.js specifier)
* added fetch polyfill in some of the did-comm tests
* fixed documentation output to include proper linkt so the core-types package

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because no functionality is being changed.
