### PR TITLE
feat(selective-disclosure): support multiple key types for generating requests

### DIFF
--- a/__tests__/shared/handleSdrMessage.ts
+++ b/__tests__/shared/handleSdrMessage.ts
@@ -34,7 +34,7 @@ export default (testContext: {
     afterAll(testContext.tearDown)
 
     it('should create identifier', async () => {
-      identifier = await agent.didManagerCreate({ kms: 'local', provider: 'did:ethr' })
+      identifier = await agent.didManagerCreate({ kms: 'local', provider: 'did:key' })
       expect(identifier).toHaveProperty('did')
     })
 
@@ -80,6 +80,85 @@ export default (testContext: {
       }
 
       expect(message.raw).toEqual(JWT)
+    })
+
+    it('should create and handle an SDR message with Ed25519', async () => {
+      const sdrIssuer = await agent.didManagerCreate({ provider: 'did:key', options: { keyType: 'Ed25519' } })
+      const req = await agent.createSelectiveDisclosureRequest({
+        data: {
+          issuer: sdrIssuer.did,
+          tag: 'sdr-one',
+          claims: [
+            {
+              reason: 'We need it',
+              claimType: 'name',
+              essential: true,
+            },
+          ],
+        },
+      })
+
+      const message = await agent.handleMessage({
+        raw: req,
+        save: false,
+      })
+
+      expect(message.raw).toEqual(req)
+    })
+
+    it('should create and handle an SDR message with Secp256k1', async () => {
+      const sdrIssuer = await agent.didManagerCreate({
+        provider: 'did:ethr',
+      })
+      const req = await agent.createSelectiveDisclosureRequest({
+        data: {
+          issuer: sdrIssuer.did,
+          tag: 'sdr-one',
+          claims: [
+            {
+              reason: 'We need it',
+              claimType: 'name',
+              essential: true,
+            },
+          ],
+        },
+      })
+
+      const message = await agent.handleMessage({
+        raw: req,
+        save: false,
+      })
+
+      expect(message.raw).toEqual(req)
+    })
+
+    it('should create and handle an SDR message with Secp256r1', async () => {
+      const sdrIssuer = await agent.didManagerCreate({
+        provider: 'did:jwk',
+        options: {
+          keyType: 'Secp256r1',
+        }
+      })
+      const req = await agent.createSelectiveDisclosureRequest({
+        data: {
+          issuer: sdrIssuer.did,
+          tag: 'sdr-one',
+          claims: [
+            {
+              reason: 'We need it',
+              claimType: 'name',
+              essential: true,
+            },
+          ],
+        },
+      })
+
+      const message = await agent.handleMessage({
+        raw: req,
+        save: false,
+      })
+
+      expect(message.raw).toEqual(req)
     })
 
     it('should be able to find the request message', async () => {

--- a/packages/core-types/src/plugin.schema.json
+++ b/packages/core-types/src/plugin.schema.json
@@ -549,11 +549,15 @@
             "algorithms": {
               "type": "array",
               "items": {
-                "type": "string"
+                "$ref": "#/components/schemas/TAlg"
               }
             }
           },
           "description": "This encapsulates data about a key.\n\nImplementations of  {@link  @veramo/key-manager#AbstractKeyManagementSystem | AbstractKeyManagementSystem }  should populate this object, for each key, with the algorithms that can be performed using it.\n\nThis can also be used to add various tags to the keys under management."
+        },
+        "TAlg": {
+          "type": "string",
+          "description": "Known algorithms supported by some of the above key types defined by  {@link  TKeyType } .\n\nActual implementations of  {@link  @veramo/key-manager#AbstractKeyManagementSystem | Key Management Systems }  can support more. One should check the  {@link  IKey.meta.algorithms  }  property to see what is possible for a particular managed key."
         },
         "ManagedKeyInfo": {
           "type": "object",
@@ -736,7 +740,7 @@
             "type",
             "publicKeyHex"
           ],
-          "description": "Cryptographic key"
+          "description": "Cryptographic key, usually managed by the current Veramo instance."
         },
         "MinimalImportableKey": {
           "$ref": "#/components/schemas/RequireOnly<IKey,(\"privateKeyHex\"|\"type\"|\"kms\")>",
@@ -1099,7 +1103,7 @@
             "type",
             "publicKeyHex"
           ],
-          "description": "Cryptographic key"
+          "description": "Cryptographic key, usually managed by the current Veramo instance."
         },
         "TKeyType": {
           "type": "string",
@@ -1119,11 +1123,15 @@
             "algorithms": {
               "type": "array",
               "items": {
-                "type": "string"
+                "$ref": "#/components/schemas/TAlg"
               }
             }
           },
           "description": "This encapsulates data about a key.\n\nImplementations of  {@link  @veramo/key-manager#AbstractKeyManagementSystem | AbstractKeyManagementSystem }  should populate this object, for each key, with the algorithms that can be performed using it.\n\nThis can also be used to add various tags to the keys under management."
