### PR TITLE
Fix react-native migrations on older Android installations

### DIFF
--- a/packages/data-store/src/entities/PreMigrationEntities.ts
+++ b/packages/data-store/src/entities/PreMigrationEntities.ts
@@ -1,5 +1,5 @@
-import { BaseEntity, Column, Entity, PrimaryColumn } from 'typeorm'
-import { KeyType } from "./key.js";
+import { Column, Entity, PrimaryColumn } from 'typeorm'
+import { Key } from './key.js'
 
 /**
  * This represents the private key data of keys that were stored by {@link @veramo/data-store#KeyStore} before Veramo
@@ -8,15 +8,13 @@ import { KeyType } from "./key.js";
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-@Entity('key')
-export class PreMigrationKey extends BaseEntity {
+@Entity('key', )
+export class PreMigrationKey extends Key {
+  // Key contains all the other columns present needed for successful migrations
+
   @PrimaryColumn()
     // @ts-ignore
   kid: string
-
-  @Column()
-    // @ts-ignore
-  type: KeyType
 
   @Column({ nullable: true })
   privateKeyHex?: string

--- a/packages/data-store/src/migrations/1.createDatabase.ts
+++ b/packages/data-store/src/migrations/1.createDatabase.ts
@@ -1,5 +1,7 @@
 import { MigrationInterface, QueryRunner, Table } from 'typeorm'
 import Debug from 'debug'
+import { migrationGetTableName } from './migration-functions.js'
+
 const debug = Debug('veramo:data-store:initial-migration')
 
 /**
@@ -8,14 +10,10 @@ const debug = Debug('veramo:data-store:initial-migration')
  * @public
  */
 export class CreateDatabase1447159020001 implements MigrationInterface {
-  async up(queryRunner: QueryRunner): Promise<void> {
-    function getTableName(givenName: string): string {
-      return (
-        queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName)?.tableName ||
-        givenName
-      )
-    }
 
+  name = 'CreateDatabase1447159020001' // Used in case this class gets minified, which would change the classname
+
+  async up(queryRunner: QueryRunner): Promise<void> {
     const dateTimeType: string = queryRunner.connection.driver.mappedDataTypes.createDate as string
 
     debug(`creating identifier table`)
@@ -23,7 +21,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE UNIQUE INDEX \"IDX_6098cca69c838d91e55ef32fe1\" ON \"identifier\" (\"alias\", \"provider\")",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('identifier'),
+        name: migrationGetTableName(queryRunner,'identifier'),
         columns: [
           { name: 'did', type: 'varchar', isPrimary: true },
           { name: 'provider', type: 'varchar', isNullable: true },
@@ -46,7 +44,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE TABLE \"key\" (\"kid\" varchar PRIMARY KEY NOT NULL, \"kms\" varchar NOT NULL, \"type\" varchar NOT NULL, \"publicKeyHex\" varchar NOT NULL, \"privateKeyHex\" varchar NOT NULL, \"meta\" text, \"identifierDid\" varchar, CONSTRAINT \"FK_3f40a9459b53adf1729dbd3b787\" FOREIGN KEY (\"identifierDid\") REFERENCES \"identifier\" (\"did\") ON DELETE NO ACTION ON UPDATE NO ACTION)",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('key'),
+        name: migrationGetTableName(queryRunner,'key'),
         columns: [
           { name: 'kid', type: 'varchar', isPrimary: true },
           { name: 'kms', type: 'varchar' },
@@ -60,7 +58,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
           {
             columnNames: ['identifierDid'],
             referencedColumnNames: ['did'],
-            referencedTableName: getTableName('identifier'),
+            referencedTableName: migrationGetTableName(queryRunner, 'identifier'),
           },
         ],
       }),
@@ -71,7 +69,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE TABLE \"service\" (\"id\" varchar PRIMARY KEY NOT NULL, \"type\" varchar NOT NULL, \"serviceEndpoint\" varchar NOT NULL, \"description\" varchar, \"identifierDid\" varchar, CONSTRAINT \"FK_e16e0280d906951809f95dd09f1\" FOREIGN KEY (\"identifierDid\") REFERENCES \"identifier\" (\"did\") ON DELETE NO ACTION ON UPDATE NO ACTION)",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('service'),
+        name: migrationGetTableName(queryRunner, 'service'),
         columns: [
           { name: 'id', type: 'varchar', isPrimary: true },
           { name: 'type', type: 'varchar' },
@@ -83,7 +81,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
           {
             columnNames: ['identifierDid'],
             referencedColumnNames: ['did'],
-            referencedTableName: getTableName('identifier'),
+            referencedTableName: migrationGetTableName(queryRunner, 'identifier'),
             onDelete: 'cascade',
           },
         ],
@@ -95,7 +93,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE TABLE \"credential\" (\"hash\" varchar PRIMARY KEY NOT NULL, \"raw\" text NOT NULL, \"id\" varchar, \"issuanceDate\" datetime NOT NULL, \"expirationDate\" datetime, \"context\" text NOT NULL, \"type\" text NOT NULL, \"issuerDid\" varchar, \"subjectDid\" varchar, CONSTRAINT \"FK_123d0977e0976565ee0932c0b9e\" FOREIGN KEY (\"issuerDid\") REFERENCES \"identifier\" (\"did\") ON DELETE NO ACTION ON UPDATE NO ACTION, CONSTRAINT \"FK_b790831f44e2fa7f9661a017b0a\" FOREIGN KEY (\"subjectDid\") REFERENCES \"identifier\" (\"did\") ON DELETE NO ACTION ON UPDATE NO ACTION)",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('credential'),
+        name: migrationGetTableName(queryRunner, 'credential'),
         columns: [
           { name: 'hash', type: 'varchar', isPrimary: true },
           { name: 'raw', type: 'text' },
@@ -111,13 +109,13 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
           {
             columnNames: ['issuerDid'],
             referencedColumnNames: ['did'],
-            referencedTableName: getTableName('identifier'),
+            referencedTableName: migrationGetTableName(queryRunner, 'identifier'),
             onDelete: 'cascade',
           },
           {
             columnNames: ['subjectDid'],
             referencedColumnNames: ['did'],
-            referencedTableName: getTableName('identifier'),
+            referencedTableName: migrationGetTableName(queryRunner, 'identifier'),
           },
         ],
       }),
