### PR TITLE
fix(cli): prevent `ExperimentalWarning` messages form being printed

### DIFF
--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -76,6 +76,8 @@ jobs:
     needs: [test-integration]
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v3
         with:
           name: coverage-artifacts

--- a/.github/workflows/build-test-publish-on-push.yml
+++ b/.github/workflows/build-test-publish-on-push.yml
@@ -83,6 +83,8 @@ jobs:
     needs: [test-integration]
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v3
         with:
           name: coverage-artifacts

--- a/packages/cli/bin/veramo.js
+++ b/packages/cli/bin/veramo.js
@@ -1,3 +1,16 @@
-#!/usr/bin/env node 
+#!/usr/bin/env node
+const originalEmit = process.emit;
+process.emit = function (name, data, ...args) {
+  if (
+    name === `warning` &&
+    typeof data === `object` &&
+    data.name === `ExperimentalWarning`
+    //if you want to only stop certain messages, test for the message here:
+    //&& data.message.includes(`Fetch API`)
+  ) {
+    return false;
+  }
+  return originalEmit.apply(process, arguments);
+};
 
 import '../build/cli.js'


### PR DESCRIPTION
## What is being changed
This removes the warnings that appear when working with the CLI after the ESM upgrade

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because we don't have a suitable CLI test suite.