+        },
+        "TAlg": {
+          "type": "string",
+          "description": "Known algorithms supported by some of the above key types defined by  {@link  TKeyType } .\n\nActual implementations of  {@link  @veramo/key-manager#AbstractKeyManagementSystem | Key Management Systems }  can support more. One should check the  {@link  IKey.meta.algorithms  }  property to see what is possible for a particular managed key."
         },
         "IDIDManagerAddServiceArgs": {
           "type": "object",
@@ -2776,7 +2784,7 @@
             "type",
             "publicKeyHex"
           ],
-          "description": "Cryptographic key"
+          "description": "Cryptographic key, usually managed by the current Veramo instance."
         },
         "TKeyType": {
           "type": "string",
@@ -2796,11 +2804,15 @@
             "algorithms": {
               "type": "array",
               "items": {
-                "type": "string"
+                "$ref": "#/components/schemas/TAlg"
               }
             }
           },
           "description": "This encapsulates data about a key.\n\nImplementations of  {@link  @veramo/key-manager#AbstractKeyManagementSystem | AbstractKeyManagementSystem }  should populate this object, for each key, with the algorithms that can be performed using it.\n\nThis can also be used to add various tags to the keys under management."
+        },
+        "TAlg": {
+          "type": "string",
+          "description": "Known algorithms supported by some of the above key types defined by  {@link  TKeyType } .\n\nActual implementations of  {@link  @veramo/key-manager#AbstractKeyManagementSystem | Key Management Systems }  can support more. One should check the  {@link  IKey.meta.algorithms  }  property to see what is possible for a particular managed key."
         },
         "IService": {
           "type": "object",

--- a/packages/core-types/src/types/IIdentifier.ts
+++ b/packages/core-types/src/types/IIdentifier.ts
@@ -54,7 +54,33 @@ export type MinimalImportableIdentifier = {
 export type TKeyType = 'Ed25519' | 'Secp256k1' | 'Secp256r1' | 'X25519' | 'Bls12381G1' | 'Bls12381G2'
 
 /**
- * Cryptographic key
+ * Known algorithms supported by some of the above key types defined by {@link TKeyType}.
+ *
+ * Actual implementations of {@link @veramo/key-manager#AbstractKeyManagementSystem | Key Management Systems} can
+ * support more. One should check the {@link IKey.meta.algorithms} property to see what is possible
+ * for a particular managed key.
+ *
+ * @public
+ */
+export type TAlg = 'ES256K' | 'ES256K-R' | 'ES256' | 'EdDSA' | 'ECDH' | 'ECDH-ES' | 'ECDH-1PU' | string
+
+/**
+ * Mapping of known key types({@link TKeyType}) to the known algorithms({@link TAlg}) they should support.
+ *
+ * @public
+ */
+export const KEY_ALG_MAPPING: Record<TKeyType, ReadonlyArray<TAlg>> = {
+  Secp256k1: ['ES256K', 'ES256K-R'],
+  Secp256r1: ['ES256', 'ECDH', 'ECDH-ES', 'ECDH-1PU'],
+  Ed25519: ['EdDSA'],
+  X25519: ['ECDH', 'ECDH-ES', 'ECDH-1PU'],
+  Bls12381G1: [],
+  Bls12381G2: [],
+} as const
+
+/**
+ * Cryptographic key, usually managed by the current Veramo instance.
+ *
  * @public
  */
 export interface IKey {
@@ -100,7 +126,7 @@ export interface IKey {
  * @public
  */
 export interface KeyMetadata {
-  algorithms?: string[]
+  algorithms?: TAlg[]
 
   [x: string]: any
 }

--- a/packages/kms-local/src/key-management-system.ts
+++ b/packages/kms-local/src/key-management-system.ts
@@ -1,4 +1,11 @@
-import { IKey, ManagedKeyInfo, MinimalImportableKey, RequireOnly, TKeyType } from '@veramo/core-types'
+import {
+  IKey,
+  KEY_ALG_MAPPING,
+  ManagedKeyInfo,
+  MinimalImportableKey,
+  RequireOnly,
+  TKeyType,
+} from '@veramo/core-types'
 import {
   AbstractKeyManagementSystem,
   AbstractPrivateKeyStore,
@@ -8,6 +15,7 @@ import {
 
 import { EdDSASigner, ES256KSigner, ES256Signer } from 'did-jwt'
 import { ed25519, x25519 } from '@noble/curves/ed25519'
+import { p256 } from '@noble/curves/p256'
 import { TransactionRequest } from '@ethersproject/abstract-provider'
 import { toUtf8String } from '@ethersproject/strings'
 import { parse } from '@ethersproject/transactions'
@@ -16,7 +24,6 @@ import { SigningKey } from '@ethersproject/signing-key'
 import { randomBytes } from '@ethersproject/random'
 import { arrayify, hexlify } from '@ethersproject/bytes'
 import Debug from 'debug'
-import { p256 } from '@noble/curves/p256'
 import {
   bytesToHex,
   concat,
@@ -302,7 +309,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
           kid: args.alias || publicKeyHex,
           publicKeyHex,
           meta: {
-            algorithms: ['Ed25519', 'EdDSA'],
+            algorithms: [...KEY_ALG_MAPPING[args.type], 'Ed25519'],
           },
         }
         break
@@ -317,8 +324,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
           publicKeyHex,
           meta: {
             algorithms: [
-              'ES256K',
-              'ES256K-R',
+              ...KEY_ALG_MAPPING[args.type],
               'eth_signTransaction',
               'eth_signTypedData',
               'eth_signMessage',
@@ -336,7 +342,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
           kid: args.alias || publicKeyHex,
           publicKeyHex,
           meta: {
-            algorithms: ['ES256'],
+            algorithms: ['ES256'], // ECDH not supported yet by this KMS
           },
         }
         break
@@ -349,7 +355,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
           kid: args.alias || publicKeyHex,
           publicKeyHex: publicKeyHex,
           meta: {
-            algorithms: ['ECDH', 'ECDH-ES', 'ECDH-1PU'],
+            algorithms: [...KEY_ALG_MAPPING[args.type]],
           },
         }
         break

--- a/packages/utils/src/__tests__/utils.test.ts
+++ b/packages/utils/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { asArray, isDefined } from '../type-utils.js'
+import { asArray, intersect, isDefined } from '../type-utils.js'
 
 describe('@veramo/utils type utils', () => {
   it('isDefined should return correct results', () => {
@@ -19,5 +19,24 @@ describe('@veramo/utils type utils', () => {
     expect(asArray(['a', 'b'])).toEqual(['a', 'b'])
     expect(asArray(undefined)).toEqual([])
     expect(asArray(null)).toEqual([])
+  })
+
+  describe('intersect', () => {
+    it('should work with primitive types', () => {
+      expect(intersect(['a'], ['b'])).toStrictEqual([])
+      expect(intersect(['a', 'a'], ['b'])).toStrictEqual([])
+      expect(intersect(['a', 'a', 'b'], ['b'])).toStrictEqual(['b'])
+      expect(intersect(['a', 'a', 'b'], ['b', 'a'])).toStrictEqual(['a', 'b'])
+      expect(intersect(['a', 'a', 'b', 1], ['b', 'a', 2])).toStrictEqual(['a', 'b'])
+      expect(intersect(['a', 'a', 'b', 1], ['b', 1, 2])).toStrictEqual(['b', 1])
+      expect(intersect([1, false], [true])).toStrictEqual([])
+      expect(intersect([1, false, null], [true, null])).toStrictEqual([null])
+      expect(intersect([1, false, undefined], [true, undefined])).toStrictEqual([undefined])
+      expect(intersect([1], [true])).toStrictEqual([])
+    })
+
+    it('does not work with objects since references are different', () => {
+      expect(intersect([{}], [{}])).toStrictEqual([])
+    })
   })
 })

--- a/packages/utils/src/type-utils.ts
+++ b/packages/utils/src/type-utils.ts
@@ -33,3 +33,17 @@ export function asArray<T>(arg?: T | T[] | any): (T | any)[] {
 export function isIterable<T>(obj: any): obj is Iterable<T> {
   return obj != null && typeof obj[Symbol.iterator] === 'function'
 }
+
+/**
+ * Compute the intersection of two arrays
+ * Elements are compared by reference so object types will appear as unique even if they contain the same data.
+ *
+ * @param a - first array
+ * @param b - second array
+ * @returns The intersection of the two arrays.
+ *
+ */
+export function intersect<T>(a: T[] | any, b: any[] | any): T[] {
+  const setB = new Set<T>(asArray(b));
+  return [...new Set(asArray(a))].filter(x => setB.has(x));
+}


### PR DESCRIPTION
## What issue is this PR fixing

fixes #946

## What is being changed

Added support for Ed25519 and Secp256r1 keys as signers of selective disclosure requests.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [x] I added unit tests.
* [X] I added integration tests.
