### PR TITLE
fix: add support for publicKeyJwk

### DIFF
--- a/packages/utils/src/did-utils.ts
+++ b/packages/utils/src/did-utils.ts
@@ -86,9 +86,14 @@ export function compressIdentifierSecp256k1Keys(identifier: IIdentifier): IKey[]
  */
 function compareBlockchainAccountId(localKey: IKey, verificationMethod: VerificationMethod): boolean {
   if (
-    (verificationMethod.type !== 'EcdsaSecp256k1RecoveryMethod2020' &&
-      verificationMethod.type !== 'EcdsaSecp256k1VerificationKey2019') ||
-    localKey.type !== 'Secp256k1'
+    !(
+      verificationMethod.type === 'EcdsaSecp256k1RecoveryMethod2020' ||
+      verificationMethod.type === 'EcdsaSecp256k1VerificationKey2019' ||
+      (verificationMethod.type === 'JsonWebKey2020' &&
+        verificationMethod.publicKeyJwk &&
+        verificationMethod.publicKeyJwk.crv === 'secp256k1') ||
+      localKey.type === 'Secp256k1'
+    )
   ) {
     return false
   }


### PR DESCRIPTION
## What issue is this PR fixing

Adds support for publicKeyJwk and fixes issue 'key not found in document' when using `did:jwk`

## What is being changed

Changes structure of if statement (makes it more readable) in `compareBlockchainAccountId` and adds `JsonWebKey2020` to said if statement.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.