@@ -128,7 +126,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE TABLE \"claim\" (\"hash\" varchar PRIMARY KEY NOT NULL, \"issuanceDate\" datetime NOT NULL, \"expirationDate\" datetime, \"context\" text NOT NULL, \"credentialType\" text NOT NULL, \"type\" varchar NOT NULL, \"value\" text, \"isObj\" boolean NOT NULL, \"issuerDid\" varchar, \"subjectDid\" varchar, \"credentialHash\" varchar, CONSTRAINT \"FK_d972c73d0f875c0d14c35b33baa\" FOREIGN KEY (\"issuerDid\") REFERENCES \"identifier\" (\"did\") ON DELETE NO ACTION ON UPDATE NO ACTION, CONSTRAINT \"FK_f411679379d373424100a1c73f4\" FOREIGN KEY (\"subjectDid\") REFERENCES \"identifier\" (\"did\") ON DELETE NO ACTION ON UPDATE NO ACTION, CONSTRAINT \"FK_3d494b79143de3d0e793883e351\" FOREIGN KEY (\"credentialHash\") REFERENCES \"credential\" (\"hash\") ON DELETE NO ACTION ON UPDATE NO ACTION)",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('claim'),
+        name: migrationGetTableName(queryRunner, 'claim'),
         columns: [
           { name: 'hash', type: 'varchar', isPrimary: true },
           { name: 'issuanceDate', type: dateTimeType },
@@ -146,18 +144,18 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
           {
             columnNames: ['issuerDid'],
             referencedColumnNames: ['did'],
-            referencedTableName: getTableName('identifier'),
+            referencedTableName: migrationGetTableName(queryRunner, 'identifier'),
             onDelete: 'cascade',
           },
           {
             columnNames: ['subjectDid'],
             referencedColumnNames: ['did'],
-            referencedTableName: getTableName('identifier'),
+            referencedTableName: migrationGetTableName(queryRunner, 'identifier'),
           },
           {
             columnNames: ['credentialHash'],
             referencedColumnNames: ['hash'],
-            referencedTableName: getTableName('credential'),
+            referencedTableName: migrationGetTableName(queryRunner, 'credential'),
             onDelete: 'cascade',
           },
         ],
