### PR TITLE
Send `Accept` header to universal resolver

### DIFF
--- a/packages/did-resolver/src/universal-resolver.ts
+++ b/packages/did-resolver/src/universal-resolver.ts
@@ -43,7 +43,8 @@ export function getUniversalResolver(
 
   const resolve: DIDResolver = async (didUrl: string): Promise<DIDResolutionResult> => {
     try {
-      const result = await fetch(url + didUrl)
+      const headers = { 'Accept': 'application/ld+json;profile="https://w3id.org/did-resolution"' }
+      const result = await fetch(url + didUrl, { headers })
       const ddo = await result.json()
       return ddo
     } catch (e) {


### PR DESCRIPTION
## Issue

According to the latest draft of the DID Resolution standard (v0.3); if the value of the Accept HTTP header is absent, the HTTP response body should be the DID document and not the DID resolution.

To get the DID resolution as response, you should send the header

    Accept: application/ld+json;profile="https://w3id.org/did-resolution"

See https://w3c-ccg.github.io/did-resolution/#bindings-https

Universal Resolver does not follow this part of the standard and returns a DID resolution if the `Accept` header is omitted. To get a DID document, you must send the header

    Accept: application/did+ld+json

## Solution

By explicitly sending the `Accept` header, the `UniversalResolver` plugin can also be used for other services (like ours) that implement DID Resolution v0.3.

## What is being changed

An `Accept` header is added with the value `application/ld+json;profile="https://w3id.org/did-resolution"` when doing the HTTP request in `resolve`.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [x] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because there are no existing tests for this class, ~~and I am aware that a PR without tests will likely get rejected~~.

## Details

![screenshot-w3c-ccg github io-2023 07 21-20_32_06](https://github.com/uport-project/veramo/assets/100821/37c33226-a00d-440c-a3cf-0003c5dd478a)
