### PR TITLE
Allow DID parameters for verifiable credentials and presentations

### DIFF
--- a/packages/cli/src/explore/utils.ts
+++ b/packages/cli/src/explore/utils.ts
@@ -3,6 +3,7 @@ import os from 'os'
 
 export function shortDid(did?: string): string {
   if (!did) return ''
+  did = did.replace(/\?.*$/, '')
   if (did.slice(0, 7) === 'did:web') {
     return did
   }

--- a/packages/credential-eip712/src/agent/CredentialEIP712.ts
+++ b/packages/credential-eip712/src/agent/CredentialEIP712.ts
@@ -14,6 +14,7 @@ import {
   MANDATORY_CREDENTIAL_CONTEXT,
   mapIdentifierKeysToDoc,
   processEntryToArray,
+  removeDIDParameters,
   resolveDidOrThrow,
 } from '@veramo/utils'
 import schema from "../plugin.schema.json" assert { type: 'json' }
@@ -63,7 +64,7 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
       issuanceDate = issuanceDate.toISOString()
     }
 
-    const issuer = extractIssuer(args.credential)
+    const issuer = extractIssuer(args.credential, { removeParameters: true })
     if (!issuer || typeof issuer === 'undefined') {
       throw new Error('invalid_argument: credential.issuer must not be empty')
     }
@@ -226,9 +227,11 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
       presentation.verifiableCredential = credentials
     }
 
+    const holder = removeDIDParameters(presentation.holder)
+
     let identifier: IIdentifier
     try {
-      identifier = await context.agent.didManagerGet({ did: presentation.holder })
+      identifier = await context.agent.didManagerGet({ did: holder })
     } catch (e) {
       throw new Error('invalid_argument: presentation.holder must be a DID managed by this agent')
     }

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -35,6 +35,7 @@ import { decodeJWT } from 'did-jwt'
 import {
   asArray,
   extractIssuer,
+  removeDIDParameters,
   isDefined,
   MANDATORY_CREDENTIAL_CONTEXT,
   processEntryToArray,
@@ -123,9 +124,11 @@ export class CredentialPlugin implements IAgentPlugin {
       })
     }
 
+    const holder = removeDIDParameters(presentation.holder)
+
     let identifier: IIdentifier
     try {
-      identifier = await context.agent.didManagerGet({ did: presentation.holder })
+      identifier = await context.agent.didManagerGet({ did: holder })
     } catch (e) {
       throw new Error('invalid_argument: presentation.holder must be a DID managed by this agent')
     }
@@ -205,7 +208,7 @@ export class CredentialPlugin implements IAgentPlugin {
     }
 
     //FIXME: if the identifier is not found, the error message should reflect that.
-    const issuer = extractIssuer(credential)
+    const issuer = extractIssuer(credential, { removeParameters: true })
     if (!issuer || typeof issuer === 'undefined') {
       throw new Error('invalid_argument: credential.issuer must not be empty')
     }