@@ -169,7 +167,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE TABLE \"presentation\" (\"hash\" varchar PRIMARY KEY NOT NULL, \"raw\" text NOT NULL, \"id\" varchar, \"issuanceDate\" datetime NOT NULL, \"expirationDate\" datetime, \"context\" text NOT NULL, \"type\" text NOT NULL, \"holderDid\" varchar, CONSTRAINT \"FK_a5e418449d9f527776a3bd0ca61\" FOREIGN KEY (\"holderDid\") REFERENCES \"identifier\" (\"did\") ON DELETE NO ACTION ON UPDATE NO ACTION)",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('presentation'),
+        name: migrationGetTableName(queryRunner, 'presentation'),
         columns: [
           { name: 'hash', type: 'varchar', isPrimary: true },
           { name: 'raw', type: 'text' },
@@ -184,7 +182,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
           {
             columnNames: ['holderDid'],
             referencedColumnNames: ['did'],
-            referencedTableName: getTableName('identifier'),
+            referencedTableName: migrationGetTableName(queryRunner, 'identifier'),
             onDelete: 'cascade',
           },
         ],
@@ -196,7 +194,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE TABLE \"message\" (\"id\" varchar PRIMARY KEY NOT NULL, \"saveDate\" datetime NOT NULL DEFAULT (datetime('now')), \"updateDate\" datetime NOT NULL DEFAULT (datetime('now')), \"createdAt\" datetime, \"expiresAt\" datetime, \"threadId\" varchar, \"type\" varchar NOT NULL, \"raw\" varchar, \"data\" text, \"replyTo\" text, \"replyUrl\" varchar, \"metaData\" text, \"fromDid\" varchar, \"toDid\" varchar, CONSTRAINT \"FK_63bf73143b285c727bd046e6710\" FOREIGN KEY (\"fromDid\") REFERENCES \"identifier\" (\"did\") ON DELETE NO ACTION ON UPDATE NO ACTION, CONSTRAINT \"FK_1a666b2c29bb2b68d91259f55df\" FOREIGN KEY (\"toDid\") REFERENCES \"identifier\" (\"did\") ON DELETE NO ACTION ON UPDATE NO ACTION)",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('message'),
+        name: migrationGetTableName(queryRunner, 'message'),
         columns: [
           { name: 'id', type: 'varchar', isPrimary: true },
           { name: 'saveDate', type: dateTimeType },
@@ -217,12 +215,12 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
           {
             columnNames: ['fromDid'],
             referencedColumnNames: ['did'],
-            referencedTableName: getTableName('identifier'),
+            referencedTableName: migrationGetTableName(queryRunner, 'identifier'),
           },
           {
             columnNames: ['toDid'],
             referencedColumnNames: ['did'],
-            referencedTableName: getTableName('identifier'),
+            referencedTableName: migrationGetTableName(queryRunner, 'identifier'),
           },
         ],
       }),
@@ -235,7 +233,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE INDEX \"IDX_3a460e48557bad5564504ddad9\" ON \"presentation_verifier_identifier\" (\"identifierDid\")",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('presentation_verifier_identifier'),
+        name: migrationGetTableName(queryRunner, 'presentation_verifier_identifier'),
         columns: [
           { name: 'presentationHash', type: 'varchar', isPrimary: true },
           { name: 'identifierDid', type: 'varchar', isPrimary: true },
@@ -249,13 +247,13 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
           {
             columnNames: ['presentationHash'],
             referencedColumnNames: ['hash'],
-            referencedTableName: getTableName('presentation'),
+            referencedTableName: migrationGetTableName(queryRunner, 'presentation'),
             onDelete: 'cascade',
           },
           {
             columnNames: ['identifierDid'],
             referencedColumnNames: ['did'],
-            referencedTableName: getTableName('identifier'),
+            referencedTableName: migrationGetTableName(queryRunner, 'identifier'),
             onDelete: 'cascade',
           },
         ],
