### PR TITLE
feat: allow Secp256r1 key type

### DIFF
--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -130,7 +130,7 @@ export class CredentialPlugin implements IAgentPlugin {
       throw new Error('invalid_argument: presentation.holder must be a DID managed by this agent')
     }
     //FIXME: `args` should allow picking a key or key type
-    const key = identifier.keys.find((k) => k.type === 'Secp256k1' || k.type === 'Ed25519')
+    const key = identifier.keys.find((k) => k.type === 'Secp256k1' || k.type === 'Ed25519' || k.type === 'Secp256r1')
     if (!key) throw Error('key_not_found: No signing key for ' + identifier.did)
 
     let verifiablePresentation: VerifiablePresentation
@@ -165,9 +165,11 @@ export class CredentialPlugin implements IAgentPlugin {
       let alg = 'ES256K'
       if (key.type === 'Ed25519') {
         alg = 'EdDSA'
+      } else if (key.type === 'Secp256r1') {
+        alg = 'ES256'
       }
-      const signer = wrapSigner(context, key, alg)
 
+      const signer = wrapSigner(context, key, alg)
       const jwt = await createVerifiablePresentationJwt(
         presentation as any,
         { did: identifier.did, signer, alg },
@@ -236,14 +238,17 @@ export class CredentialPlugin implements IAgentPlugin {
         }
       } else {
         //FIXME: `args` should allow picking a key or key type
-        const key = identifier.keys.find((k) => k.type === 'Secp256k1' || k.type === 'Ed25519')
+        const key = identifier.keys.find((k) => k.type === 'Secp256k1' || k.type === 'Ed25519' || k.type === 'Secp256r1')
         if (!key) throw Error('No signing key for ' + identifier.did)
 
         debug('Signing VC with', identifier.did)
         let alg = 'ES256K'
         if (key.type === 'Ed25519') {
           alg = 'EdDSA'
+        } else if (key.type === 'Secp256r1') {
+          alg = 'ES256'
         }
+
         const signer = wrapSigner(context, key, alg)
         const jwt = await createVerifiableCredentialJwt(
           credential as any,


### PR DESCRIPTION
## What is being changed
Allows `Secp256r1` key type for verifiable credential and verifiable presentation creation.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.