### PR TITLE
refactor(cli): use individual `Command` instances instead of global `program`

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,4 +1,9 @@
-{
+import path from "path";
+import { createRequire } from 'module';
+
+const chalkPath = (await import.meta.resolve("chalk"))
+
+export default {
   "moduleFileExtensions": [
     "ts",
     "tsx",
@@ -23,7 +28,9 @@
   ],
   "coverageProvider": "v8",
   "coverageDirectory": "./coverage",
-  "extensionsToTreatAsEsm": [".ts"],
+  "extensionsToTreatAsEsm": [
+    ".ts"
+  ],
   "testMatch": [
     "**/__tests__/**/*.test.*"
   ],
@@ -33,7 +40,18 @@
     "./setupJest.js"
   ],
   "moduleNameMapper": {
-    "^(\\.{1,2}/.*)\\.js$": "$1"
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+
+    // // https://github.com/facebook/jest/issues/12270#issuecomment-1111533936
+    // chalk: path.join(chalkPath.split("chalk/")[0], "chalk").substring(5),
+    // "#ansi-styles": path.join(
+    //   chalkPath.split("chalk/")[0],
+    //   "chalk/source/vendor/ansi-styles/index.js",
+    // ).substring(5),
+    // "#supports-color": path.join(
+    //   chalkPath.split("chalk/")[0],
+    //   "chalk/source/vendor/supports-color/index.js",
+    // ).substring(5),
   },
   "transform": {
     "^.+\\.m?tsx?$": [

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,7 +1,7 @@
-import path from "path";
-import { createRequire } from 'module';
-
-const chalkPath = (await import.meta.resolve("chalk"))
+// import path from "path";
+// import { createRequire } from 'module';
+//
+// const chalkPath = (await import.meta.resolve("chalk"))
 
 export default {
   "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@types/uuid": "^9.0.0",
     "blakejs": "^1.2.1",
     "caip": "^1.1.0",
-    "chalk": "^5.2.0",
     "credential-status": "^2.0.5",
     "cross-env": "7.0.3",
     "did-jwt": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:integration-pretty": "prettier --write __tests__/shared/documentationExamples.ts",
     "test:integration": "pnpm test:integration-build && pnpm test:ci",
     "test:ci": "pnpm test -- --coverage=true",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --experimental-import-meta-resolve\" jest",
     "test:watch": "pnpm test --watch --verbose",
     "test:browser": "cd packages/test-react-app && pnpm test:browser",
     "veramo": "cross-env ./packages/cli/bin/veramo.js",
@@ -45,6 +45,7 @@
     "@types/uuid": "^9.0.0",
     "blakejs": "^1.2.1",
     "caip": "^1.1.0",
+    "chalk": "^5.2.0",
     "credential-status": "^2.0.5",
     "cross-env": "7.0.3",
     "did-jwt": "^6.11.0",
@@ -88,5 +89,7 @@
   "engines": {
     "node": ">= 18.0.0"
   },
-  "workspaces": ["packages/*"]
+  "workspaces": [
+    "packages/*"
+  ]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@ceramicnetwork/3id-did-resolver": "^2.11.0",
     "@ceramicnetwork/http-client": "^2.15.0",
+    "@commander-js/extra-typings": "^10.0.2",
     "@microsoft/api-extractor": "^7.33.8",
     "@microsoft/api-extractor-model": "^7.25.3",
     "@transmute/credentials-context": "^0.7.0-unstable.79",
@@ -45,7 +46,7 @@
     "@veramo/url-handler": "^5.0.0",
     "@veramo/utils": "^5.0.0",
     "blessed": "^0.1.81",
-    "commander": "^9.0.0",
+    "commander": "^10.0.0",
     "console-table-printer": "^2.10.0",
     "cors": "^2.8.5",
     "cross-fetch": "^3.1.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,8 +2,26 @@
   "name": "@veramo/cli",
   "description": "Veramo command line application.",
   "version": "5.0.0",
+  "exports": {
+    ".": {
+      "types": "./build/cli.d.ts",
+      "import": "./build/cli.js"
+    },
+    "./build/setup": {
+      "types": "./build/setup.d.ts",
+      "import": "./build/setup.js"
+    },
+    "./build/lib/objectCreator": {
+      "types": "./build/lib/objectCreator.d.ts",
+      "import": "./build/lib/objectCreator.js"
+    },
+    "./build/lib/agentCreator": {
+      "types":"./build/lib/agentCreator.d.ts",
+      "import":"./build/lib/agentCreator.js"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "build/cli.js",
-  "exports": "./build/cli.js",
   "types": "build/cli.d.ts",
   "bin": {
     "veramo": "bin/veramo.js"
@@ -17,7 +35,6 @@
   "dependencies": {
     "@ceramicnetwork/3id-did-resolver": "^2.11.0",
     "@ceramicnetwork/http-client": "^2.15.0",
-    "@commander-js/extra-typings": "^10.0.2",
     "@microsoft/api-extractor": "^7.33.8",
     "@microsoft/api-extractor-model": "^7.25.3",
     "@transmute/credentials-context": "^0.7.0-unstable.79",

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,0 +1,42 @@
+import { veramo } from '../createCommand.js'
+import { jest } from '@jest/globals'
+import { createObjects } from '../lib/objectCreator'
+import { getConfig } from '../setup'
+
+jest.useFakeTimers()
+
+describe('cli version', () => {
+  const writeMock = jest.fn()
+
+  beforeAll(() => {
+    // veramo
+    //   .exitOverride()
+    //   .configureOutput({ writeOut: writeMock })
+  })
+
+  afterAll(() => {
+    jest.clearAllMocks()
+  })
+
+  it.skip('should list version number', async () => {
+    expect(() => {
+      // veramo.parse(['--version'], { from: 'user' })
+    }).toThrow()
+    expect(writeMock).toHaveBeenCalledWith(expect.stringMatching(/^\d\.\d\.\d\n?$/))
+  })
+
+  it.skip('should load the dbConnection', async () => {
+    // this seems to fail because of some timing issues or an incompatibility with the `chalk` transitive dependency
+    // all other tests that need to load the dbConnection fail similarly
+    const res = await createObjects(getConfig('./packages/cli/default/default.yml'), {
+      my: '/dbConnection',
+    })
+  })
+
+  it.skip('should check the default config', async () => {
+    expect(() => {
+      // veramo.parse(['config', 'check', '-f', './packages/cli/default/default.yml'], { from: 'user' })
+    }).toThrow(/hello/)
+    expect(writeMock).toHaveBeenCalledWith(expect.stringMatching(/^\d\.\d\.\d\n?$/))
+  })
+})

--- a/packages/cli/src/__tests__/default.test.ts
+++ b/packages/cli/src/__tests__/default.test.ts
@@ -1,6 +1,0 @@
-describe('veramo-cli', () => {
-  const a = 100
-  it('should run a dummy test', () => {
-    expect(a).toEqual(100)
-  })
-})

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,25 +1,11 @@
-import { program } from 'commander'
 import inquirer from 'inquirer'
 import inquirerAutoPrompt from 'inquirer-autocomplete-prompt'
 
 inquirer.registerPrompt('autocomplete', inquirerAutoPrompt)
-
-import './did.js'
-import './credential.js'
-import './presentation.js'
-import './explore/index.js'
-import './sdr.js'
-import './message.js'
-import './discover.js'
-import './version.js'
-import './execute.js'
-import './server.js'
-import './setup.js'
-import './config.js'
-import './dev.js'
+import { veramo } from './createCommand.js'
 
 if (!process.argv.slice(2).length) {
-  program.outputHelp()
+  veramo.outputHelp()
 } else {
-  program.parse(process.argv)
+  veramo.parse(process.argv)
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,15 +1,14 @@
-import { program } from 'commander'
+import { Command } from 'commander'
 import { SecretBox } from '@veramo/kms-local'
 import { getAgent } from './setup.js'
-import fs from "fs"
+import fs from 'fs'
 import { dirname } from 'path'
 
-import * as url from 'url';
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+import * as url from 'url'
 
-program.option('--config <path>', 'Configuration file', './agent.yml')
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
-const config = program.command('config').description('Agent configuration')
+const config = new Command('config').description('Agent configuration')
 
 config
   .command('create', { isDefault: true })
@@ -43,6 +42,8 @@ config
   .command('create-secret-key')
   .alias('gen-key')
   .alias('key-gen')
+  .alias('keygen')
+  .alias('genkey')
   .description('generate secret key')
   .option('-q, --quiet', 'Only print the raw key, no instructions', false)
   .action(async (options) => {
@@ -89,3 +90,5 @@ config
       }
     }
   })
+
+export { config }

--- a/packages/cli/src/createCommand.ts
+++ b/packages/cli/src/createCommand.ts
@@ -1,0 +1,34 @@
+import { Command } from 'commander'
+import module from 'module'
+
+import { config } from './config.js'
+import { credential } from './credential.js'
+import { dev } from './dev.js'
+import { did } from './did.js'
+import { discover } from './discover.js'
+import { execute } from './execute.js'
+import { message } from './message.js'
+import { presentation } from './presentation.js'
+import { explore } from './explore/index.js'
+import { sdr } from './sdr.js'
+import { server } from './server.js'
+
+const requireCjs = module.createRequire(import.meta.url)
+const { version } = requireCjs('../package.json')
+
+const veramo = new Command('veramo')
+  .version(version, '-v, --version')
+  .option('--config <string>', 'Configuration file', './agent.yml')
+  .addCommand(config)
+  .addCommand(credential)
+  .addCommand(dev)
+  .addCommand(did)
+  .addCommand(discover)
+  .addCommand(execute)
+  .addCommand(explore)
+  .addCommand(message)
+  .addCommand(presentation)
+  .addCommand(sdr)
+  .addCommand(server)
+
+export { veramo }

--- a/packages/cli/src/credential.ts
+++ b/packages/cli/src/credential.ts
@@ -1,5 +1,5 @@
 import { getAgent } from './setup.js'
-import { program } from 'commander'
+import { Command } from 'commander'
 import inquirer from 'inquirer'
 import qrcode from 'qrcode-terminal'
 import * as fs from 'fs'
@@ -9,7 +9,7 @@ import { CredentialPayload } from '@veramo/core-types'
 
 import fuzzy from 'fuzzy'
 
-const credential = program.command('credential').description('W3C Verifiable Credential')
+const credential = new Command('credential').description('W3C Verifiable Credential')
 
 credential
   .command('create', { isDefault: true })
@@ -17,8 +17,8 @@ credential
   .option('-s, --send', 'Send')
   .option('-j, --json', 'Output in JSON')
   .option('-q, --qrcode', 'Show qrcode')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: { send: boolean; qrcode: boolean; json: boolean }, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
     const identifiers = await agent.didManagerFind()
 
     const knownDids = await agent.dataStoreORMGetIdentifiers()
@@ -127,7 +127,7 @@ credential
       proofFormat: answers.proofFormat,
     })
 
-    if (cmd.send) {
+    if (opts.send) {
       let body
       let type
       if (answers.proofFormat == 'jwt') {
@@ -153,10 +153,10 @@ credential
       }
     }
 
-    if (cmd.qrcode) {
+    if (opts.qrcode) {
       qrcode.generate(verifiableCredential.proof.jwt)
     } else {
-      if (cmd.json) {
+      if (opts.json) {
         console.log(JSON.stringify(verifiableCredential, null, 2))
       } else {
         console.dir(verifiableCredential, { depth: 10 })
@@ -169,8 +169,8 @@ credential
   .description('Verify a W3C Verifiable Credential provided as raw string, file or stdin')
   .option('-f, --filename <string>', 'Optional. Read the credential from a file instead of stdin')
   .option('-r, --raw <string>', 'Optional. Specify the credential as a parameter instead of file or stdin')
-  .action(async (options) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (options: { raw: string; filename: string }, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
     let raw: string = ''
     if (options.raw) {
       raw = options.raw
@@ -205,8 +205,8 @@ credential
 credential
   .command('output')
   .description('Print W3C Verifiable Credential to stdout')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     const credentials = await agent.dataStoreORMGetVerifiableCredentials()
 
@@ -236,3 +236,5 @@ credential
       console.log('No credentials found.')
     }
   })
+
+export { credential }

--- a/packages/cli/src/dev.ts
+++ b/packages/cli/src/dev.ts
@@ -5,16 +5,15 @@ import {
   ApiParameterListMixin,
   ApiReturnTypeMixin,
 } from '@microsoft/api-extractor-model'
-import { program } from 'commander'
+import { Command } from 'commander'
 import { writeFileSync } from 'fs'
 import { OpenAPIV3 } from 'openapi-types'
 import { resolve } from 'path'
 import * as TJS from 'ts-json-schema-generator'
-import fs from 'fs'
 
-import module from "module"
-const requireCjs = module.createRequire(import.meta.url);
+import module from 'module'
 
+const requireCjs = module.createRequire(import.meta.url)
 
 interface Method {
   packageName: string
@@ -24,6 +23,7 @@ interface Method {
   parameters?: string
   response: string
 }
+
 const genericTypes = ['boolean', 'string', 'number', 'any', 'Array<string>']
 
 function createSchema(generator: TJS.SchemaGenerator, symbol: string) {
@@ -84,7 +84,7 @@ function getReference(response: string): OpenAPIV3.ReferenceObject | OpenAPIV3.S
   }
 }
 
-const dev = program.command('dev').description('Plugin developer tools')
+const dev = new Command('dev').description('Plugin developer tools')
 
 dev
   .command('generate-plugin-schema')
@@ -129,7 +129,7 @@ dev
         path: resolve(entryFile),
         encodeRefs: false,
         additionalProperties: true,
-        skipTypeCheck: true
+        skipTypeCheck: true,
       })
 
       const apiModel: ApiModel = new ApiModel()
@@ -208,3 +208,5 @@ dev
       process.exitCode = 1
     }
   })
+
+export { dev }

--- a/packages/cli/src/did.ts
+++ b/packages/cli/src/did.ts
@@ -1,19 +1,19 @@
-import { IDIDManagerCreateArgs } from '@veramo/core-types'
+import { IDIDManagerCreateArgs, IIdentifier } from '@veramo/core-types'
 import { getAgent } from './setup.js'
 import inquirer from 'inquirer'
-import { program } from 'commander'
+import { Command } from 'commander'
 import { printTable } from 'console-table-printer'
 
-const did = program.command('did').description('Decentralized identifiers')
+const did = new Command('did').description('Decentralized identifiers')
 
 did
   .command('providers')
   .description('list available identifier providers')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     const providers = await agent.didManagerGetProviders()
-    const list = providers.map((provider) => ({ provider }))
+    const list = providers.map((provider: string) => ({ provider }))
 
     if (list.length > 0) {
       printTable(list)
@@ -25,13 +25,17 @@ did
 did
   .command('list', { isDefault: true })
   .description('list managed identifiers')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     const list = await agent.didManagerFind()
 
     if (list.length > 0) {
-      const dids = list.map((item) => ({ provider: item.provider, alias: item.alias, did: item.did }))
+      const dids = list.map((item: IIdentifier) => ({
+        provider: item.provider,
+        alias: item.alias,
+        did: item.did,
+      }))
       printTable(dids)
     } else {
       console.log('No dids')
@@ -41,8 +45,9 @@ did
 did
   .command('create')
   .description('create an identifier')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    // FIXME: CLI add arguments for provider, kms, alias
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     try {
       const providers = await agent.didManagerGetProviders()
@@ -79,8 +84,8 @@ did
 did
   .command('delete')
   .description('delete an identifier')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     try {
       const identifiers = await agent.didManagerFind()
@@ -106,8 +111,8 @@ did
 did
   .command('add-service')
   .description('add a service endpoint to did document')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     try {
       const identifiers = await agent.didManagerFind()
@@ -154,8 +159,8 @@ did
 did
   .command('remove-service')
   .description('remove a service endpoint from did document')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     try {
       const identifiers = await agent.didManagerFind()
@@ -187,8 +192,8 @@ did
 did
   .command('add-key')
   .description('create and add a public key to did document')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     try {
       const identifiers = await agent.didManagerFind()
@@ -233,8 +238,8 @@ did
 did
   .command('remove-key')
   .description('remove a key from did document')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     try {
       const identifiers = await agent.didManagerFind()
@@ -266,8 +271,8 @@ did
 did
   .command('export')
   .description('export an identifier')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     try {
       const identifiers = await agent.didManagerFind()
@@ -294,8 +299,8 @@ did
 did
   .command('import')
   .description('import an identifier')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     try {
       const answers = await inquirer.prompt([
@@ -316,8 +321,8 @@ did
 did
   .command('resolve <didUrl>')
   .description('Resolve DID Document')
-  .action(async (didUrl) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (didUrl: string, opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
     try {
       const ddo = await agent.resolveDid({ didUrl })
       console.log(JSON.stringify(ddo, null, 2))
@@ -325,3 +330,5 @@ did
       console.error(e.message)
     }
   })
+
+export { did }

--- a/packages/cli/src/discover.ts
+++ b/packages/cli/src/discover.ts
@@ -1,18 +1,18 @@
 import { getAgent } from './setup.js'
-import { program } from 'commander'
+import { Command } from 'commander'
 import { printTable } from 'console-table-printer'
 
-const discover = program.command('discover').description('Discovery')
+const discover = new Command('discover').description('Discovery')
 
 discover
   .command('did')
   .description('did discovery')
   .option('-q, --query <string>', 'Query string')
 
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: { query: string }, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
-    const response = await agent.discoverDid({ query: cmd.query })
+    const response = await agent.discoverDid({ query: opts.query })
     const list: any = []
 
     response.results.forEach((r: any) => {
@@ -30,3 +30,5 @@ discover
       console.log('No dids discovered')
     }
   })
+
+export { discover }

--- a/packages/cli/src/execute.ts
+++ b/packages/cli/src/execute.ts
@@ -1,18 +1,17 @@
-import { program } from 'commander'
+import { Command } from 'commander'
 import inquirer from 'inquirer'
 import { getAgent } from './setup.js'
 import fs from 'fs'
 import OasResolver from 'oas-resolver'
 import fuzzy from 'fuzzy'
 
-program
-  .command('execute')
-  .description('Executes agent method')
+const execute = new Command('execute')
+  .description('Execute agent method')
   .option('-m, --method <string>', 'Method name')
   .option('-a, --argsJSON <string>', 'Method arguments')
   .option('-f, --argsFile <string>', 'Path to a file containing method arguments in a JSON string')
-  .action(async (options) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (options: { method: string; argsJSON?: string; argsFile?: string }, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
 
     try {
       let method = options.method
@@ -92,9 +91,13 @@ program
       } else {
         if (argsFile) {
           console.log({ argsFile })
-          argsString = fs.readFileSync(argsFile)
+          argsString = fs.readFileSync(argsFile).toString('utf-8')
         }
-        argsObj = JSON.parse(argsString)
+        try {
+          argsObj = JSON.parse(argsString!)
+        } catch (e: any) {
+          console.error('could not parse arguments JSON')
+        }
       }
 
       console.log('\nMethod: ', method)
@@ -111,3 +114,5 @@ program
       console.error(e.message)
     }
   })
+
+export { execute }

--- a/packages/cli/src/explore/index.ts
+++ b/packages/cli/src/explore/index.ts
@@ -1,12 +1,12 @@
 import { getAgent } from '../setup.js'
 import { Command } from 'commander'
-const program = new Command();
 import { renderMainScreen } from './main.js'
 
-program
-  .command('explore')
+const explore = new Command('explore')
   .description('launch Verifiable Data explorer')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
     await renderMainScreen(agent)
   })
+
+export { explore }

--- a/packages/cli/src/lib/agentCreator.ts
+++ b/packages/cli/src/lib/agentCreator.ts
@@ -1,6 +1,15 @@
 import { TAgent, IPluginMethodMap } from '@veramo/core-types'
 import { createObjects } from './objectCreator.js'
 
+/**
+ * Creates a Veramo agent from a config object containing an `/agent` pointer.
+ * @param config - The configuration object
+ *
+ * @see {@link https://veramo.io/docs/veramo_agent/configuration_internals | Configuration Internals} for details on
+ *   the configuration options.
+ *
+ * @beta
+ */
 export async function createAgentFromConfig<T extends IPluginMethodMap>(config: object): Promise<TAgent<T>> {
   // @ts-ignore
   const { agent } = await createObjects(config, { agent: '/agent' })

--- a/packages/cli/src/lib/objectCreator.ts
+++ b/packages/cli/src/lib/objectCreator.ts
@@ -2,6 +2,50 @@ import { set, get } from 'jsonpointer'
 import parse from 'url-parse'
 import { resolve } from 'path'
 
+/**
+ * Creates objects from a configuration object and a set of pointers.
+ *
+ * Example:
+ * ```ts
+ * const { url } = createObjects({ "rpcUrl": "http://localhost:8545", }, { url: '/rpcUrl' })
+ * ```
+ *
+ * The config can contain references (`$ref`) to other objects within using JSON pointers.
+ * Example:
+ * ```json5
+ * {
+ *   rpcUrl: "http://localhost:8545",
+ *   endpoint: {
+ *     url: {
+ *       "$ref": "/rpcUrl"
+ *     }
+ *   }
+ * }
+ *
+ * The config object can also contain references to NPM modules using the `$require` property.
+ * Example:
+ * ```json5
+ * {
+ *   agent: {
+ *     "$require": "@veramo/core#Agent",
+ *     "$args": {
+ *       plugins: [
+ *         { "$require": "@veramo/did-comm#DIDComm" },
+ *       ]
+ *     }
+ *   }
+ * }
+ * ```
+ * Environment variables can also be specified using the `$env` property.
+ *
+ * @see Please see {@link https://veramo.io/docs/veramo_agent/configuration_internals | Configuration Internals} for
+ *   more information.
+ *
+ * @param config - The configuration object
+ * @param pointers - A map of JSON pointers to objects within that config that you wish to create
+ *
+ * @beta
+ */
 export async function createObjects(config: object, pointers: Record<string, string>): Promise<any> {
   const objects = {}
 
@@ -51,9 +95,9 @@ export async function createObjects(config: object, pointers: Record<string, str
       module = resolve(module)
     }
 
-    const resolvedArgs = args !== undefined ? (await resolveRefs(args)) : []
+    const resolvedArgs = args !== undefined ? await resolveRefs(args) : []
     try {
-      let required = member ? (await import(module))[member] : (await import(module))
+      let required = member ? (await import(module))[member] : await import(module)
       if (type === 'class') {
         object = new required(...resolvedArgs)
       } else if (type === 'function') {

--- a/packages/cli/src/message.ts
+++ b/packages/cli/src/message.ts
@@ -1,8 +1,8 @@
 import { getAgent } from './setup.js'
-import { program } from 'commander'
+import { Command } from 'commander'
 import fs from 'fs'
 
-const message = program.command('message').description('Messages')
+const message = new Command('message').description('Messages')
 
 message
   .command('handle', { isDefault: true })
@@ -11,8 +11,8 @@ message
   .option('-f, --file <string>', 'Path to a file containing raw message')
   .option('--save <boolean>', 'Save message', true)
 
-  .action(async (options) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (options: { file: string; raw: string; save: boolean }, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
     try {
       let raw
 
@@ -35,3 +35,5 @@ message
       console.error(e.message)
     }
   })
+
+export { message }

--- a/packages/cli/src/sdr.ts
+++ b/packages/cli/src/sdr.ts
@@ -1,6 +1,6 @@
 import { ICredentialRequestInput } from '@veramo/selective-disclosure'
 import { getAgent } from './setup.js'
-import { program } from 'commander'
+import { Command } from 'commander'
 import inquirer from 'inquirer'
 import qrcode from 'qrcode-terminal'
 import { shortDate, shortDid } from './explore/utils.js'
@@ -9,13 +9,14 @@ import { asArray, extractIssuer } from '@veramo/utils'
 
 import fuzzy from 'fuzzy'
 
-const sdr = program.command('sdr').description('Selective Disclosure Request')
+const sdr = new Command('sdr').description('Selective Disclosure Request')
 
 sdr
   .command('create', { isDefault: true })
   .description('create Selective Disclosure Request')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .option('-q, --qrcode', 'Show qrcode')
+  .action(async (opts: { qrcode: boolean }, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
     const identifiers = await agent.didManagerFind()
 
     const knownDids = await agent.dataStoreORMGetIdentifiers()
@@ -253,7 +254,7 @@ sdr
       console.log('Subject not specified')
     }
 
-    if (cmd.qrcode) {
+    if (opts.qrcode) {
       qrcode.generate(jwt)
     } else {
       console.dir(data, { depth: 10 })
@@ -264,8 +265,8 @@ sdr
 sdr
   .command('respond')
   .description('respond to Selective Disclosure Request')
-  .action(async (cmd) => {
-    const agent = await getAgent(program.opts().config)
+  .action(async (opts: {}, cmd: Command) => {
+    const agent = await getAgent(cmd.optsWithGlobals().config)
     const sdrMessages = await agent.dataStoreORMGetMessages({
       where: [{ column: 'type', value: ['sdr'] }],
       order: [{ column: 'createdAt', direction: 'DESC' }],
@@ -354,3 +355,5 @@ sdr
 
     console.dir(verifiablePresentation, { depth: 10 })
   })
+
+export { sdr }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,30 +1,34 @@
 import express from 'express'
-import { program } from 'commander'
+import { Command } from 'commander'
 import { getConfig } from './setup.js'
 import { createObjects } from './lib/objectCreator.js'
 
-program
-  .command('server')
+const server = new Command('server')
   .description('Launch OpenAPI server')
   .option('-p, --port <number>', 'Optionally set port to override config')
-  .action(async (cmd) => {
+  .action(async (opts: { port: number }, cmd: Command) => {
     const app = express()
 
     let server: any
 
     try {
-      const config = await createObjects(getConfig(program.opts().config), { server: '/server' })
+      const config = await createObjects(getConfig(cmd.optsWithGlobals().config), { server: '/server' })
       server = config.server
     } catch (e: any) {
-      console.log(e.message)
+      console.error(e.message)
       process.exit(1)
     }
 
     for (let router of server.use) {
       app.use(...router)
+      if (typeof router[0] === 'string') {
+        console.log(`Listening to route: ${server.baseUrl}${router[0]}`)
+      }
     }
 
-    app.listen(cmd.port || server.port, async () => {
+    app.listen(opts.port || server.port, async () => {
       console.log(`🚀 Cloud Agent ready at ${server.baseUrl}`)
     })
   })
+
+export { server }

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,9 +1,0 @@
-import { program } from 'commander'
-import module from "module";
-const requireCjs = module.createRequire(import.meta.url);
-const data = requireCjs("../package.json");
-const { version } = data
-
-program.version(version, '-v, --version')
-
-export {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,6 @@ importers:
       '@types/uuid': ^9.0.0
       blakejs: ^1.2.1
       caip: ^1.1.0
-      chalk: ^5.2.0
       credential-status: ^2.0.5
       cross-env: 7.0.3
       did-jwt: ^6.11.0
@@ -74,7 +73,6 @@ importers:
       '@types/uuid': 9.0.0
       blakejs: 1.2.1
       caip: 1.1.0
-      chalk: 5.2.0
       credential-status: 2.0.5
       cross-env: 7.0.3
       did-jwt: 6.11.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,6 @@ importers:
     specifiers:
       '@ceramicnetwork/3id-did-resolver': ^2.11.0
       '@ceramicnetwork/http-client': ^2.15.0
-      '@commander-js/extra-typings': ^10.0.2
       '@microsoft/api-extractor': ^7.33.8
       '@microsoft/api-extractor-model': ^7.25.3
       '@transmute/credentials-context': ^0.7.0-unstable.79
@@ -180,7 +179,6 @@ importers:
     dependencies:
       '@ceramicnetwork/3id-did-resolver': 2.11.0
       '@ceramicnetwork/http-client': 2.15.0
-      '@commander-js/extra-typings': 10.0.2_commander@10.0.0
       '@microsoft/api-extractor': 7.33.8
       '@microsoft/api-extractor-model': 7.25.3
       '@transmute/credentials-context': 0.7.0-unstable.79
@@ -2661,14 +2659,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /@commander-js/extra-typings/10.0.2_commander@10.0.0:
-    resolution: {integrity: sha512-PSGG74fpbc2/WRInbKJbwKiUwdN9YqZSgHxDGMqInUe4G6DTLp90ww12uHMC1U/219qPWI0fLSSjwVDUTdnqIQ==}
-    peerDependencies:
-      commander: 10.0.x
-    dependencies:
-      commander: 10.0.0
-    dev: false
 
   /@craco/craco/7.0.0_zesqcerkajynswfwy7hd5fzliu:
     resolution: {integrity: sha512-OyjL9zpURB6Ha1HO62Hlt27Xd7UYJ8DRiBNuE4DBB8Ue0iQ9q/xsv3ze7ROm6gCZqV6I2Gxjnq0EHCCye+4xDQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ importers:
       '@types/uuid': ^9.0.0
       blakejs: ^1.2.1
       caip: ^1.1.0
+      chalk: ^5.2.0
       credential-status: ^2.0.5
       cross-env: 7.0.3
       did-jwt: ^6.11.0
@@ -73,6 +74,7 @@ importers:
       '@types/uuid': 9.0.0
       blakejs: 1.2.1
       caip: 1.1.0
+      chalk: 5.2.0
       credential-status: 2.0.5
       cross-env: 7.0.3
       did-jwt: 6.11.0
@@ -106,6 +108,7 @@ importers:
     specifiers:
       '@ceramicnetwork/3id-did-resolver': ^2.11.0
       '@ceramicnetwork/http-client': ^2.15.0
+      '@commander-js/extra-typings': ^10.0.2
       '@microsoft/api-extractor': ^7.33.8
       '@microsoft/api-extractor-model': ^7.25.3
       '@transmute/credentials-context': ^0.7.0-unstable.79
@@ -141,7 +144,7 @@ importers:
       '@veramo/url-handler': ^5.0.0
       '@veramo/utils': ^5.0.0
       blessed: ^0.1.81
-      commander: ^9.0.0
+      commander: ^10.0.0
       console-table-printer: ^2.10.0
       cors: ^2.8.5
       cross-fetch: ^3.1.4
@@ -177,6 +180,7 @@ importers:
     dependencies:
       '@ceramicnetwork/3id-did-resolver': 2.11.0
       '@ceramicnetwork/http-client': 2.15.0
+      '@commander-js/extra-typings': 10.0.2_commander@10.0.0
       '@microsoft/api-extractor': 7.33.8
       '@microsoft/api-extractor-model': 7.25.3
       '@transmute/credentials-context': 0.7.0-unstable.79
@@ -205,7 +209,7 @@ importers:
       '@veramo/url-handler': link:../url-handler
       '@veramo/utils': link:../utils
       blessed: 0.1.81
-      commander: 9.5.0
+      commander: 10.0.0
       console-table-printer: 2.11.1
       cors: 2.8.5
       cross-fetch: 3.1.5
@@ -232,7 +236,7 @@ importers:
       sqlite3: 5.1.4
       swagger-ui-express: 4.6.0_express@4.18.2
       ts-json-schema-generator: 1.2.0
-      typeorm: 0.3.11_pg@8.8.0+sqlite3@5.1.4
+      typeorm: 0.3.12_pg@8.8.0+sqlite3@5.1.4
       url-parse: 1.5.10
       web-did-resolver: 2.0.21
       ws: 8.12.0
@@ -2658,6 +2662,14 @@ packages:
     dev: true
     optional: true
 
+  /@commander-js/extra-typings/10.0.2_commander@10.0.0:
+    resolution: {integrity: sha512-PSGG74fpbc2/WRInbKJbwKiUwdN9YqZSgHxDGMqInUe4G6DTLp90ww12uHMC1U/219qPWI0fLSSjwVDUTdnqIQ==}
+    peerDependencies:
+      commander: 10.0.x
+    dependencies:
+      commander: 10.0.0
+    dev: false
+
   /@craco/craco/7.0.0_zesqcerkajynswfwy7hd5fzliu:
     resolution: {integrity: sha512-OyjL9zpURB6Ha1HO62Hlt27Xd7UYJ8DRiBNuE4DBB8Ue0iQ9q/xsv3ze7ROm6gCZqV6I2Gxjnq0EHCCye+4xDQ==}
     engines: {node: '>=6'}
@@ -4885,7 +4897,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       '@npmcli/name-from-folder': 1.0.1
-      glob: 8.0.3
+      glob: 8.1.0
       minimatch: 5.1.2
       read-package-json-fast: 2.0.3
     dev: true
@@ -5127,14 +5139,14 @@ packages:
     dependencies:
       asn1js: 3.0.5
       pvtsutils: 1.3.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@peculiar/json-schema/1.1.12:
     resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@peculiar/webcrypto/1.4.1:
@@ -5144,7 +5156,7 @@ packages:
       '@peculiar/asn1-schema': 2.3.3
       '@peculiar/json-schema': 1.1.12
       pvtsutils: 1.3.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       webcrypto-core: 1.7.5
     dev: false
 
@@ -6759,7 +6771,7 @@ packages:
     engines: {node: '>=14.15.0'}
     dependencies:
       js-yaml: 3.14.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /@zkochan/js-yaml/0.0.6:
@@ -7223,7 +7235,7 @@ packages:
     dependencies:
       pvtsutils: 1.3.2
       pvutils: 1.1.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /ast-types-flow/0.0.7:
@@ -7922,7 +7934,7 @@ packages:
       '@npmcli/move-file': 2.0.1
       chownr: 2.0.0
       fs-minipass: 2.1.0
-      glob: 8.0.3
+      glob: 8.1.0
       infer-owner: 1.0.4
       lru-cache: 7.14.1
       minipass: 3.3.6
@@ -7958,7 +7970,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /camelcase-css/2.0.1:
@@ -8310,6 +8322,11 @@ packages:
     dependencies:
       delayed-stream: 1.0.0
     dev: true
+
+  /commander/10.0.0:
+    resolution: {integrity: sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==}
+    engines: {node: '>=14'}
+    dev: false
 
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -9403,7 +9420,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /dot-prop/5.3.0:
@@ -11013,6 +11030,16 @@ packages:
 
   /glob/8.0.3:
     resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.2
+      once: 1.4.0
+
+  /glob/8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
     dependencies:
       fs.realpath: 1.0.0
@@ -13909,7 +13936,7 @@ packages:
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /lru-cache/5.1.1:
@@ -14315,6 +14342,12 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  /mkdirp/2.1.3:
+    resolution: {integrity: sha512-sjAkg21peAG9HS+Dkx7hlG9Ztx7HLeKnvB3NQRcu/mltCVmvkF0pisbiTSfDVYTT86XEfZrTUosLdZLStquZUw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: false
+
   /modify-values/1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
@@ -14447,7 +14480,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /node-addon-api/2.0.2:
@@ -14681,7 +14714,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      glob: 8.0.3
+      glob: 8.1.0
       ignore-walk: 5.0.1
       npm-bundled: 2.0.1
       npm-normalize-package-bin: 2.0.0
@@ -15294,7 +15327,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /parent-module/1.0.1:
@@ -15383,7 +15416,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /passport-http-bearer/1.0.1:
@@ -16625,7 +16658,7 @@ packages:
   /pvtsutils/1.3.2:
     resolution: {integrity: sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /pvutils/1.1.3:
@@ -16936,7 +16969,7 @@ packages:
     resolution: {integrity: sha512-BSzugrt4kQ/Z0krro8zhTwV1Kd79ue25IhNN/VtHFy1mG/6Tluyi+msc0UpwaoQzxSHa28mntAjIZY6kEgfR9Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
-      glob: 8.0.3
+      glob: 8.1.0
       json-parse-even-better-errors: 2.3.1
       normalize-package-data: 4.0.1
       npm-normalize-package-bin: 2.0.0
@@ -18631,6 +18664,9 @@ packages:
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
 
+  /tslib/2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+
   /tsutils/3.21.0_typescript@4.9.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -18823,87 +18859,6 @@ packages:
       - supports-color
     dev: false
 
-  /typeorm/0.3.11_pg@8.8.0+sqlite3@5.1.4:
-    resolution: {integrity: sha512-pzdOyWbVuz/z8Ww6gqvBW4nylsM0KLdUCDExr2gR20/x1khGSVxQkjNV/3YqliG90jrWzrknYbYscpk8yxFJVg==}
-    engines: {node: '>= 12.9.0'}
-    hasBin: true
-    peerDependencies:
-      '@google-cloud/spanner': ^5.18.0
-      '@sap/hana-client': ^2.12.25
-      better-sqlite3: ^7.1.2 || ^8.0.0
-      hdb-pool: ^0.1.6
-      ioredis: ^5.0.4
-      mongodb: ^3.6.0
-      mssql: ^7.3.0
-      mysql2: ^2.2.5
-      oracledb: ^5.1.0
-      pg: ^8.5.1
-      pg-native: ^3.0.0
-      pg-query-stream: ^4.0.0
-      redis: ^3.1.1 || ^4.0.0
-      sql.js: ^1.4.0
-      sqlite3: ^5.0.3
-      ts-node: ^10.7.0
-      typeorm-aurora-data-api-driver: ^2.0.0
-    peerDependenciesMeta:
-      '@google-cloud/spanner':
-        optional: true
-      '@sap/hana-client':
-        optional: true
-      better-sqlite3:
-        optional: true
-      hdb-pool:
-        optional: true
-      ioredis:
-        optional: true
-      mongodb:
-        optional: true
-      mssql:
-        optional: true
-      mysql2:
-        optional: true
-      oracledb:
-        optional: true
-      pg:
-        optional: true
-      pg-native:
-        optional: true
-      pg-query-stream:
-        optional: true
-      redis:
-        optional: true
-      sql.js:
-        optional: true
-      sqlite3:
-        optional: true
-      ts-node:
-        optional: true
-      typeorm-aurora-data-api-driver:
-        optional: true
-    dependencies:
-      '@sqltools/formatter': 1.2.5
-      app-root-path: 3.1.0
-      buffer: 6.0.3
-      chalk: 4.1.2
-      cli-highlight: 2.1.11
-      date-fns: 2.29.3
-      debug: 4.3.4
-      dotenv: 16.0.3
-      glob: 7.2.3
-      js-yaml: 4.1.0
-      mkdirp: 1.0.4
-      pg: 8.8.0
-      reflect-metadata: 0.1.13
-      sha.js: 2.4.11
-      sqlite3: 5.1.4
-      tslib: 2.4.1
-      uuid: 8.3.2
-      xml2js: 0.4.23
-      yargs: 17.6.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /typeorm/0.3.11_sqlite3@5.1.4:
     resolution: {integrity: sha512-pzdOyWbVuz/z8Ww6gqvBW4nylsM0KLdUCDExr2gR20/x1khGSVxQkjNV/3YqliG90jrWzrknYbYscpk8yxFJVg==}
     engines: {node: '>= 12.9.0'}
@@ -19063,6 +19018,87 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /typeorm/0.3.12_pg@8.8.0+sqlite3@5.1.4:
+    resolution: {integrity: sha512-sYSxBmCf1nJLLTcYtwqZ+lQIRtLPyUoO93rHTOKk9vJCyT4UfRtU7oRsJvfvKP3nnZTD1hzz2SEy2zwPEN6OyA==}
+    engines: {node: '>= 12.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@google-cloud/spanner': ^5.18.0
+      '@sap/hana-client': ^2.12.25
+      better-sqlite3: ^7.1.2 || ^8.0.0
+      hdb-pool: ^0.1.6
+      ioredis: ^5.0.4
+      mongodb: ^3.6.0
+      mssql: ^7.3.0
+      mysql2: ^2.2.5 || ^3.0.1
+      oracledb: ^5.1.0
+      pg: ^8.5.1
+      pg-native: ^3.0.0
+      pg-query-stream: ^4.0.0
+      redis: ^3.1.1 || ^4.0.0
+      sql.js: ^1.4.0
+      sqlite3: ^5.0.3
+      ts-node: ^10.7.0
+      typeorm-aurora-data-api-driver: ^2.0.0
+    peerDependenciesMeta:
+      '@google-cloud/spanner':
+        optional: true
+      '@sap/hana-client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      hdb-pool:
+        optional: true
+      ioredis:
+        optional: true
+      mongodb:
+        optional: true
+      mssql:
+        optional: true
+      mysql2:
+        optional: true
+      oracledb:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      pg-query-stream:
+        optional: true
+      redis:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+      ts-node:
+        optional: true
+      typeorm-aurora-data-api-driver:
+        optional: true
+    dependencies:
+      '@sqltools/formatter': 1.2.5
+      app-root-path: 3.1.0
+      buffer: 6.0.3
+      chalk: 4.1.2
+      cli-highlight: 2.1.11
+      date-fns: 2.29.3
+      debug: 4.3.4
+      dotenv: 16.0.3
+      glob: 8.1.0
+      js-yaml: 4.1.0
+      mkdirp: 2.1.3
+      pg: 8.8.0
+      reflect-metadata: 0.1.13
+      sha.js: 2.4.11
+      sqlite3: 5.1.4
+      tslib: 2.5.0
+      uuid: 9.0.0
+      xml2js: 0.4.23
+      yargs: 17.6.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /typescript/4.8.4:
     resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
@@ -19425,7 +19461,7 @@ packages:
       '@peculiar/json-schema': 1.1.12
       asn1js: 3.0.5
       pvtsutils: 1.3.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /webcrypto-shim/0.1.7:


### PR DESCRIPTION
## What issue is this PR fixing

This PR refactors the way commander.js is used in the CLI package.
Instead of a global `program` command being mutated by different imports, each subcommand is created as an independent instance of a `Command` object.

The main purpose is to simplify testing, however due to incompatibilities between jest/ESM/chalk/typeorm the tests can't actually be performed using the same testing harness.

A custom jest config would be needed that must only be used on the CLI tests. When enabling the workaround in  https://github.com/facebook/jest/issues/12270#issuecomment-1111533936 any tests using typeorm in any way will fail.
This means we'd also need to only use JSON storage or memory storage configs in these CLI tests.

This PR also exports some of the methods used to configure the CLI through yaml.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [X] I added unit tests... but they are skipped for now.
* [ ] I added integration tests.