@@ -269,7 +267,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE INDEX \"IDX_ef88f92988763fee884c37db63\" ON \"presentation_credentials_credential\" (\"credentialHash\")",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('presentation_credentials_credential'),
+        name: migrationGetTableName(queryRunner, 'presentation_credentials_credential'),
         columns: [
           { name: 'presentationHash', type: 'varchar', isPrimary: true },
           { name: 'credentialHash', type: 'varchar', isPrimary: true },
@@ -283,13 +281,13 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
           {
             columnNames: ['presentationHash'],
             referencedColumnNames: ['hash'],
-            referencedTableName: getTableName('presentation'),
+            referencedTableName: migrationGetTableName(queryRunner, 'presentation'),
             onDelete: 'cascade',
           },
           {
             columnNames: ['credentialHash'],
             referencedColumnNames: ['hash'],
-            referencedTableName: getTableName('credential'),
+            referencedTableName: migrationGetTableName(queryRunner, 'credential'),
             onDelete: 'cascade',
           },
         ],
@@ -303,7 +301,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE INDEX \"IDX_a13b5cf828c669e61faf489c18\" ON \"message_presentations_presentation\" (\"presentationHash\")",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('message_presentations_presentation'),
+        name: migrationGetTableName(queryRunner, 'message_presentations_presentation'),
         columns: [
           { name: 'messageId', type: 'varchar', isPrimary: true },
           { name: 'presentationHash', type: 'varchar', isPrimary: true },
@@ -317,13 +315,13 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
           {
             columnNames: ['messageId'],
             referencedColumnNames: ['id'],
-            referencedTableName: getTableName('message'),
+            referencedTableName: migrationGetTableName(queryRunner, 'message'),
             onDelete: 'cascade',
           },
           {
             columnNames: ['presentationHash'],
             referencedColumnNames: ['hash'],
-            referencedTableName: getTableName('presentation'),
+            referencedTableName: migrationGetTableName(queryRunner, 'presentation'),
             onDelete: 'cascade',
           },
         ],
