### PR TITLE
fix(data-store): match claims by credential hash when deleting credential

### DIFF
--- a/__tests__/localJsonStoreAgent.test.ts
+++ b/__tests__/localJsonStoreAgent.test.ts
@@ -77,6 +77,7 @@ import messageHandler from './shared/messageHandler'
 import utils from './shared/utils'
 import { JsonFileStore } from './utils/json-file-store'
 import credentialStatus from './shared/credentialStatus'
+import dbInitOptions from "./shared/dbInitOptions";
 
 jest.setTimeout(120000)
 
@@ -238,4 +239,5 @@ describe('Local json-data-store integration tests', () => {
   didCommPacking(testContext)
   utils(testContext)
   credentialStatus(testContext)
+  dbInitOptions(testContext)
 })

--- a/packages/data-store/src/data-store.ts
+++ b/packages/data-store/src/data-store.ts
@@ -98,7 +98,7 @@ export class DataStore implements IAgentPlugin {
 
     const claims = await (await getConnectedDb(this.dbConnection))
       .getRepository(Claim)
-      .find({ where: { credential: { id: credentialEntity.id } } as any })
+      .find({ where: { credential: { hash: credentialEntity.hash } } })
 
     await (await getConnectedDb(this.dbConnection)).getRepository(Claim).remove(claims)
 


### PR DESCRIPTION
## What issue is this PR fixing

fixes #1269

## What is being changed
When deleting a credential, the corresponding claims are matched by the credential `hash` (internally computed) instead of the credential `id` which is optional.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [X] I added integration tests.

## Details
I included the tests in the `localJsonStoreAgent` test suite as well to ensure similar behavior.
The `@veramo/data-store-json` did not manifest the same bug, but I added it to check for regressions.

This is a hotfix that should be release before the next major release
