### PR TITLE
feat(cli): add did:pkh support to the default CLI config

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ts-node": "10.9.1",
     "typeorm": "^0.3.11",
     "typescript": "4.9.4",
-    "uint8arrays": "4.0.3",
+    "uint8arrays": "3.1.1",
     "uuid": "^9.0.0",
     "web-did-resolver": "^2.0.21"
   },

--- a/packages/cli/default/default.yml
+++ b/packages/cli/default/default.yml
@@ -160,25 +160,24 @@ messageHandler:
 didResolver:
   $require: '@veramo/did-resolver#DIDResolverPlugin'
   $args:
-    - resolver:
-        $require: did-resolver#Resolver
-        $args:
-          - ethr:
-              $ref: /ethr-did-resolver
-            web:
-              $ref: /web-did-resolver
-            key:
-              $ref: /did-key-resolver
-            3:
-              $ref: /3id-did-resolver
-            elem:
-              $ref: /universal-resolver
-            io:
-              $ref: /universal-resolver
-            ion:
-              $ref: /universal-resolver
-            sov:
-              $ref: /universal-resolver
+    - ethr:
+        $ref: /ethr-did-resolver
+      web:
+        $ref: /web-did-resolver
+      key:
+        $ref: /did-key-resolver
+      pkh:
+        $require: '@veramo/did-provider-pkh?t=function&p=/pkh#getDidPkhResolver'
+      3:
+        $ref: /3id-did-resolver
+      elem:
+        $ref: /universal-resolver
+      io:
+        $ref: /universal-resolver
+      ion:
+        $ref: /universal-resolver
+      sov:
+        $ref: /universal-resolver
 
 ethr-did-resolver:
   $require: ethr-did-resolver?t=function&p=/ethr#getResolver
@@ -190,7 +189,7 @@ web-did-resolver:
 
 ceramic:
   $require: '@ceramicnetwork/http-client#CeramicClient'
-  $args: 
+  $args:
     - 'https://gateway.ceramic.network'
 
 3id-did-resolver:
@@ -259,6 +258,11 @@ didManager:
           $require: '@veramo/did-provider-key#KeyDIDProvider'
           $args:
             - defaultKms: local
+        did:pkh:
+          $require: '@veramo/did-provider-pkh#PkhDIDProvider'
+          $args:
+            - defaultKms: local
+              chainId: 1
 
 didDiscovery:
   $require: '@veramo/did-discovery#DIDDiscovery'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "@veramo/did-manager": "^5.0.0",
     "@veramo/did-provider-ethr": "^5.0.0",
     "@veramo/did-provider-key": "^5.0.0",
+    "@veramo/did-provider-pkh": "^5.0.0",
     "@veramo/did-provider-web": "^5.0.0",
     "@veramo/did-resolver": "^5.0.0",
     "@veramo/key-manager": "^5.0.0",

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -3,8 +3,6 @@ import { jest } from '@jest/globals'
 import { createObjects } from '../lib/objectCreator'
 import { getConfig } from '../setup'
 