@@ -337,7 +335,7 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
     // "CREATE INDEX \"IDX_8ae8195a94b667b185d2c023e3\" ON \"message_credentials_credential\" (\"credentialHash\")",
     await queryRunner.createTable(
       new Table({
-        name: getTableName('message_credentials_credential'),
+        name: migrationGetTableName(queryRunner, 'message_credentials_credential'),
         columns: [
           { name: 'messageId', type: 'varchar', isPrimary: true },
           { name: 'credentialHash', type: 'varchar', isPrimary: true },
@@ -351,13 +349,13 @@ export class CreateDatabase1447159020001 implements MigrationInterface {
           {
             columnNames: ['messageId'],
             referencedColumnNames: ['id'],
-            referencedTableName: getTableName('message'),
+            referencedTableName: migrationGetTableName(queryRunner, 'message'),
             onDelete: 'cascade',
           },
           {
             columnNames: ['credentialHash'],
             referencedColumnNames: ['hash'],
-            referencedTableName: getTableName('credential'),
+            referencedTableName: migrationGetTableName(queryRunner, 'credential'),
             onDelete: 'cascade',
           },
         ],

--- a/packages/data-store/src/migrations/2.simplifyRelations.ts
+++ b/packages/data-store/src/migrations/2.simplifyRelations.ts
@@ -1,5 +1,6 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm'
 import { migrationGetExistingTableByName } from './migration-functions.js'
+import { PreMigrationKey } from '../entities/PreMigrationEntities.js'
 
 /**
  * Fix inconsistencies between Entity data and column data.
@@ -12,7 +13,7 @@ export class SimplifyRelations1447159020002 implements MigrationInterface {
 
   async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.changeColumn(
-      migrationGetExistingTableByName(queryRunner, 'key'),
+      migrationGetExistingTableByName(queryRunner, 'PreMigrationKey', true),
       'identifierDid',
       new TableColumn({ name: 'identifierDid', type: 'varchar', isNullable: true }),
     )
@@ -21,6 +22,7 @@ export class SimplifyRelations1447159020002 implements MigrationInterface {
       'identifierDid',
       new TableColumn({ name: 'identifierDid', type: 'varchar', isNullable: true }),
     )
+
   }
 
   async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/data-store/src/migrations/2.simplifyRelations.ts
+++ b/packages/data-store/src/migrations/2.simplifyRelations.ts
@@ -1,5 +1,5 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm'
-import Debug from 'debug'
+import { migrationGetExistingTableByName } from './migration-functions.js'
 
 /**
  * Fix inconsistencies between Entity data and column data.
@@ -7,20 +7,17 @@ import Debug from 'debug'
  * @public
  */
 export class SimplifyRelations1447159020002 implements MigrationInterface {
+
+  name = 'SimplifyRelations1447159020002' // Used in case this class gets minified, which would change the classname
+
   async up(queryRunner: QueryRunner): Promise<void> {
-    function getTableName(givenName: string): string {
-      return (
-        queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName)?.tableName ||
-        givenName
-      )
-    }
     await queryRunner.changeColumn(
-      getTableName('key'),
+      migrationGetExistingTableByName(queryRunner, 'key'),
       'identifierDid',
       new TableColumn({ name: 'identifierDid', type: 'varchar', isNullable: true }),
     )
     await queryRunner.changeColumn(
-      getTableName('service'),
+      migrationGetExistingTableByName(queryRunner, 'service'),
       'identifierDid',
       new TableColumn({ name: 'identifierDid', type: 'varchar', isNullable: true }),
     )

--- a/packages/data-store/src/migrations/3.createPrivateKeyStorage.ts
+++ b/packages/data-store/src/migrations/3.createPrivateKeyStorage.ts
@@ -58,9 +58,10 @@ export class CreatePrivateKeyStorage1629293428674 implements MigrationInterface 
       .execute()
     // 3. drop old column
     debug(`dropping privKeyHex column from old key table`)
-    await queryRunner.dropColumn(migrationGetExistingTableByName(queryRunner, 'key'), 'privateKeyHex')
+    await queryRunner.dropColumn(migrationGetExistingTableByName(queryRunner, 'PreMigrationKey', true), 'privateKeyHex')
     //4. done
     debug(`migrated ${privKeys.length} keys to private key storage`)
+
   }
 
   async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/data-store/src/migrations/3.createPrivateKeyStorage.ts
+++ b/packages/data-store/src/migrations/3.createPrivateKeyStorage.ts
@@ -2,6 +2,8 @@ import { MigrationInterface, QueryRunner, Table, TableColumn } from 'typeorm'
 import { PrivateKey } from '../index.js'
 import { PreMigrationKey } from '../entities/PreMigrationEntities.js'
 import Debug from 'debug'
+import { migrationGetExistingTableByName, migrationGetTableName } from './migration-functions.js'
+
 const debug = Debug('veramo:data-store:migrate-private-keys')
 
 /**
@@ -10,18 +12,15 @@ const debug = Debug('veramo:data-store:migrate-private-keys')
  * @public
  */
 export class CreatePrivateKeyStorage1629293428674 implements MigrationInterface {
+
+  name = 'CreatePrivateKeyStorage1629293428674' // Used in case this class gets minified, which would change the classname
+
   async up(queryRunner: QueryRunner): Promise<void> {
-    function getTableName(givenName: string): string {
-      return (
-        queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName)?.tableName ||
-        givenName
-      )
-    }
     // 1.create new table
     debug(`creating new private-key table`)
     await queryRunner.createTable(
       new Table({
-        name: getTableName('private-key'),
+        name: migrationGetTableName(queryRunner, 'private-key'),
         columns: [
           {
             name: 'alias',
@@ -54,23 +53,18 @@ export class CreatePrivateKeyStorage1629293428674 implements MigrationInterface 
     await queryRunner.manager
       .createQueryBuilder()
       .insert()
-      .into(getTableName('private-key'))
+      .into(migrationGetTableName(queryRunner, 'private-key'))
       .values(privKeys)
       .execute()
     // 3. drop old column
     debug(`dropping privKeyHex column from old key table`)
-    await queryRunner.dropColumn(getTableName('key'), 'privateKeyHex')
+    await queryRunner.dropColumn(migrationGetExistingTableByName(queryRunner, 'key'), 'privateKeyHex')
     //4. done
     debug(`migrated ${privKeys.length} keys to private key storage`)
   }
 
   async down(queryRunner: QueryRunner): Promise<void> {
-    function getTableName(givenName: string): string {
-      return (
-        queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName)?.tableName ||
-        givenName
-      )
-    }
+
     // 1. add old column back
     debug(`adding back privateKeyHex column to key table`)
     await queryRunner.addColumn(
@@ -95,7 +89,7 @@ export class CreatePrivateKeyStorage1629293428674 implements MigrationInterface 
     }
     debug(`dropping private-key table`)
     // 3. drop the new private key table
-    await queryRunner.dropTable(getTableName('private-key'))
+    await queryRunner.dropTable(migrationGetExistingTableByName(queryRunner, 'private-key'))
     // 4. done
     debug(`rolled back ${keys.length} keys`)
   }

--- a/packages/data-store/src/migrations/index.ts
+++ b/packages/data-store/src/migrations/index.ts
@@ -3,6 +3,14 @@ import { SimplifyRelations1447159020002 } from './2.simplifyRelations.js'
 import { CreatePrivateKeyStorage1629293428674 } from './3.createPrivateKeyStorage.js'
 import { AllowNullIssuanceDateForPresentations1637237492913 } from './4.allowNullVPIssuanceDate.js'
 
+
+/**
+ * Allow others to use shared migration functions if they extend Veramo
+ *
+ * @public
+ */
+export * from './migration-functions.js'
+
 /**
  * The migrations array that SHOULD be used when initializing a TypeORM database connection.
  *
@@ -10,6 +18,7 @@ import { AllowNullIssuanceDateForPresentations1637237492913 } from './4.allowNul
  *
  * @public
  */
+
 export const migrations = [
   CreateDatabase1447159020001,
   SimplifyRelations1447159020002,

--- a/packages/data-store/src/migrations/migration-functions.ts
+++ b/packages/data-store/src/migrations/migration-functions.ts
@@ -1,0 +1,48 @@
+import { QueryRunner, Table } from 'typeorm'
+
+/**
+ * Get an existing table by name. Checks against givenTableName first, and tableName next. Throws an error if not found
+ *
+ * @param queryRunner The query runner object to use for querying
+ * @param givenName The given name of the table to search for
+ *
+ * @public
+ */
+export function migrationGetExistingTableByName(queryRunner: QueryRunner, givenName: string): Table {
+  const table = migrationGetTableByNameImpl(queryRunner, givenName)
+  if (!table) {
+    throw Error(`Could not find table with name ${givenName}`)
+  }
+  return table
+}
+
+/**
+ * Get an existing table by name. Checks against givenTableName first, and tableName next. Returns undefined if not found
+ *
+ * @param queryRunner The query runner object to use for querying
+ * @param givenName The given name of the table to search for
+ *
+ * @private
+ */
+function migrationGetTableByNameImpl(queryRunner: QueryRunner, givenName: string): Table | undefined {
+  let entityMetadata = queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName)
+  if (!entityMetadata) {
+    // We are doing this separately as we don't want the above filter to use an or expression potentially matching first on tableName instead of givenTableName
+    entityMetadata = queryRunner.connection.entityMetadatas.find((meta) => meta.tableName === givenName)
+  }
+
+  return entityMetadata ? Table.create(entityMetadata, queryRunner.connection.driver) : undefined
+}
+
+/**
+ * Get a table name. Checks against givenTableName first, and tableName next from existing tables. Then returns the name. If not found returns the givenName argument
+ *
+ * @param queryRunner The query runner object to use for querying
+ * @param givenName The given name of the table to search for
+ *
+ * @public
+ */
+export function migrationGetTableName(queryRunner: QueryRunner, givenName: string): string {
+  const table = migrationGetTableByNameImpl(queryRunner, givenName)
+  return !!table ? table.name : givenName
+}

--- a/packages/data-store/src/migrations/migration-functions.ts
+++ b/packages/data-store/src/migrations/migration-functions.ts
@@ -5,6 +5,7 @@ import { QueryRunner, Table } from 'typeorm'
  *
  * @param queryRunner The query runner object to use for querying
  * @param givenName The given name of the table to search for
+ * @param strictClassName Whether the table name should strictly match the given name
  *
  * @public
  */
@@ -21,6 +22,7 @@ export function migrationGetExistingTableByName(queryRunner: QueryRunner, givenN
  *
  * @param queryRunner The query runner object to use for querying
  * @param givenName The given name of the table to search for
+ * @param strictClassName Whether the table name should strictly match the given name
  *
  * @private
  */
@@ -39,7 +41,7 @@ function migrationGetTableByNameImpl(queryRunner: QueryRunner, givenName: string
  *
  * @param queryRunner The query runner object to use for querying
  * @param givenName The given name of the table to search for
- *
+ * @param strictClassName Whether the table name should strictly match the given name
  * @public
  */
 export function migrationGetTableName(queryRunner: QueryRunner, givenName: string, strictClassName?: boolean): string {

--- a/packages/data-store/src/migrations/migration-functions.ts
+++ b/packages/data-store/src/migrations/migration-functions.ts
@@ -8,8 +8,8 @@ import { QueryRunner, Table } from 'typeorm'
  *
  * @public
  */
-export function migrationGetExistingTableByName(queryRunner: QueryRunner, givenName: string): Table {
-  const table = migrationGetTableByNameImpl(queryRunner, givenName)
+export function migrationGetExistingTableByName(queryRunner: QueryRunner, givenName: string, strictClassName?: boolean): Table {
+  const table = migrationGetTableByNameImpl(queryRunner, givenName, strictClassName)
   if (!table) {
     throw Error(`Could not find table with name ${givenName}`)
   }
@@ -24,9 +24,9 @@ export function migrationGetExistingTableByName(queryRunner: QueryRunner, givenN
  *
  * @private
  */
-function migrationGetTableByNameImpl(queryRunner: QueryRunner, givenName: string): Table | undefined {
-  let entityMetadata = queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName)
-  if (!entityMetadata) {
+function migrationGetTableByNameImpl(queryRunner: QueryRunner, givenName: string, strictClassName?: boolean): Table | undefined {
+  let entityMetadata = queryRunner.connection.entityMetadatas.find((meta) => !!strictClassName ? meta.name === givenName : meta.givenTableName === givenName)
+  if (!entityMetadata && !strictClassName) {
     // We are doing this separately as we don't want the above filter to use an or expression potentially matching first on tableName instead of givenTableName
     entityMetadata = queryRunner.connection.entityMetadatas.find((meta) => meta.tableName === givenName)
   }
@@ -42,7 +42,7 @@ function migrationGetTableByNameImpl(queryRunner: QueryRunner, givenName: string
  *
  * @public
  */
-export function migrationGetTableName(queryRunner: QueryRunner, givenName: string): string {
-  const table = migrationGetTableByNameImpl(queryRunner, givenName)
+export function migrationGetTableName(queryRunner: QueryRunner, givenName: string, strictClassName?: boolean): string {
+  const table = migrationGetTableByNameImpl(queryRunner, givenName, strictClassName)
   return !!table ? table.name : givenName
 }


### PR DESCRIPTION
## What issue is this PR fixing

In React-Native on older Android APIs (<11) the migrations where failing. That has to do with the 2nd and 3rd migration file. The 2nd migration file wasn't correctly creating new temp tables including privateKeyHex, because it picked up the wrong entity it seems. Probably because the matching logic on the metadata against a list of metadata has a different order in these environments.  As a result the 3rd migration also failed. It is now using a name when creating new tables, but using the actual matched table from the matching logic on existing tables.

Unrelated, the TypeORM migrations are failing in production settings where minifying is being used. That has to do with the fact that TypeORM relies on classnames and its timestamp suffix. When minifying this goes away, so I simply added the name property to the migration files.

As the same method was being copied over between migrations, also create 2 helper functions, so that the code is now shared across migrations and can also be used by people extending Veramo, which might have their own migrations.

Still needs more testing before converting this from draft to final PR


## What is being changed
A clear description of what this PR brings.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [ ] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [X] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.
