### PR TITLE
test: diversify default DID providers in tests to increase coverage

### DIFF
--- a/__tests__/initial.migration.test.ts
+++ b/__tests__/initial.migration.test.ts
@@ -107,7 +107,7 @@ describe('database initial migration tests', () => {
             }),
             new DIDManager({
               store: new DIDStore(dbConnection),
-              defaultProvider: 'did:ethr:goerli',
+              defaultProvider: 'did:key',
               providers: {
                 // intentionally using deprecated config for backward compatibility checks
                 'did:ethr:goerli': new EthrDIDProvider({

--- a/__tests__/localAgent.test.ts
+++ b/__tests__/localAgent.test.ts
@@ -165,7 +165,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
       }),
       new DIDManager({
         store: new DIDStore(dbConnection),
-        defaultProvider: 'did:ethr:goerli',
+        defaultProvider: 'did:ethr:ganache',
         providers: {
           'did:ethr': new EthrDIDProvider({
             defaultKms: 'local',

--- a/__tests__/localJsonStoreAgent.test.ts
+++ b/__tests__/localJsonStoreAgent.test.ts
@@ -134,7 +134,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
       }),
       new DIDManager({
         store: new DIDStoreJson(jsonFileStore),
-        defaultProvider: 'did:ethr:goerli',
+        defaultProvider: 'did:ethr',
         providers: {
           'did:ethr': new EthrDIDProvider({
             defaultKms: 'local',

--- a/__tests__/localMemoryStoreAgent.test.ts
+++ b/__tests__/localMemoryStoreAgent.test.ts
@@ -131,7 +131,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
       }),
       new DIDManager({
         store: new MemoryDIDStore(),
-        defaultProvider: 'did:ethr:goerli',
+        defaultProvider: 'did:key',
         providers: {
           'did:ethr': new EthrDIDProvider({
             defaultKms: 'local',

--- a/__tests__/restAgent.test.ts
+++ b/__tests__/restAgent.test.ts
@@ -161,7 +161,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
       }),
       new DIDManager({
         store: new DIDStore(dbConnection),
-        defaultProvider: 'did:ethr:goerli',
+        defaultProvider: 'did:jwk',
         providers: {
           'did:ethr': new EthrDIDProvider({
             defaultKms: 'local',

--- a/__tests__/shared/credentialStatus.ts
+++ b/__tests__/shared/credentialStatus.ts
@@ -69,7 +69,11 @@ export default (testContext: {
         ],
       })
       agent = testContext.getAgent()
-      identifier = await agent.didManagerCreate({ kms: 'local' })
+      identifier = await agent.didManagerCreate({
+        kms: 'local',
+        provider: 'did:pkh',
+        options: { keyType: 'Secp256k1' },
+      })
 
       rawCredential = buildCredential(identifier, {
         type: 'ExoticStatusMethod2022',
@@ -208,7 +212,7 @@ export default (testContext: {
         plugins: [],
       })
       agent = testContext.getAgent()
-      identifier = await agent.didManagerCreate({ kms: 'local' })
+      identifier = await agent.didManagerCreate({ kms: 'local', provider: 'did:jwk' })
 
       rawCredential = {
         issuer: { id: identifier.did },
@@ -234,7 +238,6 @@ export default (testContext: {
       })
       expect(vc).toHaveProperty('proof.jwt')
 
-      // TODO It`s an exception flow an it'd be better to throw an exception instead of returning false
       await expect(agent.verifyCredential({ credential: vc })).rejects.toThrow(
         `invalid_setup: The credential status can't be verified because there is no ICredentialStatusVerifier plugin installed.`,
       )

--- a/__tests__/shared/didManager.ts
+++ b/__tests__/shared/didManager.ts
@@ -223,13 +223,6 @@ export default (testContext: {
       })
 
       expect(identifier6).toEqual(identifier5)
-
-      const identifier7 = await agent.didManagerGetByAlias({
-        alias: 'alice',
-        // default provider is 'did:ethr:goerli'
-      })
-
-      expect(identifier7).toEqual(identifier4)
     })
 
     it('should get identifiers', async () => {

--- a/__tests__/shared/documentationExamples.ts
+++ b/__tests__/shared/documentationExamples.ts
@@ -39,7 +39,7 @@ export default (testContext: {
     //DO NOT EDIT MANUALLY START
 
     it('core-types-IResolver-getDIDComponentById example', async () => {
-      const did = 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190'
+      const did = 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190'
       const didFragment = `${did}#controller`
       const fragment = await agent.getDIDComponentById({
         didDocument: (await agent.resolveDid({ didUrl: did }))?.didDocument,
@@ -47,33 +47,33 @@ export default (testContext: {
         section: 'authentication',
       })
       expect(fragment).toEqual({
-        id: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller',
+        id: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller',
         type: 'EcdsaSecp256k1RecoveryMethod2020',
-        controller: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
-        blockchainAccountId: 'eip155:5:0xb09B66026bA5909A7CFE99b76875431D2b8D5190',
+        controller: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
+        blockchainAccountId: 'eip155:1:0xb09B66026bA5909A7CFE99b76875431D2b8D5190',
       })
     })
 
     it('core-types-IResolver-resolveDid example', async () => {
       const doc = await agent.resolveDid({
-        didUrl: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
+        didUrl: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
       })
       expect(doc.didDocument).toEqual({
         '@context': [
           'https://www.w3.org/ns/did/v1',
           'https://w3id.org/security/suites/secp256k1recovery-2020/v2',
         ],
-        id: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
+        id: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
         verificationMethod: [
           {
-            id: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller',
+            id: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller',
             type: 'EcdsaSecp256k1RecoveryMethod2020',
-            controller: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
-            blockchainAccountId: 'eip155:5:0xb09B66026bA5909A7CFE99b76875431D2b8D5190',
+            controller: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
+            blockchainAccountId: 'eip155:1:0xb09B66026bA5909A7CFE99b76875431D2b8D5190',
           },
         ],
-        authentication: ['did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller'],
-        assertionMethod: ['did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller'],
+        authentication: ['did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller'],
+        assertionMethod: ['did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller'],
       })
     })
 

--- a/__tests__/shared/handleSdrMessage.ts
+++ b/__tests__/shared/handleSdrMessage.ts
@@ -34,7 +34,7 @@ export default (testContext: {
     afterAll(testContext.tearDown)
 
     it('should create identifier', async () => {
-      identifier = await agent.didManagerCreate({ kms: 'local' })
+      identifier = await agent.didManagerCreate({ kms: 'local', provider: 'did:ethr' })
       expect(identifier).toHaveProperty('did')
     })
 

--- a/__tests__/shared/keyManager.ts
+++ b/__tests__/shared/keyManager.ts
@@ -1,6 +1,13 @@
 // noinspection ES6PreferShortImport
 
-import { IAgentOptions, IDIDManager, IKeyManager, IResolver, TAgent, TKeyType } from '../../packages/core-types/src'
+import {
+  IAgentOptions,
+  IDIDManager,
+  IKeyManager,
+  IResolver,
+  TAgent,
+  TKeyType,
+} from '../../packages/core-types/src'
 import { computeAddress, serialize } from '@ethersproject/transactions'
 import { mapIdentifierKeysToDoc } from '../../packages/utils/src'
 import { recoverTypedSignature, SignTypedDataVersion } from '@metamask/eth-sig-util'
@@ -476,7 +483,7 @@ export default (testContext: {
         },
       }
 
-      const identifier = await agent.didManagerCreate({ kms: 'local' })
+      const identifier = await agent.didManagerCreate({ kms: 'local', provider: 'did:pkh' })
 
       const extendedKeys = await mapIdentifierKeysToDoc(identifier, 'verificationMethod', { agent })
       const extendedKey = extendedKeys[0]
@@ -575,7 +582,10 @@ export default (testContext: {
         },
       }
 
-      const identifier = await agent.didManagerCreate({ kms: 'local' })
+      const identifier = await agent.didManagerCreate({
+        kms: 'local',
+        provider: 'did:pkh',
+      })
 
       const extendedKeys = await mapIdentifierKeysToDoc(identifier, 'verificationMethod', { agent })
       const extendedKey = extendedKeys[0]

--- a/__tests__/shared/utils.ts
+++ b/__tests__/shared/utils.ts
@@ -21,21 +21,21 @@ export default (testContext: {
     afterAll(testContext.tearDown)
 
     it('should get chainId for ethr did', async () => {
-      const didUrl = 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190'
+      const didUrl = 'did:ethr:mainnet:0xb09b66026ba5909a7cfe99b76875431d2b8d5190'
       const didDoc = await resolveDidOrThrow(didUrl, { agent })
       if (didDoc.verificationMethod) {
         const chainId = getChainIdForDidEthr(didDoc.verificationMethod[0])
-        expect(chainId).toEqual(5)
+        expect(chainId).toEqual(1)
       }
     })
 
     it('should map identifier keys to did doc', async () => {
       const account = `0xb09b66026ba5909a7cfe99b76875431d2b8d5190`
-      const did = `did:ethr:0x5:${account}`
+      const did = `did:ethr:${account}`
       const controllerKeyId = `metamask-${account}`
       await agent.didManagerImport({
         did,
-        provider: 'did:ethr:goerli',
+        provider: 'did:ethr',
         controllerKeyId,
         keys: [
           {
@@ -56,7 +56,7 @@ export default (testContext: {
       const identifier = await agent.didManagerGet({ did })
       const extendedKeys = await mapIdentifierKeysToDoc(identifier, 'verificationMethod', { agent })
       expect(extendedKeys[0].meta.verificationMethod?.blockchainAccountId?.toLocaleLowerCase()).toEqual(
-        `eip155:5:${account}`,
+        `eip155:1:${account}`,
       )
     })
   })

--- a/__tests__/shared/verifiableDataEIP712.ts
+++ b/__tests__/shared/verifiableDataEIP712.ts
@@ -30,7 +30,10 @@ export default (testContext: {
     beforeAll(async () => {
       await testContext.setup()
       agent = testContext.getAgent()
-      identifier = await agent.didManagerCreate({ kms: 'local' })
+      identifier = await agent.didManagerCreate({
+        kms: 'local',
+        provider: 'did:pkh'
+      })
     })
     afterAll(testContext.tearDown)
 

--- a/__tests__/shared/webDidFlow.ts
+++ b/__tests__/shared/webDidFlow.ts
@@ -115,10 +115,12 @@ export default (testContext: {
       it('issuer - Alice, subject - Bob', async () => {
         const a = await agent.didManagerGetOrCreate({
           alias: 'alice',
+          provider: 'did:ethr:goerli',
         })
 
         const b = await agent.didManagerGetOrCreate({
           alias: 'bob',
+          provider: 'did:ethr:goerli',
         })
 
         const verifiableCredential = await agent.createVerifiableCredential({

--- a/packages/core-types/src/types/IResolver.ts
+++ b/packages/core-types/src/types/IResolver.ts
@@ -75,24 +75,24 @@ export interface IResolver extends IPluginMethodMap {
    * @example
    * ```typescript
    * const doc = await agent.resolveDid({
-   *   didUrl: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190'
+   *   didUrl: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190'
    * })
    * expect(doc.didDocument).toEqual({
    *   '@context': [
    *     'https://www.w3.org/ns/did/v1',
    *     'https://w3id.org/security/suites/secp256k1recovery-2020/v2',
    *   ],
-   *   id: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
+   *   id: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
    *   verificationMethod: [
    *     {
-   *       id: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller',
+   *       id: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller',
    *       type: 'EcdsaSecp256k1RecoveryMethod2020',
-   *       controller: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
-   *       blockchainAccountId: 'eip155:5:0xb09B66026bA5909A7CFE99b76875431D2b8D5190',
+   *       controller: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
+   *       blockchainAccountId: 'eip155:1:0xb09B66026bA5909A7CFE99b76875431D2b8D5190',
    *     },
    *   ],
-   *   authentication: ['did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller'],
-   *   assertionMethod: ['did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller'],
+   *   authentication: ['did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller'],
+   *   assertionMethod: ['did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller'],
    * })
    * ```
    *
@@ -106,7 +106,7 @@ export interface IResolver extends IPluginMethodMap {
    *
    * @example
    * ```typescript
-   * const did = 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190'
+   * const did = 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190'
    * const didFragment = `${did}#controller`
    * const fragment = await agent.getDIDComponentById({
    *   didDocument: (await agent.resolveDid({didUrl: did}))?.didDocument,
@@ -114,10 +114,10 @@ export interface IResolver extends IPluginMethodMap {
    *   section: 'authentication'
    * })
    * expect(fragment).toEqual({
-   *   id: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller',
+   *   id: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190#controller',
    *   type: 'EcdsaSecp256k1RecoveryMethod2020',
-   *   controller: 'did:ethr:goerli:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
-   *   blockchainAccountId: 'eip155:5:0xb09B66026bA5909A7CFE99b76875431D2b8D5190',
+   *   controller: 'did:ethr:0xb09b66026ba5909a7cfe99b76875431d2b8d5190',
+   *   blockchainAccountId: 'eip155:1:0xb09B66026bA5909A7CFE99b76875431D2b8D5190',
    * })
    * ```
    *

--- a/packages/credential-ld/src/ld-suite-loader.ts
+++ b/packages/credential-ld/src/ld-suite-loader.ts
@@ -7,11 +7,16 @@ import { TKeyType } from '@veramo/core-types'
 export class LdSuiteLoader {
   constructor(options: { veramoLdSignatures: VeramoLdSignature[] }) {
     options.veramoLdSignatures.forEach((obj) => {
+      // FIXME: some suites would work for multiple key types, but this only returns a single value per suite.
+      //       For example, EcdsaSecp256k1RecoverySignature2020 should work with both EcdsaSecp256k1VerificationKey2019
+      //       as well as EcdsaSecp256k1RecoveryMethod2020 since the VerificationKey can also be expressed as the recovery
+      //       method.
       const keyType = obj.getSupportedVeramoKeyType()
       const verificationType = obj.getSupportedVerificationType()
-      return this.signatureMap[keyType] = { ...this.signatureMap[keyType], [verificationType]: obj }
+      return (this.signatureMap[keyType] = { ...this.signatureMap[keyType], [verificationType]: obj })
     })
   }
+
   private signatureMap: Record<string, Record<string, VeramoLdSignature>> = {}
 
   getSignatureSuiteForKeyType(type: TKeyType, verificationType: string) {
@@ -22,10 +27,14 @@ export class LdSuiteLoader {
   }
 
   getAllSignatureSuites(): VeramoLdSignature[] {
-    return Object.values(this.signatureMap).map((x) => Object.values(x)).flat()
+    return Object.values(this.signatureMap)
+      .map((x) => Object.values(x))
+      .flat()
   }
 
   getAllSignatureSuiteTypes() {
-    return Object.values(this.signatureMap).map((x) => Object.keys(x)).flat()
+    return Object.values(this.signatureMap)
+      .map((x) => Object.keys(x))
+      .flat()
   }
 }

--- a/packages/test-react-app/headless-tests/browserAgent.browser-test.ts
+++ b/packages/test-react-app/headless-tests/browserAgent.browser-test.ts
@@ -56,17 +56,17 @@ describe('Browser integration tests', () => {
             'https://www.w3.org/ns/did/v1',
             'https://w3id.org/security/suites/secp256k1recovery-2020/v2',
           ],
-          id: 'did:ethr:goerli:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730',
+          id: 'did:ethr:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730',
           verificationMethod: [
             {
-              id: 'did:ethr:goerli:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730#controller',
+              id: 'did:ethr:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730#controller',
               type: 'EcdsaSecp256k1RecoveryMethod2020',
-              controller: 'did:ethr:goerli:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730',
-              blockchainAccountId: 'eip155:5:0x6AcF3bB1eF0eE84559De2bC2Bd9D91532062a730',
+              controller: 'did:ethr:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730',
+              blockchainAccountId: 'eip155:1:0x6AcF3bB1eF0eE84559De2bC2Bd9D91532062a730',
             },
           ],
-          authentication: ['did:ethr:goerli:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730#controller'],
-          assertionMethod: ['did:ethr:goerli:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730#controller'],
+          authentication: ['did:ethr:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730#controller'],
+          assertionMethod: ['did:ethr:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730#controller'],
         },
       }
 
@@ -82,7 +82,7 @@ describe('Browser integration tests', () => {
         didDocumentMetadata: {},
         didResolutionMetadata: {
           error: 'invalidDid',
-          message: 'Not a valid did:ethr: goerli:0x6acf3bb1ef0ee8459de2bc2bd9d91532062a730',
+          message: 'Not a valid did:ethr: goerli:0x16acf3bb1ef0ee8459de2bc2bd9d91532062a7',
         },
         didDocument: null,
       }

--- a/packages/test-react-app/src/App.tsx
+++ b/packages/test-react-app/src/App.tsx
@@ -11,14 +11,14 @@ function App() {
 
   const resolve = async () => {
     const doc = await agent.resolveDid({
-      didUrl: 'did:ethr:goerli:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730',
+      didUrl: 'did:ethr:0x6acf3bb1ef0ee84559de2bc2bd9d91532062a730',
     })
     setDidDoc(doc)
   }
 
   const resolveInvalid = async () => {
     const doc = await agent.resolveDid({
-      didUrl: 'did:ethr:goerli:0x6acf3bb1ef0ee8459de2bc2bd9d91532062a730',
+      didUrl: 'did:ethr:goerli:0x16acf3bb1ef0ee8459de2bc2bd9d91532062a7',
     })
     setInvalidDidDoc(doc)
   }

--- a/packages/test-react-app/src/veramo/setup.ts
+++ b/packages/test-react-app/src/veramo/setup.ts
@@ -83,7 +83,7 @@ export function getAgent(options?: IAgentOptions): TAgent<InstalledPlugins> {
       }),
       new DIDManager({
         store: new DIDStoreJson(memoryJsonStore),
-        defaultProvider: 'did:ethr:goerli',
+        defaultProvider: 'did:pkh',
         providers: {
           'did:ethr': new EthrDIDProvider({
             defaultKms: 'local',


### PR DESCRIPTION
## What is being changed
This is only a change in the tests to cover a wider range of scenarios by using different default DID providers between the integration test suites.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [X] I added integration tests.

## Details
No functionality should be changed in this PR.