-jest.useFakeTimers()
-
 describe('cli version', () => {
   const writeMock = jest.fn()
 
@@ -18,6 +16,22 @@ describe('cli version', () => {
     jest.clearAllMocks()
   })
 
+  it('should load the dbConnection', async () => {
+    const { dbConnection } = await createObjects(await getConfig('./packages/cli/default/default.yml'), {
+      dbConnection: '/dbConnection',
+    })
+    expect(dbConnection).toBeDefined()
+  })
+
+  // this seems to fail because of an incompatibility between jest and the `multiformats@11` transitive dependency
+  it.skip('should load the agent', async () => {
+    const { agent } = await createObjects(await getConfig('./packages/cli/default/default.yml'), {
+      agent: '/agent',
+    })
+    expect(agent).toBeDefined()
+  })
+
+  // this seems to fail because of some timing issues or an incompatibility with the `chalk` transitive dependency
   it.skip('should list version number', async () => {
     expect(() => {
       // veramo.parse(['--version'], { from: 'user' })
@@ -25,14 +39,7 @@ describe('cli version', () => {
     expect(writeMock).toHaveBeenCalledWith(expect.stringMatching(/^\d\.\d\.\d\n?$/))
   })
 
-  it.skip('should load the dbConnection', async () => {
-    // this seems to fail because of some timing issues or an incompatibility with the `chalk` transitive dependency
-    // all other tests that need to load the dbConnection fail similarly
-    const res = await createObjects(getConfig('./packages/cli/default/default.yml'), {
-      my: '/dbConnection',
-    })
-  })
-
+  // this seems to fail because of some timing issues or an incompatibility with the `chalk` transitive dependency
   it.skip('should check the default config', async () => {
     expect(() => {
       // veramo.parse(['config', 'check', '-f', './packages/cli/default/default.yml'], { from: 'user' })

--- a/packages/cli/src/lib/agentCreator.ts
+++ b/packages/cli/src/lib/agentCreator.ts
@@ -8,7 +8,7 @@ import { createObjects } from './objectCreator.js'
  * @see {@link https://veramo.io/docs/veramo_agent/configuration_internals | Configuration Internals} for details on
  *   the configuration options.
  *
- * @beta
+ * @beta - This API may change without a major version bump
  */
 export async function createAgentFromConfig<T extends IPluginMethodMap>(config: object): Promise<TAgent<T>> {
   // @ts-ignore

--- a/packages/cli/src/lib/objectCreator.ts
+++ b/packages/cli/src/lib/objectCreator.ts
@@ -12,30 +12,32 @@ import { resolve } from 'path'
  *
  * The config can contain references (`$ref`) to other objects within using JSON pointers.
  * Example:
- * ```json5
+ * ```json
  * {
- *   rpcUrl: "http://localhost:8545",
- *   endpoint: {
- *     url: {
+ *   "rpcUrl": "http://localhost:8545",
+ *   "endpoint": {
+ *     "url": {
  *       "$ref": "/rpcUrl"
  *     }
  *   }
  * }
+ * ```
  *
  * The config object can also contain references to NPM modules using the `$require` property.
  * Example:
- * ```json5
+ * ```json
  * {
- *   agent: {
+ *   "agent": {
  *     "$require": "@veramo/core#Agent",
  *     "$args": {
- *       plugins: [
+ *       "plugins": [
  *         { "$require": "@veramo/did-comm#DIDComm" },
  *       ]
  *     }
  *   }
  * }
  * ```
+ *
  * Environment variables can also be specified using the `$env` property.
  *
  * @see Please see {@link https://veramo.io/docs/veramo_agent/configuration_internals | Configuration Internals} for
@@ -44,9 +46,9 @@ import { resolve } from 'path'
  * @param config - The configuration object
  * @param pointers - A map of JSON pointers to objects within that config that you wish to create
  *
- * @beta
+ * @beta - This API may change without a major version bump
  */
-export async function createObjects(config: object, pointers: Record<string, string>): Promise<any> {
+export async function createObjects(config: object, pointers: Record<string, string>): Promise<Record<string, any>> {
   const objects = {}
 
   async function resolveRefs(input: any): Promise<any> {

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -16,17 +16,33 @@ import { createAgentFromConfig } from './lib/agentCreator.js'
 
 import fs from 'fs'
 
-export const getConfig = (fileName: string): any => {
-  if (!fs.existsSync(fileName)) {
-    console.log('Config file not found: ' + fileName)
+/**
+ * Parses a yaml config file and returns a config object
+ * @param filePath
+ */
+export const getConfig = async (filePath: fs.PathLike): Promise<{ version?: number; [x: string]: any }> => {
+  let fileContent: string
+
+  // read file async
+  try {
+    fileContent = await fs.promises.readFile(filePath, 'utf8')
+  } catch (e) {
+    console.log('Config file not found: ' + filePath)
     console.log('Use "veramo config create" to create one')
     process.exit(1)
   }
 
-  const config = yaml.parse(fs.readFileSync(fileName).toString(), { prettyErrors: true })
+  let config
+
+  try {
+    config = yaml.parse(fileContent, { prettyErrors: true })
+  } catch (e) {
+    console.error(`Unable to parse config file: ${e.message} ${e.linePos}`)
+    process.exit(1)
+  }
 
   if (config?.version != 3) {
-    console.log('Unsupported configuration file version:', config.version)
+    console.error('Unsupported configuration file version:', config.version)
     process.exit(1)
   }
   return config
@@ -47,7 +63,7 @@ export type ConfiguredAgent = TAgent<EnabledInterfaces>
 
 export async function getAgent(fileName: string): Promise<ConfiguredAgent> {
   try {
-    return await createAgentFromConfig<EnabledInterfaces>(getConfig(fileName))
+    return await createAgentFromConfig<EnabledInterfaces>(await getConfig(fileName))
   } catch (e: any) {
     console.log('Unable to create agent from ' + fileName + '.', e.message)
     process.exit(1)

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "../did-manager" },
     { "path": "../did-provider-ethr" },
     { "path": "../did-provider-key" },
+    { "path": "../did-provider-pkh" },
     { "path": "../did-provider-web" },
     { "path": "../did-resolver" },
     { "path": "../key-manager" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
       ts-node: 10.9.1
       typeorm: ^0.3.11
       typescript: 4.9.4
-      uint8arrays: 4.0.3
+      uint8arrays: 3.1.1
       uuid: ^9.0.0
       web-did-resolver: ^2.0.21
     devDependencies:
@@ -98,7 +98,7 @@ importers:
       ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
       typeorm: 0.3.11_ts-node@10.9.1
       typescript: 4.9.4
-      uint8arrays: 4.0.3
+      uint8arrays: 3.1.1
       uuid: 9.0.0
       web-did-resolver: 2.0.21
 
@@ -130,6 +130,7 @@ importers:
       '@veramo/did-manager': ^5.0.0
       '@veramo/did-provider-ethr': ^5.0.0
       '@veramo/did-provider-key': ^5.0.0
+      '@veramo/did-provider-pkh': ^5.0.0
       '@veramo/did-provider-web': ^5.0.0
       '@veramo/did-resolver': ^5.0.0
       '@veramo/key-manager': ^5.0.0
@@ -194,6 +195,7 @@ importers:
       '@veramo/did-manager': link:../did-manager
       '@veramo/did-provider-ethr': link:../did-provider-ethr
       '@veramo/did-provider-key': link:../did-provider-key
+      '@veramo/did-provider-pkh': link:../did-provider-pkh
       '@veramo/did-provider-web': link:../did-provider-web
       '@veramo/did-resolver': link:../did-resolver
       '@veramo/key-manager': link:../key-manager
@@ -14391,6 +14393,7 @@ packages:
   /multiformats/11.0.0:
     resolution: {integrity: sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dev: false
 
   /multiformats/9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
@@ -19115,6 +19118,7 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     dependencies:
       multiformats: 11.0.0
+    dev: false
 
   /unbox-primitive/1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}


### PR DESCRIPTION
## What issue is this PR fixing

This adds support for did:pkh to the default CLI config.
```bash
> veramo did create
##  choose: did:pkh
> veramo did resolve did:pkh:eip155.....
## resolves a did:pkh
```

This also cleans some CLI initialization code and inline docs related to config loading.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [X] I added unit tests unrelated to did:pkh.
* [ ] I added integration tests.
* [X] I did not add relevant automated tests because there is still an incompatibility between the CLI tests and Jest.