### PR TITLE
fix: remove JSON.stringify for string credential

### DIFF
--- a/packages/credential-eip712/src/agent/CredentialEIP712.ts
+++ b/packages/credential-eip712/src/agent/CredentialEIP712.ts
@@ -218,7 +218,7 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
         if (typeof cred !== 'string' && cred.proof.jwt) {
           return cred.proof.jwt
         } else {
-          return JSON.stringify(cred)
+          return cred
         }
       })
       presentation.verifiableCredential = credentials

--- a/packages/credential-eip712/src/agent/CredentialEIP712.ts
+++ b/packages/credential-eip712/src/agent/CredentialEIP712.ts
@@ -215,10 +215,12 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
     if (args.presentation.verifiableCredential) {
       const credentials = args.presentation.verifiableCredential.map((cred) => {
         // map JWT credentials to their canonical form
-        if (typeof cred !== 'string' && cred.proof.jwt) {
+        if(typeof cred === 'string') {
+          return cred
+        } else if (cred.proof.jwt) {
           return cred.proof.jwt
         } else {
-          return cred
+          return JSON.stringify(cred)
         }
       })
       presentation.verifiableCredential = credentials


### PR DESCRIPTION
## What issue is this PR fixing
Fixes issue where a credential in string format is encoded as a string twice. 

## What is being changed
Removes JSON.stringify for string credential.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.