--- a/packages/selective-disclosure/src/action-handler.ts
+++ b/packages/selective-disclosure/src/action-handler.ts
@@ -202,7 +202,7 @@ export class SelectiveDisclosure implements IAgentPlugin {
 
           if (
             credentialRequest.issuers &&
-            !credentialRequest.issuers.map((i) => i.did).includes(extractIssuer(credential))
+            !credentialRequest.issuers.map((i) => i.did).includes(extractIssuer(credential, { removeParameters: true }))
           ) {
             return false
           }

--- a/packages/utils/src/__tests__/credential-utils.test.ts
+++ b/packages/utils/src/__tests__/credential-utils.test.ts
@@ -225,6 +225,12 @@ describe('@veramo/utils credential utils', () => {
         type: 'fake',
       },
     }
+    const ldCred3 = {
+      issuer: 'did:key:z6MkvGFkoFarw7pXRBkKqZKwDcc2L3U4AZC1RtBiceicUHqn?versionTime=2023-01-01T00:00:00Z',
+      proof: {
+        type: 'fake',
+      },
+    }
     const ldPres = {
       holder: 'did:key:z6MkvGFkoFarw7pXRBkKqZKwDcc2L3U4AZC1RtBiceicUHqn',
       proof: {
@@ -235,6 +241,8 @@ describe('@veramo/utils credential utils', () => {
       'eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7InlvdSI6IlJvY2sifX0sInN1YiI6ImRpZDp3ZWI6ZXhhbXBsZS5jb20iLCJuYmYiOjE2Mzc2ODAzMTcsImlzcyI6ImRpZDpldGhyOnJpbmtlYnk6MHgwMmY2NDk1NWRkMDVkZGU1NTkxMGYzNzllYzU3ODVlZWUwOGJiZTZlNTBkZGFlNmJhY2UwNTk2ZmQ4ZDQ2MDE4ZjcifQ.ujM4zNm8h5-Cg01vh4ka_7NmdwYl8HAjO90XjxYYwSa0-4rqzM5ndt-OE6vS6y0gPwhwlQWHmDxg4X7OTzCUoQ'
     expect(extractIssuer(ldCred1)).toEqual('did:key:z6MkvGFkoFarw7pXRBkKqZKwDcc2L3U4AZC1RtBiceicUHqn')
     expect(extractIssuer(ldCred2)).toEqual('did:key:z6MkvGFkoFarw7pXRBkKqZKwDcc2L3U4AZC1RtBiceicUHqn')
+    expect(extractIssuer(ldCred3)).toEqual('did:key:z6MkvGFkoFarw7pXRBkKqZKwDcc2L3U4AZC1RtBiceicUHqn?versionTime=2023-01-01T00:00:00Z')
+    expect(extractIssuer(ldCred3, { removeParameters: true })).toEqual('did:key:z6MkvGFkoFarw7pXRBkKqZKwDcc2L3U4AZC1RtBiceicUHqn')
     expect(extractIssuer(ldPres)).toEqual('did:key:z6MkvGFkoFarw7pXRBkKqZKwDcc2L3U4AZC1RtBiceicUHqn')
     expect(extractIssuer(jwt)).toEqual(
       'did:ethr:rinkeby:0x02f64955dd05dde55910f379ec5785eee08bbe6e50ddae6bace0596fd8d46018f7',

--- a/packages/utils/src/credential-utils.ts
+++ b/packages/utils/src/credential-utils.ts
@@ -104,6 +104,8 @@ export function computeEntryHash(
  * `iss` from a JWT or `issuer`/`issuer.id` from a VC or `holder` from a VP
  *
  * @param input - the credential or presentation whose issuer/holder needs to be extracted.
+ * @param options
+ *   removeParameters - Remove all DID parameters from the issuer ID
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
@@ -114,6 +116,7 @@ export function extractIssuer(
     | CredentialPayload
     | PresentationPayload
     | null,
+  options: { removeParameters?: boolean } = {}
 ): string {
   if (!isDefined(input)) {
     return ''
@@ -121,7 +124,8 @@ export function extractIssuer(
     // JWT
     try {
       const { payload } = decodeJWT(input)
-      return payload.iss || ''
+      const iss = payload.iss || ''
+      return !!options.removeParameters ? removeDIDParameters(iss) : iss
     } catch (e: any) {
       return ''
     }
@@ -135,6 +139,18 @@ export function extractIssuer(
     } else {
       iss = ''
     }
-    return typeof iss === 'string' ? iss : iss?.id || ''
+    if (typeof iss !== 'string') iss = iss.id || ''
+    return !!options.removeParameters ? removeDIDParameters(iss) : iss
   }
+}
+
+/**
+ * Remove all DID parameters from a DID url
+ *
+ * @param did - the DID URL
+ *
+ * @beta This API may change without a BREAKING CHANGE notice.
+ */
+export function removeDIDParameters(did: string): string {
+  return did.replace(/\?.+$/, '')
 }


### PR DESCRIPTION
Fixes #1201

```
{
  credential: {
    issuer: { id: `${identifier.did}?versionTime=${versionTime}` },
    credentialSubject: {
      id: 'did:web:example.com',
      you: 'Rock',
    },
  },
  proofFormat: 'jwt',
}
```

Remove DID parameters in the `issuer` and `holder` properties when looking up the identifier using the DID manager. The DID manager doesn't handle DID parameters like `versionTime`. When the DID manager is used we should be able to safely ignore them. They're only used when resolving the DID.

## What is being changed

Added `options` property to `extractIssuer`, with option `removeParameters`. Added a `removeDIDParameters` function to credential-utils.

The `credentials-w3c`, `credentials-ld`, and `credentials-jwt` plugins all remove the DID parameters before looking up the identifier via the DID manager. If the DID is resolved, the parameters are not removed.

Modified `shortDid` to always remove parameters.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [X] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

No tests for:
* `credentials-jwt`, because there are no existing tests
* `credentials-ld` doesn't mock services, making it hard to test this feature
