### PR TITLE
fix: add did-provider-peer to CLI dependencies

### DIFF
--- a/packages/cli/bin/veramo.js
+++ b/packages/cli/bin/veramo.js
@@ -1,3 +1,3 @@
-#!/usr/bin/env node
+#!/usr/bin/env NODE_NO_WARNINGS=1 node 
 
 import '../build/cli.js'

--- a/packages/cli/default/default.yml
+++ b/packages/cli/default/default.yml
@@ -166,6 +166,8 @@ didResolver:
         $ref: /web-did-resolver
       key:
         $ref: /did-key-resolver
+      peer:
+        $require: '@veramo/did-provider-peer?t=function&p=/peer#getResolver'
       pkh:
         $require: '@veramo/did-provider-pkh?t=function&p=/pkh#getDidPkhResolver'
       elem:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
     "@veramo/did-manager": "^5.1.2",
     "@veramo/did-provider-ethr": "^5.1.2",
     "@veramo/did-provider-key": "^5.1.2",
+    "@veramo/did-provider-peer": "^5.1.2",
     "@veramo/did-provider-pkh": "^5.1.2",
     "@veramo/did-provider-web": "^5.1.2",
     "@veramo/did-resolver": "^5.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,7 @@ importers:
       '@veramo/did-manager': ^5.1.2
       '@veramo/did-provider-ethr': ^5.1.2
       '@veramo/did-provider-key': ^5.1.2
+      '@veramo/did-provider-peer': ^5.1.2
       '@veramo/did-provider-pkh': ^5.1.2
       '@veramo/did-provider-web': ^5.1.2
       '@veramo/did-resolver': ^5.1.2
@@ -191,6 +192,7 @@ importers:
       '@veramo/did-manager': link:../did-manager
       '@veramo/did-provider-ethr': link:../did-provider-ethr
       '@veramo/did-provider-key': link:../did-provider-key
+      '@veramo/did-provider-peer': link:../did-provider-peer
       '@veramo/did-provider-pkh': link:../did-provider-pkh
       '@veramo/did-provider-web': link:../did-provider-web
       '@veramo/did-resolver': link:../did-resolver


### PR DESCRIPTION
## What issue is this PR fixing

Allows agent configs to use did-provider-peer package (e.g. to add did-peer resolver)

## What is being changed
- adds package to CLI dependencies
- adds did-peer resolver to default agent config
- Suppresses `ExperimentalWarning: Importing JSON modules` node warnings when running CLI

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

