### PR TITLE
feat: exporting didcomm mediator utils

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -173,7 +173,7 @@ export class Agent implements IAgent {
    * @public
    */
   async execute<P = any, R = any>(method: string, args: P): Promise<R> {
-    Debug('veramo:agent:' + method)('%o', args)
+    Debug('veramo:agent:' + method)('%s %o', 'arg', args)
     if (!this.methods[method]) throw Error('Method not available: ' + method)
     const _args = args || {}
     if (this.schemaValidation && this.schema.components.methods[method]) {
@@ -183,7 +183,7 @@ export class Agent implements IAgent {
     if (this.schemaValidation && this.schema.components.methods[method]) {
       validateReturnType(method, result, this.schema)
     }
-    Debug('veramo:agent:' + method + ':result')('%o', result)
+    Debug('veramo:agent:' + method)('%s %o', 'res', result)
     return result
   }
 

--- a/packages/did-comm/src/protocols/coordinate-mediation-message-handler.ts
+++ b/packages/did-comm/src/protocols/coordinate-mediation-message-handler.ts
@@ -9,10 +9,34 @@ const debug = Debug('veramo:did-comm:coordinate-mediation-message-handler')
 
 type IContext = IAgentContext<IDIDManager & IKeyManager & IDIDComm & IDataStore>
 
+/**
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
 export const MEDIATE_REQUEST_MESSAGE_TYPE = 'https://didcomm.org/coordinate-mediation/2.0/mediate-request'
+
+/**
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
 export const MEDIATE_GRANT_MESSAGE_TYPE = 'https://didcomm.org/coordinate-mediation/2.0/mediate-grant'
+
+/**
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
 export const MEDIATE_DENY_MESSAGE_TYPE = 'https://didcomm.org/coordinate-mediation/2.0/mediate-deny'
 
+/**
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
+export const STATUS_REQUEST_MESSAGE_TYPE = 'https://didcomm.org/messagepickup/3.0/status-request'
+
+/**
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
+export const DELIVERY_REQUEST_MESSAGE_TYPE = 'https://didcomm.org/messagepickup/3.0/delivery-request'
+
+/**
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
 export function createMediateRequestMessage(
   recipientDidUrl: string,
   mediatorDidUrl: string,
@@ -28,6 +52,9 @@ export function createMediateRequestMessage(
   }
 }
 
+/**
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
 export function createMediateGrantMessage(
   recipientDidUrl: string,
   mediatorDidUrl: string,
@@ -43,6 +70,40 @@ export function createMediateGrantMessage(
     body: {
       routing_did: [mediatorDidUrl],
     },
+  }
+}
+
+/**
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
+export function createStatusRequestMessage(
+  recipientDidUrl: string,
+  mediatorDidUrl: string,
+): IDIDCommMessage {
+  return {
+    id: v4(),
+    type: STATUS_REQUEST_MESSAGE_TYPE,
+    to: mediatorDidUrl,
+    from: recipientDidUrl,
+    return_route: 'all',
+    body: {},
+  }
+}
+
+/**
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
+export function createDeliveryRequestMessage(
+  recipientDidUrl: string,
+  mediatorDidUrl: string,
+): IDIDCommMessage {
+  return {
+    id: v4(),
+    type: DELIVERY_REQUEST_MESSAGE_TYPE,
+    to: mediatorDidUrl,
+    from: recipientDidUrl,
+    return_route: 'all',
+    body: { limit: 2 },
   }
 }
 

--- a/packages/did-comm/src/protocols/index.ts
+++ b/packages/did-comm/src/protocols/index.ts
@@ -1,4 +1,4 @@
 export { TrustPingMessageHandler } from './trust-ping-message-handler.js'
-export { CoordinateMediationMediatorMessageHandler, CoordinateMediationRecipientMessageHandler } from "./coordinate-mediation-message-handler.js"
+export * from "./coordinate-mediation-message-handler.js"
 export { RoutingMessageHandler } from "./routing-message-handler.js"
 export { PickupMediatorMessageHandler, PickupRecipientMessageHandler } from "./messagepickup-message-handler.js"


### PR DESCRIPTION
## What is being changed
* Exports `@veramo/did-comm` mediator utility methods
* Changes debug message format in the `agent.execute` method to be more readable

old:
```
veramo:agent:resolveDid {didUrl: 'did:web:dev-didcomm-mediator.herokuapp.com'} 
veramo:agent:resolveDid:result {didDocumentMetadata: {…}, didResolutionMetadata: {…}, didDocument: {…}}
```

new:
```
veramo:agent:resolveDid arg {didUrl: 'did:web:dev-didcomm-mediator.herokuapp.com'} 
veramo:agent:resolveDid res {didDocumentMetadata: {…}, didResolutionMetadata: {…}, didDocument: {…}}
```

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [ ] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [ ] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

## Details
If applicable, add screen captures, error messages or stack traces to help explain your problem.
