### PR TITLE
fix(ci): benign change meant to tag all packages for another patch release

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -125,8 +125,8 @@
   "contributors": [
     "Mircea Nistor <mircea.nistor@mesh.xyz"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -57,8 +57,8 @@
   "contributors": [
     "Mircea Nistor <mircea.nistor@mesh.xyz>"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,8 +38,8 @@
   "contributors": [
     "Mircea Nistor <mircea.nistor@mesh.xyz>"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/credential-eip712/package.json
+++ b/packages/credential-eip712/package.json
@@ -50,8 +50,8 @@
       "email": "italo.borssatto@mesh.xyz"
     }
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/credential-ld/package.json
+++ b/packages/credential-ld/package.json
@@ -55,8 +55,8 @@
   },
   "repository": "git@github.com:uport-project/veramo.git",
   "author": "Mircea Nistor <mircea.nistor@mesh.xyz>",
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/credential-status/package.json
+++ b/packages/credential-status/package.json
@@ -33,8 +33,8 @@
   "repository": "git@github.com:uport-project/veramo.git",
   "author": "Konstantin Tsabolov <konstantin.tsabolov@spherity.com>",
   "contributors": [],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/credential-w3c/package.json
+++ b/packages/credential-w3c/package.json
@@ -46,8 +46,8 @@
   "contributors": [
     "Mircea Nistor <mircea.nistor@mesh.xyz>"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/data-store-json/package.json
+++ b/packages/data-store-json/package.json
@@ -37,8 +37,8 @@
   },
   "repository": "git@github.com:uport-project/veramo.git",
   "author": "Mircea Nistor <mircea.nistor@mesh.xyz>",
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/data-store/package.json
+++ b/packages/data-store/package.json
@@ -39,7 +39,7 @@
   "contributors": [
     "Mircea Nistor <mircea.nistor@mesh.xyz>"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module"
 }

--- a/packages/did-comm/package.json
+++ b/packages/did-comm/package.json
@@ -55,8 +55,8 @@
     "Mircea Nistor <mircea.nistor@mesh.xyz",
     "Oliver Terbu <oliver.terbu@mesh.xyz"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/did-discovery/package.json
+++ b/packages/did-discovery/package.json
@@ -47,7 +47,7 @@
       "email": "oliver.terbu@mesh.xyz"
     }
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module"
 }

--- a/packages/did-jwt/package.json
+++ b/packages/did-jwt/package.json
@@ -37,8 +37,8 @@
       "email": "mircea.nistor@mesh.xyz"
     }
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/did-manager/package.json
+++ b/packages/did-manager/package.json
@@ -33,8 +33,8 @@
       "email": "mircea.nistor@mesh.xyz"
     }
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/did-provider-ethr/package.json
+++ b/packages/did-provider-ethr/package.json
@@ -45,8 +45,8 @@
       "email": "mircea.nistor@mesh.xyz"
     }
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/did-provider-ion/package.json
+++ b/packages/did-provider-ion/package.json
@@ -47,12 +47,12 @@
   },
   "repository": "git@github.com:uport-project/veramo.git",
   "author": "Sphereon <dev@sphereon.com>",
-  "license": "Apache-2.0",
   "keywords": [
     "Veramo",
     "ION",
     "DID"
   ],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/did-provider-jwk/package.json
+++ b/packages/did-provider-jwk/package.json
@@ -25,8 +25,8 @@
     "typescript": "5.1.3"
   },
   "author": "Tadej Podrekar",
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "files": [
     "build/**/*",
     "src/**/*",

--- a/packages/did-provider-key/package.json
+++ b/packages/did-provider-key/package.json
@@ -42,8 +42,8 @@
   "contributors": [
     "Mircea Nistor <mircea.nistor@mesh.xyz"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/did-provider-peer/package.json
+++ b/packages/did-provider-peer/package.json
@@ -40,8 +40,8 @@
   "contributors": [
     "Alex Andrei <alex.andrei@rootsid.com>"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/did-provider-pkh/package.json
+++ b/packages/did-provider-pkh/package.json
@@ -36,8 +36,8 @@
   "repository": "git@github.com:uport-project/veramo.git",
   "author": "Diego Chagastelles <dchagastelles@gmail.com>",
   "contributors": [],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/did-provider-web/package.json
+++ b/packages/did-provider-web/package.json
@@ -32,8 +32,8 @@
   "contributors": [
     "Mircea Nistor <mircea.nistor@mesh.xyz>"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/did-resolver/package.json
+++ b/packages/did-resolver/package.json
@@ -36,8 +36,8 @@
   "contributors": [
     "Mircea Nistor <mircea.nistor@mesh.xyz"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/key-manager/package.json
+++ b/packages/key-manager/package.json
@@ -44,8 +44,8 @@
       "email": "mircea.nistor@mesh.xyz"
     }
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/kms-local/package.json
+++ b/packages/kms-local/package.json
@@ -47,8 +47,8 @@
       "email": "mircea.nistor@mesh.xyz"
     }
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/kms-web3/package.json
+++ b/packages/kms-web3/package.json
@@ -38,8 +38,8 @@
       "email": "mircea.nistor@mesh.xyz"
     }
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/kv-store/package.json
+++ b/packages/kv-store/package.json
@@ -46,12 +46,12 @@
   },
   "repository": "git@github.com:uport-project/veramo.git",
   "author": "Niels Klomp <nklomp@sphereon.com>",
-  "license": "Apache-2.0",
   "keywords": [
     "Veramo",
     "Key Value Store",
     "keyv"
   ],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/message-handler/package.json
+++ b/packages/message-handler/package.json
@@ -34,8 +34,8 @@
       "email": "mircea.nistor@mesh.xyz"
     }
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/remote-client/package.json
+++ b/packages/remote-client/package.json
@@ -33,8 +33,8 @@
   "contributors": [
     "Mircea Nistor <mircea.nistor@mesh.xyz>"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/remote-server/package.json
+++ b/packages/remote-server/package.json
@@ -48,8 +48,8 @@
       "email": "mircea.nistor@mesh.xyz"
     }
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/selective-disclosure/package.json
+++ b/packages/selective-disclosure/package.json
@@ -45,8 +45,8 @@
   "contributors": [
     "Mircea Nistor mircea.nistor@mesh.xyz"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/url-handler/package.json
+++ b/packages/url-handler/package.json
@@ -36,8 +36,8 @@
   "contributors": [
     "Mircea Nistor <mircea.nistor@mesh.xyz"
   ],
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -39,8 +39,8 @@
   },
   "repository": "git@github.com:uport-project/veramo.git",
   "author": "Mircea Nistor <mircea.nistor@mesh.xyz>",
-  "license": "Apache-2.0",
   "keywords": [],
+  "license": "Apache-2.0",
   "type": "module",
   "moduleDirectories": [
     "node_modules",


### PR DESCRIPTION
We currently use `lerna` to trigger releases of the `@veramo/*` packages in tandem. Lerna skips minor or patch releases for packages that don't have changes, even if we instruct it to keep all package versions in sync.

To work around this limitation, this PR adds some irrelevant changes to all the packages so they will get included in the next version bump.