### PR TITLE
chore(ci): update lerna.json workspaces

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -17,6 +17,5 @@
       "gitRemote": "origin",
       "message": "chore(release): %s [skip ci]"
     }
-  },
-  "useWorkspaces": true
+  }
 }


### PR DESCRIPTION
## What issue is this PR fixing

Lerna removed the `useWorkspaces` configuration and is failing builds that still have it. This PR removes that config, so that we get back release automation